### PR TITLE
Fix bugs related to primary time

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ Languages features not implemented:
 * From Arden Syntax 2.5 specification:
     * 11.2.5.2 Message As statement 
     * 11.2.5.6 Destination As statement
-    * A6.2 "Time of" always returns null for objects. (correct would be: if all attributes of an object share a common primary time, the time of operator will return that time when applied to the object) 
-    * Timezones for ArdenTime values.
     * Some string formatting specificiers are not implemented.
     * There is no way to use Arden variables within mapping clauses.
     * Citation/links slots are not syntax checked.

--- a/src/arden/compiler/UnaryOperatorCompiler.java
+++ b/src/arden/compiler/UnaryOperatorCompiler.java
@@ -29,7 +29,78 @@ package arden.compiler;
 
 import java.util.GregorianCalendar;
 
-import arden.compiler.node.*;
+import arden.compiler.node.AAbsOfNoreadFuncOp;
+import arden.compiler.node.AAcosOfNoreadFuncOp;
+import arden.compiler.node.AAllOfNoreadFuncOp;
+import arden.compiler.node.AAnyOfNoreadFuncOp;
+import arden.compiler.node.AAsFuncOp;
+import arden.compiler.node.AAsinOfNoreadFuncOp;
+import arden.compiler.node.AAtanOfNoreadFuncOp;
+import arden.compiler.node.AAvgOfReadFuncOp;
+import arden.compiler.node.AAvgeOfReadFuncOp;
+import arden.compiler.node.ACeilOfNoreadFuncOp;
+import arden.compiler.node.ACloneOfNoreadFuncOp;
+import arden.compiler.node.ACntOfReadFuncOp;
+import arden.compiler.node.ACosOfNoreadFuncOp;
+import arden.compiler.node.ACsinOfNoreadFuncOp;
+import arden.compiler.node.ADecOfNoreadFuncOp;
+import arden.compiler.node.AEarFromOfFuncOp;
+import arden.compiler.node.AEarliestIndexFromOfFuncOp;
+import arden.compiler.node.AExOfReadFuncOp;
+import arden.compiler.node.AExattrOfNoreadFuncOp;
+import arden.compiler.node.AExcOfNoreadFuncOp;
+import arden.compiler.node.AExdOfNoreadFuncOp;
+import arden.compiler.node.AExhOfNoreadFuncOp;
+import arden.compiler.node.AExmiOfNoreadFuncOp;
+import arden.compiler.node.AExmoOfNoreadFuncOp;
+import arden.compiler.node.AExpOfNoreadFuncOp;
+import arden.compiler.node.AExsOfNoreadFuncOp;
+import arden.compiler.node.AExsOfReadFuncOp;
+import arden.compiler.node.AExyOfNoreadFuncOp;
+import arden.compiler.node.AFirFromOfFuncOp;
+import arden.compiler.node.AFlrOfNoreadFuncOp;
+import arden.compiler.node.AIncOfNoreadFuncOp;
+import arden.compiler.node.AIndexmaxIndexFromOfFuncOp;
+import arden.compiler.node.AIndexminIndexFromOfFuncOp;
+import arden.compiler.node.AIntOfNoreadFuncOp;
+import arden.compiler.node.AInterOfNoreadFuncOp;
+import arden.compiler.node.ALastFromOfFuncOp;
+import arden.compiler.node.ALatFromOfFuncOp;
+import arden.compiler.node.ALatestIndexFromOfFuncOp;
+import arden.compiler.node.ALcOfNoreadFuncOp;
+import arden.compiler.node.ALenOfNoreadFuncOp;
+import arden.compiler.node.ALogOfNoreadFuncOp;
+import arden.compiler.node.ALogtOfNoreadFuncOp;
+import arden.compiler.node.AMaxFromOfFuncOp;
+import arden.compiler.node.AMaxiFromOfFuncOp;
+import arden.compiler.node.AMaximumIndexFromOfFuncOp;
+import arden.compiler.node.AMedOfReadFuncOp;
+import arden.compiler.node.AMinFromOfFuncOp;
+import arden.compiler.node.AMiniFromOfFuncOp;
+import arden.compiler.node.AMinimumIndexFromOfFuncOp;
+import arden.compiler.node.AModdOfNoreadFuncOp;
+import arden.compiler.node.AModiOfNoreadFuncOp;
+import arden.compiler.node.ANoOfNoreadFuncOp;
+import arden.compiler.node.AOfnrOfFuncOp;
+import arden.compiler.node.AOfrOfFuncOp;
+import arden.compiler.node.APerdOfNoreadFuncOp;
+import arden.compiler.node.APeriOfNoreadFuncOp;
+import arden.compiler.node.ARevOfNoreadFuncOp;
+import arden.compiler.node.ARoundOfNoreadFuncOp;
+import arden.compiler.node.ASinOfNoreadFuncOp;
+import arden.compiler.node.ASineOfNoreadFuncOp;
+import arden.compiler.node.ASlpOfNoreadFuncOp;
+import arden.compiler.node.ASqrtOfNoreadFuncOp;
+import arden.compiler.node.AStdvOfNoreadFuncOp;
+import arden.compiler.node.AStrOfNoreadFuncOp;
+import arden.compiler.node.ASumOfReadFuncOp;
+import arden.compiler.node.ATanOfNoreadFuncOp;
+import arden.compiler.node.ATangOfNoreadFuncOp;
+import arden.compiler.node.ATimeOfNoreadFuncOp;
+import arden.compiler.node.ATruncOfNoreadFuncOp;
+import arden.compiler.node.AUcOfNoreadFuncOp;
+import arden.compiler.node.AVarOfNoreadFuncOp;
+import arden.compiler.node.Node;
 import arden.runtime.ArdenValue;
 import arden.runtime.UnaryOperator;
 
