### PR TITLE
Attach source

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -27,6 +27,7 @@
     <property name="build.dir" value="bin" />
     <property name="dist.dir" value="dist" />
     <property name="dist.file" value="${name}-${version}.jar" />
+    <property name="dist.source" value="on" />
     <property name="mainclass" value="arden.MainClass" />
     <property name="mainclass.test.implementation" value="arden.tests.implementation.ImplementationTestSuite" />
     <property name="mainclass.test.specification" value="arden.tests.specification.SpecificationTestSuite" />
@@ -177,7 +178,12 @@
             </manifest>
             <!-- include build without tests -->
             <fileset dir="${build.dir}" excludes="arden/tests/**" />
+            <!-- include source -->
+            <fileset dir="${src.dir}">
+                <include name="**/*.java" if="${dist.source}"/>
+            </fileset>
             <fileset file="${resource.dir}/arden2bytecode.config" />
+            <!-- include libraries -->
             <zipgroupfileset refid="dist.libs" />
         </jar>
         <basename property="jar.filename" file="${dist.file}" />

--- a/build.xml
+++ b/build.xml
@@ -175,8 +175,8 @@
                 <attribute name="Implementation-Title" value="${name}" />
                 <attribute name="Implementation-Version" value="${version}" />
             </manifest>
-            <!-- exclude tests -->
-            <fileset dir="${build.dir}" excludes="${build.dir}/arden/tests" />
+            <!-- include build without tests -->
+            <fileset dir="${build.dir}" excludes="arden/tests/**" />
             <fileset file="${resource.dir}/arden2bytecode.config" />
             <zipgroupfileset refid="dist.libs" />
         </jar>


### PR DESCRIPTION
When building the distributables, the .java files are contained in the jar-file by default. This allows easy source lookup, for example when adding Arden2ByteCode as a library to a an Eclipse project. 
It can be disable via the `dist.source` property.