### PR TITLE
Test fixes and improvements

### DIFF
--- a/test/arden/tests/specification/Operators/NumericFunctionOperatorsTest.java
+++ b/test/arden/tests/specification/Operators/NumericFunctionOperatorsTest.java
@@ -67,7 +67,7 @@ public class NumericFunctionOperatorsTest extends SpecificationTest {
 		
 		// primary time is preserved
 		String data = new ArdenCodeBuilder().addData("x := \"5\"; TIME x := 1997-10-31T00:00:00;").toString();
-		assertEvaluatesToWithData(data, "TIME x AS NUMBER", "1997-10-31T00:00:00");
+		assertEvaluatesToWithData(data, "TIME (x AS NUMBER)", "1997-10-31T00:00:00");
 	}
 	
 }

--- a/test/arden/tests/specification/StructureSlots/ActionSlotTest.java
+++ b/test/arden/tests/specification/StructureSlots/ActionSlotTest.java
@@ -1,9 +1,8 @@
 package arden.tests.specification.StructureSlots;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
@@ -59,7 +58,7 @@ public class ActionSlotTest extends SpecificationTest {
 		
 		String multiReturn = new ArdenCodeBuilder().addAction("RETURN 5, (\"a\", \"b\");").toString();
 		List<String> returnValues = getCompiler().compileAndRun(multiReturn).returnValues;
-		assertTrue(returnValues.equals(Arrays.asList("5", "(\"a\",\"b\")")));
+		assertArrayEquals(new String[]{"5", "(\"a\",\"b\")"}, returnValues.toArray());
 		
 		String empty = new ArdenCodeBuilder().toString();
 		assertNoReturn(empty);

--- a/test/arden/tests/specification/StructureSlots/DataSlotTest.java
+++ b/test/arden/tests/specification/StructureSlots/DataSlotTest.java
@@ -211,21 +211,33 @@ public class DataSlotTest extends SpecificationTest {
 	public void testIncludeStatement() throws Exception {
 		String mlm1 = new ArdenCodeBuilder()
 				.replaceSlotContent("mlmname:", "mlm1")
-				.addData("a := 1;")
+				.addData("Patient := OBJECT [Name, DateOfBirth, Id];")
 				.toString();
 		String mlm2 = new ArdenCodeBuilder()
 				.replaceSlotContent("mlmname:", "mlm2")
-				.addData("a := 2;")
+				.addData("Patient := OBJECT [Id, Name, DateOfBirth, Gender, Phone];")
 				.toString();
+		
+		String include = new ArdenCodeBuilder()
+				.addMlm(mlm1)
+				.addData("othermlm := MLM 'mlm1';")
+				.addData("INCLUDE othermlm;")
+				.addData("p := NEW Patient;")
+				.addData("p.Id := 5;")
+				.addAction("RETURN p.Id;")
+				.toString();
+		assertReturns(include, "5");
 		
 		String localPrecedence = new ArdenCodeBuilder()
 				.addMlm(mlm1)
-				.addData("a := 3;")
+				.addData("Patient := OBJECT [Id, Name, Phone];")
 				.addData("othermlm := MLM 'mlm1';")
 				.addData("INCLUDE othermlm;")
-				.addAction("RETURN a;")
+				.addData("p := NEW Patient;")
+				.addData("p.Phone := 12345;")
+				.addAction("RETURN p.Phone;")
 				.toString();
-		assertReturns(localPrecedence, "3");
+		assertReturns(localPrecedence, "12345");
 		
 		String latestPrecedence = new ArdenCodeBuilder()
 				.addMlm(mlm1)
@@ -234,9 +246,11 @@ public class DataSlotTest extends SpecificationTest {
 				.addData("INCLUDE mlm1;")
 				.addData("mlm2 := MLM 'mlm2';")
 				.addData("INCLUDE mlm2;")
-				.addAction("RETURN a;")
+				.addData("p := NEW Patient;")
+				.addData("p.Gender := \"f\";")
+				.addAction("RETURN p.Gender;")
 				.toString();
-		assertReturns(latestPrecedence, "2");
+		assertReturns(latestPrecedence, "\"f\"");
 	}
 
 }

--- a/test/arden/tests/specification/StructureSlots/TokensTest.java
+++ b/test/arden/tests/specification/StructureSlots/TokensTest.java
@@ -160,6 +160,7 @@ public class TokensTest extends SpecificationTest {
 	public void testComments() throws Exception {
 		assertValidStatement("/* Lorem /* ipsum // */");
 		assertValidStatement("// Lorem // */ ipsum \n");
+		assertValidStatement("a/**/:=/*xyz*/5;");
 	}
 
 	@Test

--- a/test/arden/tests/specification/testcompiler/SpecificationTest.java
+++ b/test/arden/tests/specification/testcompiler/SpecificationTest.java
@@ -1,16 +1,12 @@
 package arden.tests.specification.testcompiler;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.junit.Assert;
-
-import arden.tests.specification.testcompiler.impl.TestCompilerImpl;
 
 public abstract class SpecificationTest {
 	// Initialise your compiler here. It will be used by all tests.
-	private TestCompiler compiler = new TestCompilerImpl();
+	private TestCompiler compiler = new arden.tests.specification.testcompiler.impl.TestCompilerImpl();
 
 	public TestCompiler getCompiler() {
 		return compiler;
@@ -32,22 +28,25 @@ public abstract class SpecificationTest {
 			builder = new ArdenCodeBuilder();
 		}
 		String code = builder.addExpression(expression).toString();
-		TestCompilerResult result = getCompiler().compileAndRun(code);
-		Assert.assertEquals(1, result.returnValues.size());
-		String returnValue = result.returnValues.get(0);
-		assertEquals(expected.toLowerCase(), returnValue.toLowerCase());
+		assertReturns(code, expected);
 	}
 	
 	protected void assertReturns(String code, String expected) throws TestCompilerException {
 		TestCompilerResult result = getCompiler().compileAndRun(code);
-		Assert.assertEquals(1, result.returnValues.size());
+		assertEquals("Too many return values.", 1, result.returnValues.size());
 		String returnValue = result.returnValues.get(0);
 		assertEquals(expected.toLowerCase(), returnValue.toLowerCase());
 	}
 	
 	protected void assertNoReturn(String code) throws TestCompilerException {
 		TestCompilerResult result = getCompiler().compileAndRun(code);
-		assertTrue(result.returnValues.isEmpty());
+		if(result.returnValues.isEmpty()) {
+			// test passed
+		} else {
+			// a single "NULL" is also okay
+			assertEquals("Too many return values.", 1, result.returnValues.size());
+			assertEquals("null", result.returnValues.get(0).toLowerCase());
+		}
 	}
 	
 	protected void assertValidStatement(String statement) throws TestCompilerException {
@@ -72,7 +71,7 @@ public abstract class SpecificationTest {
 	protected void assertInvalid(String code) {
 		try {
 			getCompiler().compile(code);
-			fail("Expected an " + TestCompilerCompiletimeException.class.getSimpleName() + " to be thrown");
+			fail("Expected a " + TestCompilerCompiletimeException.class.getSimpleName() + " to be thrown.");
 		} catch(TestCompilerCompiletimeException e) {
 			// test passed
 		}
@@ -81,7 +80,7 @@ public abstract class SpecificationTest {
 	protected void assertException(String code) {
 		try {
 			getCompiler().compileAndRun(code);
-			fail("Expected an " + TestCompilerException.class.getSimpleName() + " to be thrown");
+			fail("Expected a " + TestCompilerException.class.getSimpleName() + " to be thrown.");
 		} catch(TestCompilerException e) {
 			// test passed
 		}


### PR DESCRIPTION
This fixes `testIncludeStatment()` so it checks  whether Object Declarations are overwritten after an `INCLUDE`.
Also fixes a possible precedence bug in `testAsNumber()`, adds a whitespace test to `testComments()` and adds better assert messages.