@@ -257,8 +328,8 @@ final class UnaryOperatorCompiler extends VisitorBase {
 
 	@Override
 	public void caseAInterOfNoreadFuncOp(AInterOfNoreadFuncOp node) {
-		parent.invokeOperator(UnaryOperator.TIME, argument);
-		context.writer.invokeStatic(ExpressionCompiler.getMethod("increase", ArdenValue.class));
+		argument.apply(parent);
+		context.writer.invokeStatic(ExpressionCompiler.getMethod("interval", ArdenValue.class));
 	}
 
 	@Override

--- a/src/arden/runtime/ArdenTime.java
+++ b/src/arden/runtime/ArdenTime.java
@@ -57,7 +57,9 @@ public final class ArdenTime extends ArdenValue {
 
 	public static final DateFormat isoDateTimeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
 	public static final DateFormat isoDateTimeFormatWithMillis = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+	public static final DateFormat isoDateTimeFormatWithGmtTimeZone = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssz");
 	public static final DateFormat isoDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+	public static final int isoDateTimeLength = 19;
 
 	@Override
 	public String toString() {

--- a/src/arden/runtime/ExpressionHelpers.java
+++ b/src/arden/runtime/ExpressionHelpers.java
@@ -248,16 +248,36 @@ public final class ExpressionHelpers {
 
 	/** implements the MEDIAN operator */
 	public static ArdenValue median(ArdenValue sequence) {
-		ArdenValue sorted = sortByData(sequence);
+		// sort by data and time
+		ArdenValue sorted = sort(sequence, dataAndTimeComparator);
 		if (!(sorted instanceof ArdenList))
 			return sorted; // error during sorting
 		ArdenValue[] values = ((ArdenList) sorted).values;
 		if (values.length == 0) {
 			return ArdenNull.INSTANCE;
 		} else if ((values.length % 2) == 1) {
-			return values[values.length / 2];
+			ArdenValue median = values[values.length / 2];
+			// get the element with the same value but the latest primary time by going towards the end
+			for(int i = values.length / 2; i < values.length; i++) {
+				if(values[i].compareTo(median) == 0) 
+					median = values[i];
+				else
+					break;
+			}
+			return median;
 		} else {
-			return average(binaryComma(values[values.length / 2 - 1], values[values.length / 2]));
+			ArdenValue leftMedian = values[values.length / 2 - 1];
+			ArdenValue rightMedian = values[values.length / 2];
+			for(int i = values.length / 2 + 1; i < values.length; i++) {
+				if(values[i].compareTo(rightMedian) == 0) {
+					if(leftMedian.compareTo(rightMedian) == 0)
+						leftMedian = rightMedian;
+					rightMedian = values[i];
+				} else {
+					break;
+				}
+			}
+			return average(binaryComma(leftMedian, rightMedian));
 		}
 	}
 

--- a/src/arden/runtime/ExpressionHelpers.java
+++ b/src/arden/runtime/ExpressionHelpers.java
@@ -692,7 +692,7 @@ public final class ExpressionHelpers {
 		ArdenValue pivot = ((ArdenList) sortedInput).values[arr.length - numberOfElements];
 		int pos = 0;
 		for (int i = 0; i < arr.length; i++) {
-			if (arr[i].primaryTime <= pivot.primaryTime) {
+			if (arr[i].primaryTime >= pivot.primaryTime) {
 				output[pos++] = ArdenNumber.create(i + 1, ArdenValue.NOPRIMARYTIME);
 				if (pos == numberOfElements)
 					break;

--- a/src/arden/runtime/ExpressionHelpers.java
+++ b/src/arden/runtime/ExpressionHelpers.java
@@ -97,7 +97,7 @@ public final class ExpressionHelpers {
 		}
 		if (alreadySorted)
 			return input;
-		ArdenValue[] result = (ArdenValue[]) input.values.clone();
+		ArdenValue[] result = input.values.clone();
 		Arrays.sort(result, new Comparator<ArdenValue>() {
 			@Override
 			public int compare(ArdenValue o1, ArdenValue o2) {
@@ -117,7 +117,7 @@ public final class ExpressionHelpers {
 			if (val.primaryTime == ArdenValue.NOPRIMARYTIME)
 				return ArdenNull.INSTANCE;
 		}
-		ArdenValue[] result = (ArdenValue[]) input.values.clone();
+		ArdenValue[] result = input.values.clone();
 		Arrays.sort(result, new Comparator<ArdenValue>() {
 			@Override
 			public int compare(ArdenValue o1, ArdenValue o2) {
@@ -329,7 +329,7 @@ public final class ExpressionHelpers {
 		return new ArdenList(result);
 	}
 
-	/** implements the SEQTO operator */
+	/** implements the REVERSE operator */
 	public static ArdenValue reverse(ArdenValue input) {
 		ArdenValue[] inputs = unaryComma(input).values;
 		ArdenValue[] result = new ArdenValue[inputs.length];
@@ -368,6 +368,22 @@ public final class ExpressionHelpers {
 			outputs[i] = BinaryOperator.MUL.runElement(
 					BinaryOperator.DIV.runElement(BinaryOperator.SUB.runElement(inputs[i + 1], inputs[i]), inputs[i]),
 					ArdenNumber.ONE_HUNDRED).setTime(inputs[i + 1].primaryTime);
+		}
+		return new ArdenList(outputs);
+	}
+	
+	/** implements the INTERVAL operator */
+	public static ArdenValue interval(ArdenValue input) {
+		ArdenValue[] inputs = unaryComma(input).values;
+		if (inputs.length == 0)
+			return ArdenNull.INSTANCE;
+		ArdenValue[] outputs = new ArdenValue[inputs.length - 1];
+		for (int i = 0; i < outputs.length; i++) {
+			if (inputs[i].primaryTime == ArdenValue.NOPRIMARYTIME || inputs[i+1].primaryTime == ArdenValue.NOPRIMARYTIME)
+				return ArdenNull.INSTANCE;
+			ArdenTime first = new ArdenTime(inputs[i].primaryTime);
+			ArdenTime second = new ArdenTime(inputs[i+1].primaryTime);
+			outputs[i] = BinaryOperator.SUB.runElement(second, first);
 		}
 		return new ArdenList(outputs);
 	}

--- a/src/arden/runtime/UnaryOperator.java
+++ b/src/arden/runtime/UnaryOperator.java
@@ -82,7 +82,21 @@ public abstract class UnaryOperator {
 	public static final UnaryOperator TIME = new UnaryOperator("TIME") {
 		@Override
 		public ArdenValue runElement(ArdenValue val) {
-			if (val.primaryTime == ArdenValue.NOPRIMARYTIME)
+			if(val instanceof ArdenObject) {
+				// check primary time of fields
+				ArdenValue[] fields = ((ArdenObject) val).fields;
+				if(fields.length == 0) {
+					return ArdenNull.INSTANCE;
+				}
+				long firstTime = fields[0].primaryTime;
+				for(ArdenValue field : fields) {
+					if (field instanceof ArdenList || field.primaryTime == ArdenValue.NOPRIMARYTIME
+							|| field.primaryTime != firstTime) {
+						return ArdenNull.INSTANCE;
+					}
+				}
+				return new ArdenTime(firstTime);
+			} else if (val.primaryTime == ArdenValue.NOPRIMARYTIME)
 				return ArdenNull.INSTANCE;
 			else
 				return new ArdenTime(val.primaryTime, val.primaryTime);


### PR DESCRIPTION
This fixes primary time bugs for these operators:
- `INTERVAL`
- `MAX`, `MIN`, `INDEX MAX`, `MIN ... FROM`, etc.
- `MEDIAN`
- objects

Datetime constants should now be correctly interpreted:
- lowercase 't' and 'z' are now allowed
- the ISO 8601 timezone extensions ('Z', '+01:00', '-01:00') are now supported

This also fixes `LATEST ... FROM` returning the same as `EARLIEST ... FROM`.