### PR TITLE
Fix bugs in textual slots

### DIFF
--- a/src/arden.scc
+++ b/src/arden.scc
@@ -500,7 +500,7 @@ knowledge_body =
 /****** maintenance slots ******/
 
 title_slot =
-                title text semicolons;
+                title text? semicolons;
 
 mlmname_slot =
       {mname}   mlmname mlmname_text semicolons
@@ -518,7 +518,7 @@ arden_version_slot =
                   /* form of < mlmname_slot >           */
 
 version_slot =
-                version colon text semicolons;
+                version colon text? semicolons;
 
 institution_slot =
                 institution colon text? semicolons;

--- a/src/arden/compiler/Compiler.java
+++ b/src/arden/compiler/Compiler.java
@@ -59,6 +59,7 @@ import arden.compiler.node.PUrgencySlot;
 import arden.compiler.node.PUrgencyVal;
 import arden.compiler.node.Start;
 import arden.compiler.node.TIdentifier;
+import arden.compiler.node.TNumberLiteral;
 import arden.compiler.parser.Parser;
 import arden.compiler.parser.ParserException;
 import arden.runtime.ArdenValue;
@@ -304,8 +305,11 @@ public final class Compiler {
 			// {num} P.number
 			// | {id} identifier;
 			if (val instanceof ANumUrgencyVal) {
-				urgency = ParseHelpers
-						.getLiteralDoubleValue(((ANumUrgencyVal) val).getNumberLiteral());
+				TNumberLiteral literal = ((ANumUrgencyVal) val).getNumberLiteral();
+				urgency = ParseHelpers.getLiteralDoubleValue(literal);
+				if(urgency < 1 || urgency > 99) {
+					throw new RuntimeCompilerException(literal, "Urgency must be a number from 1 to 99");
+				}
 				context.writer.loadDoubleConstant(urgency);
 			} else if (val instanceof AIdUrgencyVal) {
 				TIdentifier ident = ((AIdUrgencyVal) val).getIdentifier();

--- a/src/arden/compiler/MetadataCompiler.java
+++ b/src/arden/compiler/MetadataCompiler.java
@@ -93,7 +93,11 @@ final class MetadataCompiler extends DepthFirstAdapter {
 	// | {fname} filename mlmname_text semicolons;
 	@Override
 	public void caseAMnameMlmnameSlot(AMnameMlmnameSlot node) {
-		maintenance.setMlmName(node.getMlmnameText().getText().trim());
+		String mlmname = node.getMlmnameText().getText().trim();
+		if(mlmname.isEmpty() || mlmname.length() > 80) {
+			throw new RuntimeCompilerException(node.getMlmnameText(), "The mlmname must be 1 to 80 characters in length");
+		}
+		maintenance.setMlmName(mlmname);
 	}
 
 	@Override
@@ -120,14 +124,24 @@ final class MetadataCompiler extends DepthFirstAdapter {
 	// version_slot = version colon text semicolons;
 	@Override
 	public void caseAVersionSlot(AVersionSlot node) {
-		if (node.getText() != null)
-			maintenance.setVersion(node.getText().getText().trim());
+		if (node.getText() != null) {
+			String version = node.getText().getText().trim();
+			if(version.length() > 80) {
+				throw new RuntimeCompilerException(node.getText(), "Version must be shorter than 81 characters");
+			}
+			maintenance.setVersion(version);
+		}
 	}
 
 	@Override
 	public void caseAInstitutionSlot(AInstitutionSlot node) {
-		if (node.getText() != null)
-			maintenance.setInstitution(node.getText().getText().trim());
+		if (node.getText() != null) {
+			String institution = node.getText().getText().trim();
+			if(institution.length() > 80) {
+				throw new RuntimeCompilerException(node.getText(), "Institution must be shorter than 81 characters");
+			}
+			maintenance.setInstitution(institution);
+		}
 	}
 
 	// author_slot = author text? semicolons;

--- a/src/arden/compiler/MetadataCompiler.java
+++ b/src/arden/compiler/MetadataCompiler.java
@@ -30,7 +30,30 @@ package arden.compiler;
 import java.util.Date;
 
 import arden.compiler.analysis.DepthFirstAdapter;
-import arden.compiler.node.*;
+import arden.compiler.node.AAuthorSlot;
+import arden.compiler.node.ACitationsSlot;
+import arden.compiler.node.ADateMlmDate;
+import arden.compiler.node.ADateSlot;
+import arden.compiler.node.ADtimeMlmDate;
+import arden.compiler.node.AEmptyArdenVersionSlot;
+import arden.compiler.node.AEmptyPrioritySlot;
+import arden.compiler.node.AExpValidationCode;
+import arden.compiler.node.AExplanationSlot;
+import arden.compiler.node.AFnameMlmnameSlot;
+import arden.compiler.node.AInstitutionSlot;
+import arden.compiler.node.AKeywordsSlot;
+import arden.compiler.node.ALinksSlot;
+import arden.compiler.node.AMnameMlmnameSlot;
+import arden.compiler.node.APriPrioritySlot;
+import arden.compiler.node.AProdValidationCode;
+import arden.compiler.node.APurposeSlot;
+import arden.compiler.node.AResValidationCode;
+import arden.compiler.node.ASpecialistSlot;
+import arden.compiler.node.ATestValidationCode;
+import arden.compiler.node.ATitleSlot;
+import arden.compiler.node.AVersionSlot;
+import arden.compiler.node.AVrsnArdenVersionSlot;
+import arden.compiler.node.TNumberLiteral;
 import arden.runtime.LibraryMetadata;
 import arden.runtime.MaintenanceMetadata;
 import arden.runtime.RuntimeHelpers;
@@ -209,6 +232,10 @@ final class MetadataCompiler extends DepthFirstAdapter {
 
 	@Override
 	public void caseAPriPrioritySlot(APriPrioritySlot node) {
-		priority = ParseHelpers.getLiteralDoubleValue(node.getNumberLiteral());
+		TNumberLiteral literal = node.getNumberLiteral();
+		priority = ParseHelpers.getLiteralDoubleValue(literal);
+		if(priority < 1 || priority > 99) {
+			throw new RuntimeCompilerException(literal, "Priority must be a number from 1 to 99");
+		}
 	}
 }


### PR DESCRIPTION
An error is now shown when invalid values (not in range 1..99) are given for urgency and priority.

Invalid length (>80 characters) for mlmname, institution and version slot now lead to and error.

The title and version slot can now be empty. This was mentioned in the paper as an error because it happened for one of the tested mlms, but is actually required as per the specification:
> "For required textual slots, the text may be empty."