### PR TITLE
Update ConstantParser

### DIFF
--- a/src/arden/MainClass.java
+++ b/src/arden/MainClass.java
@@ -56,7 +56,6 @@ import arden.constants.ConstantParser.ConstantParserException;
 import arden.runtime.ArdenValue;
 import arden.runtime.BaseExecutionContext;
 import arden.runtime.ExecutionContext;
-import arden.runtime.ExpressionHelpers;
 import arden.runtime.MedicalLogicModule;
 import arden.runtime.StdIOExecutionContext;
 import arden.runtime.jdbc.JDBCExecutionContext;
@@ -232,6 +231,14 @@ public class MainClass {
 	}
 
 	public boolean runFiles(List<File> files) {
+		ArdenValue[] arguments;
+		try {
+			arguments = getArguments();
+		} catch (MainException e) {
+			e.print();
+			return false;
+		}
+
 		List<MedicalLogicModule> mlms;
 		try {
 			mlms = getMlmsFromFiles(files);
@@ -248,7 +255,12 @@ public class MainClass {
 			}
 
 			// run the mlm
-			runMlm(mlm, context);
+			try {
+				runMlm(mlm, context, arguments);
+			} catch (MainException e) {
+				e.print();
+				return false;
+			}
 		}
 		return true;
 	}
@@ -343,6 +355,22 @@ public class MainClass {
 		return true;
 	}
 
