### PR TITLE
Tests update

### DIFF
--- a/test/arden/tests/specification/README.md
+++ b/test/arden/tests/specification/README.md
@@ -7,7 +7,7 @@ Most of the statements made in the Arden Syntax language specification (v2.5) ar
 ## Running
 - **Using [Eclipse](https://eclipse.org/)**  
 Right-click on [SpecificationTestSuite.java](SpecificationTestSuite.java) and select *Run As* &rArr; *JUnit Test*. A new view should open and show a list of all successful, failed or skipped tests.
-- **Using [Apache Ant](http://ant.apache.org/)**
+- **Using [Apache Ant](http://ant.apache.org/)**  
 Using the command line go, to the project root and type `ant test`. A report, which can be opened in a browser, will be generated into the [report](../../../../report) directory.
 
 

--- a/test/arden/tests/specification/operators/StringOperatorsTest.java
+++ b/test/arden/tests/specification/operators/StringOperatorsTest.java
@@ -35,12 +35,12 @@ public class StringOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("(\"a\", \"b\", \"c\") formatted with \"%s ~ %s ~ %s\"", "\"a ~ b ~ c\"");
 		assertEvaluatesTo("(97, 98, 99) formatted with \"%c, %c, %c\"", "\"a, b, c\"");
 		assertEvaluatesTo("5.1234 formatted with \"%3.5f\"", "\"5.12340\"");
-		assertEvaluatesTo("12345678 formatted with \"%i\"", "\"12345678\"");
+		assertEvaluatesTo("12345678 formatted with \"%I\"", "\"12345678\"");
 		assertEvaluatesTo("1 formatted with \"%3d%%\"", "\"  1%\"");
 		assertEvaluatesTo("1 formatted with \"%03d%%\"", "\"001%\"");
 		assertEvaluatesTo("(4,42) formatted with \"%0*d\"", "\"0042\"");
-		assertEvaluatesTo("1 formatted with \"%-3i\"", "\"1  \"");
-		assertEvaluatesTo("1 formatted with \"%-+3i\"", "\"+1 \"");
+		assertEvaluatesTo("1 formatted with \"%-3I\"", "\"1  \"");
+		assertEvaluatesTo("1 formatted with \"%-+3I\"", "\"+1 \"");
 		assertEvaluatesTo("\"abc\" formatted with \"%3.2s\"", "\" ab\"");
 		assertEvaluatesTo("5.1234 formatted with \"%.4e\"", "\"5.1234e+000\"");
 		assertEvaluatesTo("5.1234 formatted with \"%.4g\"", "\"5.123\"");

--- a/test/arden/tests/specification/structureslots/ActionSlotTest.java
+++ b/test/arden/tests/specification/structureslots/ActionSlotTest.java
@@ -1,26 +1,13 @@
 package arden.tests.specification.structureslots;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
-import java.util.List;
-
 import org.junit.Test;
 
 import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.SpecificationTest;
 import arden.tests.specification.testcompiler.TestCompilerException;
-import arden.tests.specification.testcompiler.TestCompilerResult;
-import arden.tests.specification.testcompiler.TestCompilerResult.TestCompilerOutputText;
 
 public class ActionSlotTest extends SpecificationTest {
 	// TODO error on illegal statements
-	
-	private void assertWrites(String code, String expected) throws TestCompilerException {
-		TestCompilerResult result = getCompiler().compileAndRun(code);
-		TestCompilerOutputText outputText = result.outputTexts.get(0);
-		assertEquals(expected, outputText.text);
-	}
 	
 	@Test
 	public void testWriteStatement() throws Exception {
@@ -57,8 +44,7 @@ public class ActionSlotTest extends SpecificationTest {
 		assertStatementReturns("RETURN 1; RETURN 2;", "1");
 		
 		String multiReturn = new ArdenCodeBuilder().addAction("RETURN 5, (\"a\", \"b\");").toString();
-		List<String> returnValues = getCompiler().compileAndRun(multiReturn).returnValues;
-		assertArrayEquals(new String[]{"5", "(\"a\",\"b\")"}, returnValues.toArray());
+		assertReturns(multiReturn, "5", "(\"a\",\"b\")");
 		
 		String empty = new ArdenCodeBuilder().toString();
 		assertNoReturn(empty);

--- a/test/arden/tests/specification/structureslots/TokensTest.java
+++ b/test/arden/tests/specification/structureslots/TokensTest.java
@@ -13,7 +13,7 @@ public class TokensTest extends SpecificationTest {
 	
 	public void assertInvalidIdentifier(String reservedWord) {
 		try {
-			String invalidIdentifier = new ArdenCodeBuilder().addAction(reservedWord+ " := 5;").toString();
+			String invalidIdentifier = new ArdenCodeBuilder().addAction("let" + reservedWord + " be 5;").toString();
 			getCompiler().compile(invalidIdentifier);
 			fail("Expected an " + TestCompilerException.class.getSimpleName() + " to be thrown for reserved word: \"" + reservedWord+ "\"");
 		} catch(TestCompilerCompiletimeException e) {

--- a/test/arden/tests/specification/testcompiler/TestCompiler.java
+++ b/test/arden/tests/specification/testcompiler/TestCompiler.java
@@ -7,12 +7,12 @@ package arden.tests.specification.testcompiler;
 public interface TestCompiler {
 
 	/**
-	 * Used to check whether only compiletime tests (e.g. grammar tests, compile
-	 * time errors) should be run, or both compiletime and runtime tests (e.g.
-	 * operator tests) should also be run.
+	 * Used to check if runtime tests (e.g. operator tests, which check return
+	 * values) should be run by calling {@link #compileAndRun(String)}, or only
+	 * compiled to check for syntax errors by calling {@link #compile(String)}.
 	 * 
 	 * @return <code>true</code> if runtime tests should run, <code>false</code>
-	 *         otherwise.
+	 *         if they should only be compiled.
 	 */
 	public boolean isRuntimeSupported();
 
@@ -21,7 +21,7 @@ public interface TestCompiler {
 	 * which are supported.
 	 * 
 	 * @param version
-	 *            The version to check against
+	 *            The {@link ArdenVersion} to check against
 	 * @return <code>true</code> if backward compatibility tests for this
 	 *         version should run, <code>false</code> otherwise.
 	 */


### PR DESCRIPTION
This allows parsers (e.g. IDEs like [Arden4Eclipse] (https://github.com/PLRI/ardensyntax-eclipse-plugin)) or compilers without runtime support to run all tests.
Tests which require runtime support then just check whether the code is correctly parsed (or an expected compiletime error is returned) and expected return values are ignored.

Also fixes two minor test bugs.