+	private ArdenValue[] getArguments() throws MainException {
+		List<ArdenValue> args = new ArrayList<>();
+
+		if (options.isArguments()) {
+			try {
+				for (String arg : options.getArguments()) {
+					args.add(ConstantParser.parse(arg));
+				}
+			} catch (ConstantParserException e) {
+				throw new MainException("Error parsing arguments", e);
+			}
+		}
+
+		return args.toArray(new ArdenValue[args.size()]);
+	}
+
 	private BaseExecutionContext createExecutionContext() {
 		BaseExecutionContext context;
 		if (options.getEnvironment().startsWith("jdbc")) {
@@ -370,6 +398,9 @@ public class MainClass {
 				}
 			} else if (file.getName().endsWith(MLM_FILE_EXTENSION)) {
 				// compile .mlm file
+				if (options.getVerbose()) {
+					System.out.println("Compiling " + file.getPath() + " ...");
+				}
 				mlms.add(compileMlm(file));
 			} else {
 				errors.add("File \"" + file.getPath() + "\" is neither .class nor .mlm file. Can't run such a file.");
@@ -381,11 +412,7 @@ public class MainClass {
 		return mlms;
 	}
 
-	private CompiledMlm compileMlm(File file) throws MainException {
-		if (options.getVerbose()) {
-			System.out.println("Compiling " + file.getPath() + " ...");
-		}
-
+	public static CompiledMlm compileMlm(File file) throws MainException {
 		CompiledMlm mlm;
 		Compiler compiler = new Compiler();
 		compiler.enableDebugging(file.getPath());
@@ -401,9 +428,7 @@ public class MainClass {
 		return mlm;
 	}
 
-	private ArdenValue[] runMlm(MedicalLogicModule mlm, ExecutionContext context) {
-		ArdenValue[] arguments = getArguments();
-
+	public static ArdenValue[] runMlm(MedicalLogicModule mlm, ExecutionContext context, ArdenValue[] arguments) throws MainException {
 		ArdenValue[] result = null;
 		try {
 			result = mlm.run(context, arguments);
@@ -417,31 +442,9 @@ public class MainClass {
 				System.out.println("There was no return value.");
 			}
 		} catch (InvocationTargetException e) {
-			e.printStackTrace();
+			throw new MainException("Could not run MLM", e);
 		}
 		return result;
-	}
-
-	private ArdenValue[] getArguments() {
-		ArdenValue[] arguments = null;
-		if (options.isArguments()) {
-			ArdenValue ardenArg = null;
-			for (String arg : options.getArguments()) {
-				ArdenValue parsedArg = null;
-				try {
-					parsedArg = ConstantParser.parse(arg);
-				} catch (ConstantParserException e) {
-					e.printStackTrace();
-				}
-				if (ardenArg == null) {
-					ardenArg = parsedArg;
-				} else {
-					ardenArg = ExpressionHelpers.binaryComma(ardenArg, parsedArg);
-				}
-			}
-			arguments = new ArdenValue[] { ardenArg };
-		}
-		return arguments;
 	}
 
 	public static String getFilenameBase(String filename) {

--- a/src/arden/MainClass.java
+++ b/src/arden/MainClass.java
@@ -52,7 +52,7 @@ import arden.compiler.CompiledMlm;
 import arden.compiler.Compiler;
 import arden.compiler.CompilerException;
 import arden.constants.ConstantParser;
-import arden.constants.ConstantParser.ConstantParserException;
+import arden.constants.ConstantParserException;
 import arden.runtime.ArdenValue;
 import arden.runtime.BaseExecutionContext;
 import arden.runtime.ExecutionContext;

--- a/src/arden/constants/ConstantParser.java
+++ b/src/arden/constants/ConstantParser.java
@@ -5,13 +5,16 @@ import java.io.PushbackReader;
 import java.io.StringReader;
 import java.text.DateFormat;
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.Date;
-import java.util.Deque;
-import java.util.LinkedList;
+import java.util.List;
+import java.util.Stack;
 
 import arden.constants.analysis.DepthFirstAdapter;
 import arden.constants.lexer.Lexer;
 import arden.constants.lexer.LexerException;
+import arden.constants.node.AArdenConstant;
+import arden.constants.node.AAtomExpr;
 import arden.constants.node.ADateAtom;
 import arden.constants.node.ADtimeAtom;
 import arden.constants.node.AFalseArdenBoolean;
@@ -22,6 +25,7 @@ import arden.constants.node.ANumberAtom;
 import arden.constants.node.AParAtom;
 import arden.constants.node.AStringAtom;
 import arden.constants.node.ATrueArdenBoolean;
+import arden.constants.node.Node;
 import arden.constants.node.Start;
 import arden.constants.node.TArdenDate;
 import arden.constants.node.TArdenDateTime;
@@ -39,64 +43,117 @@ import arden.runtime.ArdenValue;
 import arden.runtime.ExpressionHelpers;
 
 public class ConstantParser {
-	
-	public class ConstantParserException extends Exception {
-		private static final long serialVersionUID = 1L;
-		int line;
-		int pos;
 
-		public ConstantParserException(ParserException e) {
-			super(e);
-			if (e.getToken() != null) {
-				line = e.getToken().getLine();
-				pos = e.getToken().getPos();
-			} else {
-				line = pos = -1;
-			}
-		}
-
-		public ConstantParserException(LexerException e) {
-			super(e);
-			line = pos = -1;
+	/**
+	 * Translates code for an Arden Syntax constant to an {@link ArdenValue}.
+	 * The constant may e.g. be a number, a string (surrounded by double quotes)
+	 * or a list (with or without parentheses).
+	 * 
+	 * @param input
+	 *            A single Arden Syntax constant
+	 * @return The constant translated to an ArdenValue
+	 */
+	public static ArdenValue parse(String input) throws ConstantParserException {
+		if (input == null) {
+			return ArdenNull.create(System.currentTimeMillis());
 		}
 
-		public ConstantParserException(IOException e) {
-			super(e);
-			line = pos = -1;
+		try {
+			Start syntaxTree = parseAST(input);
+			return parseValue(syntaxTree);
+		} catch (RuntimeException e) {
+			throw (ConstantParserException) e.getCause();
 		}
-		
-		public ConstantParserException(String message) {
-			super(message);
-			line = pos = -1;
-		}
-		
-		public ConstantParserException(Token token, String message) {
-			super(message);
-			line = token.getLine();
-			pos = token.getPos();
-		}
-		
-		public int getLine() {
-			return line;
-		}
-		
-		public int getPos() {
-			return pos;
-		}
-	}		
-	
-	public ConstantParser() {
 	}
-	
-	private class AstVisitor extends DepthFirstAdapter {
-		Deque<ArdenValue> stack;
-		ArdenValue result;
-		long primaryTime;
-		
+
+	/**
+	 * Translates a comma separated list of Arden Syntax constants to
+	 * {@link ArdenValue}s. Constants with parentheses are considered as a
+	 * single {@link ArdenList}. This is equivalent to how the Arden Syntax
+	 * RETURN statement handles multi-returns and lists.
+	 * 
+	 * @param input
+	 *            Arden Syntax constants
+	 * @return The constants translated to ArdenValues
+	 * @throws ConstantParserException
+	 */
+	public static ArdenValue[] parseMultiple(String input) throws ConstantParserException {
+		if (input == null) {
+			return new ArdenValue[] { ArdenNull.create(System.currentTimeMillis()) };
+		}
+
+		Start syntaxTree = parseAST(input);
+
+		MultiVisitor visitor = new MultiVisitor();
+		try {
+			syntaxTree.apply(visitor);
+			return visitor.getResult();
+		} catch (RuntimeException e) {
+			throw (ConstantParserException) e.getCause();
+		}
+	}
+
+	private static Start parseAST(String input) throws ConstantParserException {
+		StringReader reader = new StringReader(input);
+		Lexer lexer = new Lexer(new PushbackReader(reader, 256));
+		Parser parser = new Parser(lexer);
+		try {
+			return parser.parse();
+		} catch (ParserException e) {
+			throw new ConstantParserException(e);
+		} catch (LexerException e) {
+			throw new ConstantParserException(e);
+		} catch (IOException e) {
+			throw new ConstantParserException(e);
+		}
+	}
+
+	private static ArdenValue parseValue(Node node) {
+		ConstantVisitor visitor = new ConstantVisitor();
+		node.apply(visitor);
+		return visitor.getResult();
+	}
+
+	private static class MultiVisitor extends DepthFirstAdapter {
+		List<ArdenValue> output = new ArrayList<>();
+
+		@Override
+		public void caseAArdenConstant(AArdenConstant node) {
+			node.getExpr().apply(this);
+		}
+
+		@Override
+		public void caseAAtomExpr(AAtomExpr node) {
+			// single constant or a list of constants in parentheses
+			output.add(parseValue(node.getAtom()));
+		}
+
+		@Override
+		public void caseAListatomExpr(AListatomExpr node) {
+			// single comma and constant
+			output.add(parseValue(node.getAtom()));
+		}
+
+		@Override
+		public void caseAListExpr(AListExpr node) {
+			// multiple constants, separated by commas
+			node.getExpr().apply(this);
+			output.add(parseValue(node.getAtom()));
+		}
+
+		public ArdenValue[] getResult() {
+			return output.toArray(new ArdenValue[output.size()]);
+		}
+	}
+
+	private static class ConstantVisitor extends DepthFirstAdapter {
+		Stack<ArdenValue> stack = new Stack<>();
+		long primaryTime = System.currentTimeMillis();
+
 		private boolean isWhitespace(char c) {
 			return c == ' ' || c == '\t' || c == '\n' || c == '\r';
 		}
-		
+
 		public String parseString(TArdenString literal) throws ConstantParserException {
 			String input = literal.getText();
 			if (input.length() < 2 || input.charAt(0) != '"' || input.charAt(input.length() - 1) != '"')
@@ -128,21 +185,24 @@ public class ConstantParser {
 			}
 			return output.toString();
 		}
-		
+
 		public long parseIsoDateTime(TArdenDateTime dateTime) throws ConstantParserException {
 			/*
 			 * SimpleDateFormat is very bad at parsing ISO 8601. Therefore we
 			 * change the text to a parsable format by extracting the fractional
 			 * seconds and changing the timezone part.
 			 */
-			String text = dateTime.getText().toUpperCase(); // allow lowercase 't' and 'z'
+
+			// allow lowercase 't' and 'z'
+			String text = dateTime.getText().toUpperCase();
+
 			StringBuilder parsableText = new StringBuilder(text);
 			DateFormat format;
 			long millis = 0;
-			
+
 			// parse fractional seconds if present
 			int millisPos = ArdenTime.isoDateTimeLength;
-			if(millisPos < text.length() && text.charAt(millisPos) == '.') {
+			if (millisPos < text.length() && text.charAt(millisPos) == '.') {
 				int multiplier = 100;
 				millisPos++;
 				while (millisPos < text.length()) {
@@ -160,20 +220,20 @@ public class ConstantParser {
 				// remove fractional seconds part
 				parsableText.delete(ArdenTime.isoDateTimeLength, millisPos);
 			}
-			
+
 			// parse timezone if present
 			int timezonePos = ArdenTime.isoDateTimeLength;
-			if(timezonePos < parsableText.length()) {
+			if (timezonePos < parsableText.length()) {
 				// has timezone
 				format = ArdenTime.isoDateTimeFormatWithGmtTimeZone;
 				switch (parsableText.charAt(timezonePos)) {
 				case 'Z':
 					// 2000-01-01T00:00:00Z -> 2000-01-01T00:00:00GMT-00:00
-					parsableText.replace(timezonePos, timezonePos+1, "GMT-00:00");
+					parsableText.replace(timezonePos, timezonePos + 1, "GMT-00:00");
 					break;
 				case '+': // fall through
 				case '-':
-					// 2000-01-01T00:00:00+01:00 -> 2000-01-01T00:00:00GMT+01:00 
+					// 2000-01-01T00:00:00+01:00 -> 2000-01-01T00:00:00GMT+01:00
 					parsableText.insert(timezonePos, "GMT");
 					break;
 				default:
@@ -183,7 +243,7 @@ public class ConstantParser {
 				// no timezone
 				format = ArdenTime.isoDateTimeFormat;
 			}
-			
+
 			Date date;
 			try {
 				date = format.parse(parsableText.toString());
@@ -197,26 +257,20 @@ public class ConstantParser {
 			try {
 				return ArdenTime.isoDateFormat.parse(isoDate.getText()).getTime();
 			} catch (ParseException e) {
-				throw new ConstantParserException(e.getMessage());
+				throw new ConstantParserException(isoDate, e.getMessage());
 			}
 		}
-		
-		public AstVisitor() {
-			stack = new LinkedList<ArdenValue>();
-			primaryTime = System.currentTimeMillis();
-			result = null;
-		}
-		
+
 		@Override
 		public void caseATrueArdenBoolean(ATrueArdenBoolean node) {
 			stack.push(ArdenBoolean.create(true, primaryTime));
 		}
-		
+
 		@Override
 		public void caseAFalseArdenBoolean(AFalseArdenBoolean node) {
 			stack.push(ArdenBoolean.create(false, primaryTime));
 		}
-		
+
 		@Override
 		public void caseAStringAtom(AStringAtom node) {
 			TArdenString string = node.getArdenString();
@@ -226,7 +280,7 @@ public class ConstantParser {
 				throw new RuntimeException(e);
 			}
 		}
-		
+
 		@Override
 		public void caseANumberAtom(ANumberAtom node) {
 			String numStr = node.getArdenNumber().getText();
@@ -234,25 +288,25 @@ public class ConstantParser {
 			try {
 				d = Double.parseDouble(numStr);
 			} catch (NumberFormatException e) {
-				throw new RuntimeException("Not a valid number at pos: " + node.getArdenNumber().getPos());
+				throw new RuntimeException(new ConstantParserException(node.getArdenNumber(), "Not a valid number"));
 			}
 			if (Double.isInfinite(d) || Double.isNaN(d)) {
-				throw new RuntimeException("Not a valid number at pos: "  + node.getArdenNumber().getPos());
+				throw new RuntimeException(new ConstantParserException(node.getArdenNumber(), "Not a valid number"));
 			}
 			stack.push(ArdenNumber.create(d, primaryTime));
 		}
-		
+
 		@Override
 		public void caseANullAtom(ANullAtom node) {
 			stack.push(ArdenNull.create(primaryTime));
 		}
-		
+
 		@Override
 		public void caseAListatomExpr(AListatomExpr node) {
 			node.getAtom().apply(this);
 			stack.push(ExpressionHelpers.unaryComma(stack.pop()));
 		}
-		
+
 		@Override
 		public void caseAListExpr(AListExpr node) {
 			node.getExpr().apply(this);
@@ -260,7 +314,7 @@ public class ConstantParser {
 			ArdenValue atomValue = stack.pop();
 			stack.push(ExpressionHelpers.binaryComma(stack.pop(), atomValue));
 		}
-		
+
 		@Override
 		public void caseADateAtom(ADateAtom node) {
 			TArdenDate date = node.getArdenDate();
@@ -270,7 +324,7 @@ public class ConstantParser {
 				throw new RuntimeException(e);
 			}
 		}
-		
+
 		@Override
 		public void caseADtimeAtom(ADtimeAtom node) {
 			TArdenDateTime dateTime = node.getArdenDateTime();
@@ -280,49 +334,62 @@ public class ConstantParser {
 				throw new RuntimeException(e);
 			}
 		}
-		
+
 		@Override
 		public void caseAParAtom(AParAtom node) {
 			stack.push(ArdenList.EMPTY);
 		}
-		
-		@Override
-		public void outStart(Start node) {
-			if (stack.size() != 1) {
-				throw new RuntimeException("Input is malformed in terms of parentheses.");
-			}
-			result = stack.getFirst();
-		}
-		
-		public ArdenValue getResult() {
-			return result;
-		}
-	}
-	
-	public static ArdenValue parse(String input) throws ConstantParserException {
-		return new ConstantParser().doParse(input);
-	}
-	
-	public ArdenValue doParse(String input) throws ConstantParserException {		
-		if (input == null) {
-			return ArdenNull.create(System.currentTimeMillis());
-		}
-		StringReader reader = new StringReader(input);
 
-		Lexer lexer = new Lexer(new PushbackReader(reader, 256));
-		Parser parser = new Parser(lexer);
-		Start syntaxTree;
-		try {
-			syntaxTree = parser.parse();
-		} catch (ParserException e) {
-			throw new ConstantParserException(e);
-		} catch (LexerException e) {
-			throw new ConstantParserException(e);
-		} catch (IOException e) {
-			throw new ConstantParserException(e);
+		public ArdenValue getResult() {
+			if (stack.size() != 1) {
+				throw new RuntimeException(new ConstantParserException("Input is malformed in terms of parentheses."));
+			}
+			return stack.peek();
 		}
-		AstVisitor visitor = new AstVisitor(); 
-		syntaxTree.apply(visitor);
-		return visitor.getResult();
+	}
+
+	public static class ConstantParserException extends Exception {
+		private static final long serialVersionUID = 1L;
+		int line;
+		int pos;
+
+		public ConstantParserException(ParserException e) {
+			super(e);
+			if (e.getToken() != null) {
+				line = e.getToken().getLine();
+				pos = e.getToken().getPos();
+			} else {
+				line = pos = -1;
+			}
+		}
+
+		public ConstantParserException(LexerException e) {
+			super(e);
+			line = pos = -1;
+		}
+
+		public ConstantParserException(IOException e) {
+			super(e);
+			line = pos = -1;
+		}
+
+		public ConstantParserException(String message) {
+			super(message);
+			line = pos = -1;
+		}
+
+		public ConstantParserException(Token token, String message) {
+			super(message);
+			line = token.getLine();
+			pos = token.getPos();
+		}
+
+		public int getLine() {
+			return line;
+		}
+
+		public int getPos() {
+			return pos;
+		}
 	}
 }

--- a/src/arden/constants/ConstantParser.java
+++ b/src/arden/constants/ConstantParser.java
@@ -3,44 +3,16 @@ package arden.constants;
 import java.io.IOException;
 import java.io.PushbackReader;
 import java.io.StringReader;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Stack;
 
-import arden.constants.analysis.DepthFirstAdapter;
 import arden.constants.lexer.Lexer;
 import arden.constants.lexer.LexerException;
-import arden.constants.node.AArdenConstant;
-import arden.constants.node.AAtomExpr;
-import arden.constants.node.ADateAtom;
-import arden.constants.node.ADtimeAtom;
-import arden.constants.node.AFalseArdenBoolean;
-import arden.constants.node.AListExpr;
-import arden.constants.node.AListatomExpr;
-import arden.constants.node.ANullAtom;
-import arden.constants.node.ANumberAtom;
-import arden.constants.node.AParAtom;
-import arden.constants.node.AStringAtom;
-import arden.constants.node.ATrueArdenBoolean;
 import arden.constants.node.Node;
 import arden.constants.node.Start;
-import arden.constants.node.TArdenDate;
-import arden.constants.node.TArdenDateTime;
-import arden.constants.node.TArdenString;
-import arden.constants.node.Token;
 import arden.constants.parser.Parser;
 import arden.constants.parser.ParserException;
-import arden.runtime.ArdenBoolean;
 import arden.runtime.ArdenList;
 import arden.runtime.ArdenNull;
-import arden.runtime.ArdenNumber;
-import arden.runtime.ArdenString;
-import arden.runtime.ArdenTime;
 import arden.runtime.ArdenValue;
-import arden.runtime.ExpressionHelpers;
 
 public class ConstantParser {
 
@@ -60,7 +32,9 @@ public class ConstantParser {
 
 		try {
 			Start syntaxTree = parseAST(input);
-			return parseValue(syntaxTree);
+			ConstantVisitor visitor = new ConstantVisitor();
+			syntaxTree.apply(visitor);
+			return visitor.getResult();
 		} catch (RuntimeException e) {
 			throw (ConstantParserException) e.getCause();
 		}
@@ -93,7 +67,7 @@ public class ConstantParser {
 		}
 	}
 
-	private static Start parseAST(String input) throws ConstantParserException {
+	public static Start parseAST(String input) throws ConstantParserException {
 		StringReader reader = new StringReader(input);
 		Lexer lexer = new Lexer(new PushbackReader(reader, 256));
 		Parser parser = new Parser(lexer);
@@ -107,289 +81,11 @@ public class ConstantParser {
 			throw new ConstantParserException(e);
 		}
 	}
-
-	private static ArdenValue parseValue(Node node) {
+	
+	public static ArdenValue parseValue(Node node) {
 		ConstantVisitor visitor = new ConstantVisitor();
 		node.apply(visitor);
 		return visitor.getResult();
 	}
 
-	private static class MultiVisitor extends DepthFirstAdapter {
-		List<ArdenValue> output = new ArrayList<>();
-
-		@Override
-		public void caseAArdenConstant(AArdenConstant node) {
-			node.getExpr().apply(this);
-		}
-
-		@Override
-		public void caseAAtomExpr(AAtomExpr node) {
-			// single constant or a list of constants in parentheses
-			output.add(parseValue(node.getAtom()));
-		}
-
-		@Override
-		public void caseAListatomExpr(AListatomExpr node) {
-			// single comma and constant
-			output.add(parseValue(node.getAtom()));
-		}
-
-		@Override
-		public void caseAListExpr(AListExpr node) {
-			// multiple constants, separated by commas
-			node.getExpr().apply(this);
-			output.add(parseValue(node.getAtom()));
-		}
-
-		public ArdenValue[] getResult() {
-			return output.toArray(new ArdenValue[output.size()]);
-		}
-	}
-
-	private static class ConstantVisitor extends DepthFirstAdapter {
-		Stack<ArdenValue> stack = new Stack<>();
-		long primaryTime = System.currentTimeMillis();
-
-		private boolean isWhitespace(char c) {
-			return c == ' ' || c == '\t' || c == '\n' || c == '\r';
-		}
-
-		public String parseString(TArdenString literal) throws ConstantParserException {
-			String input = literal.getText();
-			if (input.length() < 2 || input.charAt(0) != '"' || input.charAt(input.length() - 1) != '"')
-				throw new ConstantParserException(literal, "Invalid string literal");
-			StringBuilder output = new StringBuilder();
-			for (int i = 1; i < input.length() - 1; i++) {
-				char c = input.charAt(i);
-				if (c == '\r' || c == '\n') {
-					// (see spec for special rules in this case)
-					while (output.length() > 0 && isWhitespace(output.charAt(output.length() - 1)))
-						output.deleteCharAt(output.length() - 1);
-					int numLineFeed = 0;
-					while (isWhitespace(c)) {
-						if (c == '\n')
-							numLineFeed++;
-						c = input.charAt(++i);
-					}
-					if (numLineFeed > 1)
-						output.append('\n');
-					else
-						output.append(' ');
-				}
-				if (c == '"') {
-					i += 1;
-					if (input.charAt(i) != '"')
-						throw new ConstantParserException(literal, "Invalid string literal");
-				}
-				output.append(c);
-			}
-			return output.toString();
-		}
-
-		public long parseIsoDateTime(TArdenDateTime dateTime) throws ConstantParserException {
-			/*
-			 * SimpleDateFormat is very bad at parsing ISO 8601. Therefore we
-			 * change the text to a parsable format by extracting the fractional
-			 * seconds and changing the timezone part.
-			 */
-
-			// allow lowercase 't' and 'z'
-			String text = dateTime.getText().toUpperCase();
-
-			StringBuilder parsableText = new StringBuilder(text);
-			DateFormat format;
-			long millis = 0;
-
-			// parse fractional seconds if present
-			int millisPos = ArdenTime.isoDateTimeLength;
-			if (millisPos < text.length() && text.charAt(millisPos) == '.') {
-				int multiplier = 100;
-				millisPos++;
-				while (millisPos < text.length()) {
-					char c = text.charAt(millisPos);
-					boolean isDigit = c >= '0' && c <= '9';
-					if (isDigit) {
-						millis += (c - '0') * multiplier;
-						multiplier /= 10;
-						millisPos++;
-					} else {
-						// timezone follows
-						break;
-					}
-				}
-				// remove fractional seconds part
-				parsableText.delete(ArdenTime.isoDateTimeLength, millisPos);
-			}
-
-			// parse timezone if present
-			int timezonePos = ArdenTime.isoDateTimeLength;
-			if (timezonePos < parsableText.length()) {
-				// has timezone
-				format = ArdenTime.isoDateTimeFormatWithGmtTimeZone;
-				switch (parsableText.charAt(timezonePos)) {
-				case 'Z':
-					// 2000-01-01T00:00:00Z -> 2000-01-01T00:00:00GMT-00:00
-					parsableText.replace(timezonePos, timezonePos + 1, "GMT-00:00");
-					break;
-				case '+': // fall through
-				case '-':
-					// 2000-01-01T00:00:00+01:00 -> 2000-01-01T00:00:00GMT+01:00
-					parsableText.insert(timezonePos, "GMT");
-					break;
-				default:
-					throw new ConstantParserException(dateTime, "Invalid DateTime literal");
-				}
-			} else {
-				// no timezone
-				format = ArdenTime.isoDateTimeFormat;
-			}
-
-			Date date;
-			try {
-				date = format.parse(parsableText.toString());
-			} catch (ParseException e) {
-				throw new ConstantParserException(dateTime, "Invalid DateTime literal");
-			}
-			return date.getTime() + millis;
-		}
-
-		public long parseIsoDate(TArdenDate isoDate) throws ConstantParserException {
-			try {
-				return ArdenTime.isoDateFormat.parse(isoDate.getText()).getTime();
-			} catch (ParseException e) {
-				throw new ConstantParserException(isoDate, e.getMessage());
-			}
-		}
-
-		@Override
-		public void caseATrueArdenBoolean(ATrueArdenBoolean node) {
-			stack.push(ArdenBoolean.create(true, primaryTime));
-		}
-
-		@Override
-		public void caseAFalseArdenBoolean(AFalseArdenBoolean node) {
-			stack.push(ArdenBoolean.create(false, primaryTime));
-		}
-
-		@Override
-		public void caseAStringAtom(AStringAtom node) {
-			TArdenString string = node.getArdenString();
-			try {
-				stack.push(new ArdenString(parseString(string), primaryTime));
-			} catch (ConstantParserException e) {
-				throw new RuntimeException(e);
-			}
-		}
-
-		@Override
-		public void caseANumberAtom(ANumberAtom node) {
-			String numStr = node.getArdenNumber().getText();
-			double d = Double.NaN;
-			try {
-				d = Double.parseDouble(numStr);
-			} catch (NumberFormatException e) {
-				throw new RuntimeException(new ConstantParserException(node.getArdenNumber(), "Not a valid number"));
-			}
-			if (Double.isInfinite(d) || Double.isNaN(d)) {
-				throw new RuntimeException(new ConstantParserException(node.getArdenNumber(), "Not a valid number"));
-			}
-			stack.push(ArdenNumber.create(d, primaryTime));
-		}
-
-		@Override
-		public void caseANullAtom(ANullAtom node) {
-			stack.push(ArdenNull.create(primaryTime));
-		}
-
-		@Override
-		public void caseAListatomExpr(AListatomExpr node) {
-			node.getAtom().apply(this);
-			stack.push(ExpressionHelpers.unaryComma(stack.pop()));
-		}
-
-		@Override
-		public void caseAListExpr(AListExpr node) {
-			node.getExpr().apply(this);
-			node.getAtom().apply(this);
-			ArdenValue atomValue = stack.pop();
-			stack.push(ExpressionHelpers.binaryComma(stack.pop(), atomValue));
-		}
-
-		@Override
-		public void caseADateAtom(ADateAtom node) {
-			TArdenDate date = node.getArdenDate();
-			try {
-				stack.push(new ArdenTime(parseIsoDate(date), primaryTime));
-			} catch (ConstantParserException e) {
-				throw new RuntimeException(e);
-			}
-		}
-
-		@Override
-		public void caseADtimeAtom(ADtimeAtom node) {
-			TArdenDateTime dateTime = node.getArdenDateTime();
-			try {
-				stack.push(new ArdenTime(parseIsoDateTime(dateTime), primaryTime));
-			} catch (ConstantParserException e) {
-				throw new RuntimeException(e);
-			}
-		}
-
-		@Override
-		public void caseAParAtom(AParAtom node) {
-			stack.push(ArdenList.EMPTY);
-		}
-
-		public ArdenValue getResult() {
-			if (stack.size() != 1) {
-				throw new RuntimeException(new ConstantParserException("Input is malformed in terms of parentheses."));
-			}
-			return stack.peek();
-		}
-	}
-
-	public static class ConstantParserException extends Exception {
-		private static final long serialVersionUID = 1L;
-		int line;
-		int pos;
-
-		public ConstantParserException(ParserException e) {
-			super(e);
-			if (e.getToken() != null) {
-				line = e.getToken().getLine();
-				pos = e.getToken().getPos();
-			} else {
-				line = pos = -1;
-			}
-		}
-
-		public ConstantParserException(LexerException e) {
-			super(e);
-			line = pos = -1;
-		}
-
-		public ConstantParserException(IOException e) {
-			super(e);
-			line = pos = -1;
-		}
-
-		public ConstantParserException(String message) {
-			super(message);
-			line = pos = -1;
-		}
-
-		public ConstantParserException(Token token, String message) {
-			super(message);
-			line = token.getLine();
-			pos = token.getPos();
-		}
-
-		public int getLine() {
-			return line;
-		}
-
-		public int getPos() {
-			return pos;
-		}
-	}
 }

--- a/src/arden/constants/ConstantParserException.java
+++ b/src/arden/constants/ConstantParserException.java
@@ -1,0 +1,52 @@
+package arden.constants;
+
+import java.io.IOException;
+
+import arden.constants.lexer.LexerException;
+import arden.constants.node.Token;
+import arden.constants.parser.ParserException;
+
+public class ConstantParserException extends Exception {
+	private static final long serialVersionUID = 1L;
+	int line;
+	int pos;
+
+	public ConstantParserException(ParserException e) {
+		super(e);
+		if (e.getToken() != null) {
+			line = e.getToken().getLine();
+			pos = e.getToken().getPos();
+		} else {
+			line = pos = -1;
+		}
+	}
+
+	public ConstantParserException(LexerException e) {
+		super(e);
+		line = pos = -1;
+	}
+
+	public ConstantParserException(IOException e) {
+		super(e);
+		line = pos = -1;
+	}
+
+	public ConstantParserException(String message) {
+		super(message);
+		line = pos = -1;
+	}
+
+	public ConstantParserException(Token token, String message) {
+		super(message);
+		line = token.getLine();
+		pos = token.getPos();
+	}
+
+	public int getLine() {
+		return line;
+	}
+
+	public int getPos() {
+		return pos;
+	}
+}

--- a/src/arden/constants/ConstantVisitor.java
+++ b/src/arden/constants/ConstantVisitor.java
@@ -1,0 +1,240 @@
+package arden.constants;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.Stack;
+
+import arden.constants.analysis.DepthFirstAdapter;
+import arden.constants.node.ADateAtom;
+import arden.constants.node.ADtimeAtom;
+import arden.constants.node.AFalseArdenBoolean;
+import arden.constants.node.AListExpr;
+import arden.constants.node.AListatomExpr;
+import arden.constants.node.ANullAtom;
+import arden.constants.node.ANumberAtom;
+import arden.constants.node.AParAtom;
+import arden.constants.node.AStringAtom;
+import arden.constants.node.ATrueArdenBoolean;
+import arden.constants.node.TArdenDate;
+import arden.constants.node.TArdenDateTime;
+import arden.constants.node.TArdenNumber;
+import arden.constants.node.TArdenString;
+import arden.runtime.ArdenBoolean;
+import arden.runtime.ArdenList;
+import arden.runtime.ArdenNull;
+import arden.runtime.ArdenNumber;
+import arden.runtime.ArdenString;
+import arden.runtime.ArdenTime;
+import arden.runtime.ArdenValue;
+import arden.runtime.ExpressionHelpers;
+
+class ConstantVisitor extends DepthFirstAdapter {
+	Stack<ArdenValue> stack = new Stack<>();
+	long primaryTime = System.currentTimeMillis();
+
+	private static boolean isWhitespace(char c) {
+		return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+	}
+	
+	private static String parseString(TArdenString literal) throws ConstantParserException {
+		String input = literal.getText();
+		if (input.length() < 2 || input.charAt(0) != '"' || input.charAt(input.length() - 1) != '"')
+			throw new ConstantParserException(literal, "Invalid string literal");
+		StringBuilder output = new StringBuilder();
+		for (int i = 1; i < input.length() - 1; i++) {
+			char c = input.charAt(i);
+			if (c == '\r' || c == '\n') {
+				// (see spec for special rules in this case)
+				while (output.length() > 0 && isWhitespace(output.charAt(output.length() - 1)))
+					output.deleteCharAt(output.length() - 1);
+				int numLineFeed = 0;
+				while (isWhitespace(c)) {
+					if (c == '\n')
+						numLineFeed++;
+					c = input.charAt(++i);
+				}
+				if (numLineFeed > 1)
+					output.append('\n');
+				else
+					output.append(' ');
+			}
+			if (c == '"') {
+				i += 1;
+				if (input.charAt(i) != '"')
+					throw new ConstantParserException(literal, "Invalid string literal");
+			}
+			output.append(c);
+		}
+		return output.toString();
+	}
+
+	private static long parseIsoDateTime(TArdenDateTime dateTime) throws ConstantParserException {
+		/*
+		 * SimpleDateFormat is very bad at parsing ISO 8601. Therefore we
+		 * change the text to a parsable format by extracting the fractional
+		 * seconds and changing the timezone part.
+		 */
+
+		// allow lowercase 't' and 'z'
+		String text = dateTime.getText().toUpperCase();
+
+		StringBuilder parsableText = new StringBuilder(text);
+		DateFormat format;
+		long millis = 0;
+
+		// parse fractional seconds if present
+		int millisPos = ArdenTime.isoDateTimeLength;
+		if (millisPos < text.length() && text.charAt(millisPos) == '.') {
+			int multiplier = 100;
+			millisPos++;
+			while (millisPos < text.length()) {
+				char c = text.charAt(millisPos);
+				boolean isDigit = c >= '0' && c <= '9';
+				if (isDigit) {
+					millis += (c - '0') * multiplier;
+					multiplier /= 10;
+					millisPos++;
+				} else {
+					// timezone follows
+					break;
+				}
+			}
+			// remove fractional seconds part
+			parsableText.delete(ArdenTime.isoDateTimeLength, millisPos);
+		}
+
+		// parse timezone if present
+		int timezonePos = ArdenTime.isoDateTimeLength;
+		if (timezonePos < parsableText.length()) {
+			// has timezone
+			format = ArdenTime.isoDateTimeFormatWithGmtTimeZone;
+			switch (parsableText.charAt(timezonePos)) {
+			case 'Z':
+				// 2000-01-01T00:00:00Z -> 2000-01-01T00:00:00GMT-00:00
+				parsableText.replace(timezonePos, timezonePos + 1, "GMT-00:00");
+				break;
+			case '+': // fall through
+			case '-':
+				// 2000-01-01T00:00:00+01:00 -> 2000-01-01T00:00:00GMT+01:00
+				parsableText.insert(timezonePos, "GMT");
+				break;
+			default:
+				throw new ConstantParserException(dateTime, "Invalid DateTime literal");
+			}
+		} else {
+			// no timezone
+			format = ArdenTime.isoDateTimeFormat;
+		}
+
+		Date date;
+		try {
+			date = format.parse(parsableText.toString());
+		} catch (ParseException e) {
+			throw new ConstantParserException(dateTime, "Invalid DateTime literal");
+		}
+		return date.getTime() + millis;
+	}
+
+	private static long parseIsoDate(TArdenDate isoDate) throws ConstantParserException {
+		try {
+			return ArdenTime.isoDateFormat.parse(isoDate.getText()).getTime();
+		} catch (ParseException e) {
+			throw new ConstantParserException(isoDate, e.getMessage());
+		}
+	}
+	
+	private static double parseNumber(TArdenNumber ardenNumber) throws ConstantParserException {
+		double d = Double.NaN;
+		try {
+			d = Double.parseDouble(ardenNumber.getText());
+		} catch (NumberFormatException e) {
+			throw new ConstantParserException(ardenNumber, "Not a valid number");
+		}
+		if (Double.isInfinite(d) || Double.isNaN(d)) {
+			throw new ConstantParserException(ardenNumber, "Not a valid number");
+		}
+		return d;
+	}
+
+	@Override
+	public void caseATrueArdenBoolean(ATrueArdenBoolean node) {
+		stack.push(ArdenBoolean.create(true, primaryTime));
+	}
+
+	@Override
+	public void caseAFalseArdenBoolean(AFalseArdenBoolean node) {
+		stack.push(ArdenBoolean.create(false, primaryTime));
+	}
+
+	@Override
+	public void caseAStringAtom(AStringAtom node) {
+		try {
+			String string = parseString(node.getArdenString());
+			stack.push(new ArdenString(string, primaryTime));
+		} catch (ConstantParserException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void caseANumberAtom(ANumberAtom node) {
+		try {
+			double value = parseNumber(node.getArdenNumber());
+			stack.push(ArdenNumber.create(value, primaryTime));
+		} catch (ConstantParserException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void caseANullAtom(ANullAtom node) {
+		stack.push(ArdenNull.create(primaryTime));
+	}
+
+	@Override
+	public void caseAListatomExpr(AListatomExpr node) {
+		node.getAtom().apply(this);
+		stack.push(ExpressionHelpers.unaryComma(stack.pop()));
+	}
+
+	@Override
+	public void caseAListExpr(AListExpr node) {
+		node.getExpr().apply(this);
+		node.getAtom().apply(this);
+		ArdenValue atomValue = stack.pop();
+		stack.push(ExpressionHelpers.binaryComma(stack.pop(), atomValue));
+	}
+
+	@Override
+	public void caseADateAtom(ADateAtom node) {
+		try {
+			long millis = parseIsoDate(node.getArdenDate());
+			stack.push(new ArdenTime(millis, primaryTime));
+		} catch (ConstantParserException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void caseADtimeAtom(ADtimeAtom node) {
+		try {
+			long millis = parseIsoDateTime(node.getArdenDateTime());
+			stack.push(new ArdenTime(millis, primaryTime));
+		} catch (ConstantParserException e) {
+			throw new RuntimeException(e);
+		}
+	}
+	
+	@Override
+	public void caseAParAtom(AParAtom node) {
+		stack.push(ArdenList.EMPTY);
+	}
+
+	public ArdenValue getResult() {
+		if (stack.size() != 1) {
+			throw new RuntimeException(new ConstantParserException("Input is malformed in terms of parentheses."));
+		}
+		return stack.peek();
+	}
+}

--- a/src/arden/constants/MultiVisitor.java
+++ b/src/arden/constants/MultiVisitor.java
@@ -1,0 +1,44 @@
+package arden.constants;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import arden.constants.analysis.DepthFirstAdapter;
+import arden.constants.node.AArdenConstant;
+import arden.constants.node.AAtomExpr;
+import arden.constants.node.AListExpr;
+import arden.constants.node.AListatomExpr;
+import arden.runtime.ArdenValue;
+
+class MultiVisitor extends DepthFirstAdapter {
+	List<ArdenValue> output = new ArrayList<>();
+
+	@Override
+	public void caseAArdenConstant(AArdenConstant node) {
+		node.getExpr().apply(this);
+	}
+
+	@Override
+	public void caseAAtomExpr(AAtomExpr node) {
+		// single constant or a list of constants in parentheses
+		output.add(ConstantParser.parseValue(node.getAtom()));
+	}
+
+	@Override
+	public void caseAListatomExpr(AListatomExpr node) {
+		// single comma and constant
+		output.add(ConstantParser.parseValue(node.getAtom()));
+	}
+
+	@Override
+	public void caseAListExpr(AListExpr node) {
+		// multiple constants, separated by commas
+		node.getExpr().apply(this);
+		output.add(ConstantParser.parseValue(node.getAtom()));
+	}
+
+	public ArdenValue[] getResult() {
+		return output.toArray(new ArdenValue[output.size()]);
+	}
+	
+}

--- a/src/arden/runtime/StdIOExecutionContext.java
+++ b/src/arden/runtime/StdIOExecutionContext.java
@@ -4,7 +4,7 @@ import java.util.Scanner;
 
 import arden.CommandLineOptions;
 import arden.constants.ConstantParser;
-import arden.constants.ConstantParser.ConstantParserException;
+import arden.constants.ConstantParserException;
 
 /** Reads and prints queries from/to StdIO. */
 public class StdIOExecutionContext extends BaseExecutionContext {

--- a/src/arden/runtime/StdIOExecutionContext.java
+++ b/src/arden/runtime/StdIOExecutionContext.java
@@ -24,7 +24,7 @@ public class StdIOExecutionContext extends BaseExecutionContext {
 		}
 		ArdenValue[] val = null;
 		try {
-			val = new ArdenValue[] { ConstantParser.parse(line) };
+			val = ConstantParser.parseMultiple(line);
 		} catch (ConstantParserException e) {
 			System.out.println("Error parsing at char: " + e.getPos());
 			System.out.println("Message: " + e.getMessage());

--- a/src/arden/runtime/StdIOExecutionContext.java
+++ b/src/arden/runtime/StdIOExecutionContext.java
@@ -8,7 +8,8 @@ import arden.constants.ConstantParser.ConstantParserException;
 
 /** Reads and prints queries from/to StdIO. */
 public class StdIOExecutionContext extends BaseExecutionContext {
-	Scanner sc = new Scanner(System.in);
+	private Scanner sc = new Scanner(System.in);
+	private static final String PROMPT_SIGN = "> ";
 
 	public StdIOExecutionContext(CommandLineOptions options) {
 		super(options);
@@ -16,19 +17,32 @@ public class StdIOExecutionContext extends BaseExecutionContext {
 
 	public DatabaseQuery createQuery(String mapping) {
 		System.out.println("Query mapping: \"" + mapping + "\". Enter result as "
-				+ "constant Arden Syntax expression (Strings in quotes)");
-		System.out.print(" >");
-		String line = null;
-		if (sc.hasNext()) {
-			line = sc.nextLine();
-		}
+				+ "Arden Syntax constant (Strings in quotes)");
+		System.out.print(PROMPT_SIGN);
+		
 		ArdenValue[] val = null;
-		try {
-			val = ConstantParser.parseMultiple(line);
-		} catch (ConstantParserException e) {
-			System.out.println("Error parsing at char: " + e.getPos());
-			System.out.println("Message: " + e.getMessage());
+		while (val == null) {
+			if (sc.hasNextLine()) {
+				String line = sc.nextLine();
+				if (line.isEmpty()) {
+					System.out.print(PROMPT_SIGN);
+					continue; // retry
+				}
+				
+				try {
+					val = ConstantParser.parseMultiple(line);
+				} catch (ConstantParserException e) {
+					System.out.println("Syntax error: ");
+					System.out.println(e.getMessage());
+					System.out.println("Please enter again:");
+					System.out.print(PROMPT_SIGN);
+					continue; // retry
+				}
+			} else {
+				val = new ArdenValue[] { ArdenNull.create(System.currentTimeMillis()) };
+			}
 		}
+		
 		return new MemoryQuery(val);
 	}
 

--- a/src/ardenConstants.scc
+++ b/src/ardenConstants.scc
@@ -1,35 +1,17 @@
-
 Package arden.constants;
 
 Helpers
-    ascii = [0..0x007f];
-
     space = ' ';
     tab = 0x0009;
     lf = 0x000a;
     cr = 0x000d;
     wschar = space | tab | lf | cr;
     
-    input = [ascii - [cr + lf]]; 
-    
-    digit = ['0'..'9'];
-    sign = ('+' | '-');
-    exp = ('e' | 'E') sign? digit+;
-    
+    ascii = [0..0x007f];
+    input = [ascii - [cr + lf]];
     string_char = [input - '"'];
     
-    fractional_seconds =
-          /* empty */
-        | '.' digit+;
-        
-    time_zone =
-          /* empty */
-        | 'Z'
-        | 'z'
-        | '+' digit digit ':' digit digit
-        | '-' digit digit ':' digit digit; 
-	
-	a = ['a' + 'A'];
+    a = ['a' + 'A'];
     b = ['b' + 'B'];
     c = ['c' + 'C'];
     d = ['d' + 'D'];
@@ -56,27 +38,36 @@ Helpers
     y = ['y' + 'Y'];
     z = ['z' + 'Z'];
     
+    digit = ['0'..'9'];
+    sign = ['+' + '-'];
+    exp = e sign? digit+;
+    
+    iso_date = digit digit digit digit '-' digit digit '-' digit digit;
+    iso_time = digit digit ':' digit digit ':' digit digit;
+    fractional_seconds = '.' digit+;
+    time_zone = z | sign digit digit ':' digit digit;
+
 Tokens
     comma = ',';
     l_par = '(';
     r_par = ')';
     null = n u l l;
-	true = t r u e;
-	false = f a l s e;
+    true = t r u e;
+    false = f a l s e;
     
-    arden_number =  
-          sign? (digit+ ('.' digit*)? exp?) 
+    arden_number =
+          sign? (digit+ ('.' digit*)? exp?)
         | sign? ('.' digit+ exp?);
-
-    arden_string = 
+    
+    arden_string =
         '"' ( 
             string_char* ('"' '"' string_char*)* 
         ) '"';
-        
-    arden_date = digit digit digit digit '-' digit digit '-' digit digit;
     
-    arden_date_time = digit digit digit digit '-' digit digit '-' digit digit t digit digit ':' digit digit ':' digit digit fractional_seconds time_zone;        
-        
+    arden_date = iso_date;
+    
+    arden_date_time = iso_date t iso_time fractional_seconds? time_zone?;
+    
     ws = wschar+;
     
     year  = y e a r s?;
@@ -86,7 +77,6 @@ Tokens
     hour = h o u r s?;
     minute = m i n u t e s?;
     second = s e c o n d s?;
-    
 
 Ignored Tokens
     ws;
@@ -94,23 +84,10 @@ Ignored Tokens
 Productions
     arden_constant = expr;
     
-    duration_op =
-          {year} year
-        | {month} month
-        | {week} week
-        | {day} day
-        | {hour} hour
-        | {min} minute
-        | {sec} second;
-    
-    arden_boolean = 
-		  {true} true 
-		| {false} false;
-	
     expr = 
-          {atom} atom
-        | {listatom} comma atom
-        | {list} expr comma atom;
+      {atom} atom
+    | {listatom} comma atom
+    | {list} expr comma atom;
     
     atom = 
           {number} arden_number 
@@ -122,3 +99,16 @@ Productions
         | {null} null
         | {expr} l_par expr r_par
         | {par} l_par r_par;
+    
+    duration_op =
+          {year} year
+        | {month} month
+        | {week} week
+        | {day} day
+        | {hour} hour
+        | {min} minute
+        | {sec} second;
+    
+    arden_boolean =
+          {true} true
+        | {false} false;

--- a/src/ardenConstants.scc
+++ b/src/ardenConstants.scc
@@ -16,6 +16,17 @@ Helpers
     exp = ('e' | 'E') ('+' | '-')? digit+;
     
     string_char = [input - '"'];
+    
+    fractional_seconds =
+          /* empty */
+        | '.' digit+;
+        
+    time_zone =
+          /* empty */
+        | 'Z'
+        | 'z'
+        | '+' digit digit ':' digit digit
+        | '-' digit digit ':' digit digit; 
 	
 	n = 'n' | 'N';
 	u = 'u' | 'U';
@@ -41,10 +52,14 @@ Tokens
         | ('.' digit+ exp?);
 
     arden_string = 
-        '"' (
+        '"' ( 
             string_char* ('"' '"' string_char*)* 
         ) '"';
+        
+    arden_date = digit digit digit digit '-' digit digit '-' digit digit;
     
+    arden_date_time = digit digit digit digit '-' digit digit '-' digit digit t digit digit ':' digit digit ':' digit digit fractional_seconds time_zone;        
+        
     ws = wschar+;
     
 
@@ -68,6 +83,8 @@ Productions
           {number} arden_number 
         | {string} arden_string 
         | {boolean} arden_boolean
+        | {date} arden_date
+        | {dtime} arden_date_time
         | {null} null
         | {expr} l_par expr r_par
         | {par} l_par r_par;

--- a/src/ardenConstants.scc
+++ b/src/ardenConstants.scc
@@ -29,18 +29,34 @@ Helpers
         | '+' digit digit ':' digit digit
         | '-' digit digit ':' digit digit; 
 	
-	n = 'n' | 'N';
-	u = 'u' | 'U';
-	l = 'l' | 'L';
-	t = 't' | 'T';
-	r = 'r' | 'R';
-	e = 'e' | 'E';
-	f = 'f' | 'F';
-	a = 'a' | 'A';
-	s = 's' | 'S';	
+	a = ['a' + 'A'];
+    b = ['b' + 'B'];
+    c = ['c' + 'C'];
+    d = ['d' + 'D'];
+    e = ['e' + 'E'];
+    f = ['f' + 'F'];
+    g = ['g' + 'G'];
+    h = ['h' + 'H'];
+    i = ['i' + 'I'];
+    j = ['j' + 'J'];
+    k = ['k' + 'K'];
+    l = ['l' + 'L'];
+    m = ['m' + 'M'];
+    n = ['n' + 'N'];
+    o = ['o' + 'O'];
+    p = ['p' + 'P'];
+    q = ['q' + 'Q'];
+    r = ['r' + 'R'];
+    s = ['s' + 'S'];
+    t = ['t' + 'T'];
+    u = ['u' + 'U'];
+    v = ['v' + 'V'];
+    w = ['w' + 'W'];
+    x = ['x' + 'X'];
+    y = ['y' + 'Y'];
+    z = ['z' + 'Z'];
     
 Tokens
-
     comma = ',';
     l_par = '(';
     r_par = ')';
@@ -63,13 +79,29 @@ Tokens
         
     ws = wschar+;
     
+    year  = y e a r s?;
+    month = m o n t h s?;
+    week = w e e k s?;
+    day = d a y s?;
+    hour = h o u r s?;
+    minute = m i n u t e s?;
+    second = s e c o n d s?;
+    
 
 Ignored Tokens
     ws;
 
 Productions
-
     arden_constant = expr;
+    
+    duration_op =
+          {year} year
+        | {month} month
+        | {week} week
+        | {day} day
+        | {hour} hour
+        | {min} minute
+        | {sec} second;
     
     arden_boolean = 
 		  {true} true 
@@ -86,6 +118,7 @@ Productions
         | {boolean} arden_boolean
         | {date} arden_date
         | {dtime} arden_date_time
+        | {duration} arden_number duration_op
         | {null} null
         | {expr} l_par expr r_par
         | {par} l_par r_par;

--- a/src/ardenConstants.scc
+++ b/src/ardenConstants.scc
@@ -13,7 +13,8 @@ Helpers
     input = [ascii - [cr + lf]]; 
     
     digit = ['0'..'9'];
-    exp = ('e' | 'E') ('+' | '-')? digit+;
+    sign = ('+' | '-');
+    exp = ('e' | 'E') sign? digit+;
     
     string_char = [input - '"'];
     
@@ -48,8 +49,8 @@ Tokens
 	false = f a l s e;
     
     arden_number =  
-          (digit+ ('.' digit*)? exp?) 
-        | ('.' digit+ exp?);
+          sign? (digit+ ('.' digit*)? exp?) 
+        | sign? ('.' digit+ exp?);
 
     arden_string = 
         '"' ( 

--- a/test/arden/tests/implementation/ConstantParserTest.java
+++ b/test/arden/tests/implementation/ConstantParserTest.java
@@ -1,5 +1,6 @@
 package arden.tests.implementation;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -17,38 +18,37 @@ import arden.runtime.ArdenTime;
 import arden.runtime.ArdenValue;
 
 public class ConstantParserTest extends ImplementationTest {
-	
+
 	@Test
 	public void testEmptyList() throws Exception {
 		assertEquals(ArdenList.EMPTY, ConstantParser.parse("()"));
 	}
-	
+
 	@Test
 	public void testNumber() throws Exception {
 		assertEquals(ArdenNumber.create(5.0, ArdenValue.NOPRIMARYTIME), ConstantParser.parse("5.0"));
 		assertFalse(ConstantParser.parse("5.0").equals(ArdenNumber.create(4.0, ArdenValue.NOPRIMARYTIME)));
 	}
-	
+
 	@Test
 	public void testSingleElementList() throws Exception {
-		ArdenList list = new ArdenList(new ArdenValue[]{
-				ArdenNumber.create(1.0, ArdenValue.NOPRIMARYTIME)});
+		ArdenList list = new ArdenList(new ArdenValue[] { ArdenNumber.create(1.0, ArdenValue.NOPRIMARYTIME) });
 		assertEquals(list, ConstantParser.parse("(,1)"));
 	}
-	
+
 	@Test
 	public void testList() throws Exception {
-		ArdenList list = new ArdenList(new ArdenValue[]{
+		ArdenList list = new ArdenList(new ArdenValue[] {
 				ArdenNumber.create(1.0, ArdenValue.NOPRIMARYTIME),
 				ArdenNumber.create(2.0, ArdenValue.NOPRIMARYTIME),
 				ArdenNumber.create(3.0, ArdenValue.NOPRIMARYTIME)
 		});
 		assertEquals(list, ConstantParser.parse("(1,2,3)"));
 	}
-	
+
 	@Test
 	public void testListConcat() throws Exception {
-		ArdenList list = new ArdenList(new ArdenValue[]{
+		ArdenList list = new ArdenList(new ArdenValue[] {
 				ArdenNumber.create(1.0, ArdenValue.NOPRIMARYTIME),
 				ArdenNumber.create(2.1, ArdenValue.NOPRIMARYTIME),
 				ArdenNumber.create(2.2, ArdenValue.NOPRIMARYTIME),
@@ -57,38 +57,50 @@ public class ConstantParserTest extends ImplementationTest {
 		});
 		assertEquals(list, ConstantParser.parse("(1,(2.1,2.2,2.3),3)"));
 	}
-	
+
 	@Test
 	public void testString() throws Exception {
 		assertEquals(new ArdenString("vfs\"dkj"), ConstantParser.parse("\"vfs\"\"dkj\""));
 	}
-	
+
 	@Test
 	public void testDate() throws Exception {
 		Calendar calendar = Calendar.getInstance(); // local timezone
 		calendar.set(1989, Calendar.AUGUST, 8, 0, 0, 0);
 		calendar.clear(Calendar.MILLISECOND);
-		
+
 		ArdenTime ardenTime = new ArdenTime(calendar.getTimeInMillis());
 		String isoString = ArdenTime.isoDateFormat.format(calendar.getTime());
-		
+
 		assertEquals(ardenTime, ConstantParser.parse(isoString));
 	}
-	
+
 	@Test
 	public void testDatetime() throws Exception {
 		Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("GMT+5"));
 		calendar.set(1989, Calendar.AUGUST, 8, 1, 2, 3);
 		calendar.set(Calendar.MILLISECOND, 45);
-		
+
 		ArdenTime ardenTime = new ArdenTime(calendar.getTimeInMillis());
 
 		DateFormat format = (DateFormat) ArdenTime.isoDateTimeFormatWithMillis.clone();
 		format.setTimeZone(TimeZone.getTimeZone("GMT+5"));
 		String isoString = format.format(calendar.getTimeInMillis());
 		isoString += "+05:00";
-		
+
 		assertEquals(ardenTime, ConstantParser.parse(isoString));
 	}
-	
+
+	@Test
+	public void testMuliReturn() throws Exception {
+		Calendar calendar = Calendar.getInstance(); // local timezone
+		calendar.set(1989, Calendar.AUGUST, 5, 0, 0, 0);
+		calendar.clear(Calendar.MILLISECOND);
+		ArdenTime ardenTime = new ArdenTime(calendar.getTimeInMillis());
+		String isoString = ArdenTime.isoDateFormat.format(calendar.getTime());
+
+		ArdenValue[] returns = new ArdenValue[] { new ArdenNumber(1), new ArdenString("asdf"), ardenTime };
+		assertArrayEquals(returns, ConstantParser.parseMultiple("1, \"asdf\", " + isoString));
+	}
+
 }

--- a/test/arden/tests/implementation/ConstantParserTest.java
+++ b/test/arden/tests/implementation/ConstantParserTest.java
@@ -1,16 +1,16 @@
 package arden.tests.implementation;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 
 import java.text.DateFormat;
 import java.util.Calendar;
 import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
 import arden.constants.ConstantParser;
+import arden.runtime.ArdenDuration;
 import arden.runtime.ArdenList;
 import arden.runtime.ArdenNumber;
 import arden.runtime.ArdenString;
@@ -18,11 +18,6 @@ import arden.runtime.ArdenTime;
 import arden.runtime.ArdenValue;
 
 public class ConstantParserTest extends ImplementationTest {
-
-	@Test
-	public void testEmptyList() throws Exception {
-		assertEquals(ArdenList.EMPTY, ConstantParser.parse("()"));
-	}
 
 	@Test
 	public void testNumber() throws Exception {
@@ -35,6 +30,11 @@ public class ConstantParserTest extends ImplementationTest {
 		assertEquals(ArdenNumber.create(-5.0, ArdenValue.NOPRIMARYTIME), ConstantParser.parse("-5.0"));
 		assertEquals(ArdenNumber.create(+5.0, ArdenValue.NOPRIMARYTIME), ConstantParser.parse("+5.0"));
 		assertFalse(ConstantParser.parse("-5.0").equals(ArdenNumber.create(+5.0, ArdenValue.NOPRIMARYTIME)));
+	}
+
+	@Test
+	public void testEmptyList() throws Exception {
+		assertEquals(ArdenList.EMPTY, ConstantParser.parse("()"));
 	}
 
 	@Test
@@ -96,6 +96,33 @@ public class ConstantParserTest extends ImplementationTest {
 		isoString += "+05:00";
 
 		assertEquals(ardenTime, ConstantParser.parse(isoString));
+	}
+	
+	@Test
+	public void testDuration() throws Exception {
+		// second durations
+		assertEquals(ArdenDuration.create(1, false, ArdenValue.NOPRIMARYTIME), ConstantParser.parse("1 second"));
+		
+		assertEquals(ArdenDuration.create(
+				TimeUnit.MINUTES.toSeconds(15), false, ArdenValue.NOPRIMARYTIME),
+				ConstantParser.parse("15 minutes"));
+		
+		assertEquals(ArdenDuration.create(
+				TimeUnit.HOURS.toSeconds(123), false, ArdenValue.NOPRIMARYTIME),
+				ConstantParser.parse("123 hours"));
+		
+		assertEquals(ArdenDuration.create(
+				TimeUnit.DAYS.toSeconds(7), false, ArdenValue.NOPRIMARYTIME),
+				ConstantParser.parse("7 days"));
+		
+		// month durations
+		assertEquals(ArdenDuration.create(
+				5, true, ArdenValue.NOPRIMARYTIME),
+				ConstantParser.parse("5 months"));
+		
+		assertEquals(ArdenDuration.create(
+				12, true, ArdenValue.NOPRIMARYTIME),
+				ConstantParser.parse("1 year"));
 	}
 
 	@Test

--- a/test/arden/tests/implementation/ConstantParserTest.java
+++ b/test/arden/tests/implementation/ConstantParserTest.java
@@ -29,6 +29,13 @@ public class ConstantParserTest extends ImplementationTest {
 		assertEquals(ArdenNumber.create(5.0, ArdenValue.NOPRIMARYTIME), ConstantParser.parse("5.0"));
 		assertFalse(ConstantParser.parse("5.0").equals(ArdenNumber.create(4.0, ArdenValue.NOPRIMARYTIME)));
 	}
+	
+	@Test
+	public void testSign() throws Exception {
+		assertEquals(ArdenNumber.create(-5.0, ArdenValue.NOPRIMARYTIME), ConstantParser.parse("-5.0"));
+		assertEquals(ArdenNumber.create(+5.0, ArdenValue.NOPRIMARYTIME), ConstantParser.parse("+5.0"));
+		assertFalse(ConstantParser.parse("-5.0").equals(ArdenNumber.create(+5.0, ArdenValue.NOPRIMARYTIME)));
+	}
 
 	@Test
 	public void testSingleElementList() throws Exception {

--- a/test/arden/tests/implementation/ConstantParserTest.java
+++ b/test/arden/tests/implementation/ConstantParserTest.java
@@ -3,12 +3,17 @@ package arden.tests.implementation;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+import java.text.DateFormat;
+import java.util.Calendar;
+import java.util.TimeZone;
+
 import org.junit.Test;
 
 import arden.constants.ConstantParser;
 import arden.runtime.ArdenList;
 import arden.runtime.ArdenNumber;
 import arden.runtime.ArdenString;
+import arden.runtime.ArdenTime;
 import arden.runtime.ArdenValue;
 
 public class ConstantParserTest extends ImplementationTest {
@@ -56,6 +61,34 @@ public class ConstantParserTest extends ImplementationTest {
 	@Test
 	public void testString() throws Exception {
 		assertEquals(new ArdenString("vfs\"dkj"), ConstantParser.parse("\"vfs\"\"dkj\""));
+	}
+	
+	@Test
+	public void testDate() throws Exception {
+		Calendar calendar = Calendar.getInstance(); // local timezone
+		calendar.set(1989, Calendar.AUGUST, 8, 0, 0, 0);
+		calendar.clear(Calendar.MILLISECOND);
+		
+		ArdenTime ardenTime = new ArdenTime(calendar.getTimeInMillis());
+		String isoString = ArdenTime.isoDateFormat.format(calendar.getTime());
+		
+		assertEquals(ardenTime, ConstantParser.parse(isoString));
+	}
+	
+	@Test
+	public void testDatetime() throws Exception {
+		Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("GMT+5"));
+		calendar.set(1989, Calendar.AUGUST, 8, 1, 2, 3);
+		calendar.set(Calendar.MILLISECOND, 45);
+		
+		ArdenTime ardenTime = new ArdenTime(calendar.getTimeInMillis());
+
+		DateFormat format = (DateFormat) ArdenTime.isoDateTimeFormatWithMillis.clone();
+		format.setTimeZone(TimeZone.getTimeZone("GMT+5"));
+		String isoString = format.format(calendar.getTimeInMillis());
+		isoString += "+05:00";
+		
+		assertEquals(ardenTime, ConstantParser.parse(isoString));
 	}
 	
 }


### PR DESCRIPTION
This allows the ConstantParser to parse more kinds of Arden Syntax constants and also allows it to parse multiple return values, similar to the `RETURN` statement. For example for the query `(id, name, birthdate, values) := {patient data};` on would enter `123, "Jane Doe", 1970-01-01, (2.1,2.3,2.4)`. 
Lists have to be surrounded by parenthesis and strings by double quotes.
Multiple command line arguments are separated by spaces, so it is possible to have comma separated lists with or without parenthesis, e.g. (bash) `./arden2bytecode -a 1,2,3 '(3,2)' '"asdf"' -r ...`

This also allows to retry queries (after a syntax error) in the StdIOExecutionContext.

All supported constants:
- (Negative) Numbers
- Strings
- Booleans
- Dates/Datetimes
- Durations
- `NULL`
- Lists of constants