### PR TITLE
Help message wrapping

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -40,13 +40,10 @@
             <include name="*.jar" />
         </fileset>
     </path>
-    <path id="run.classpath">
+    <path id="test.classpath">
         <path refid="build.classpath" />
         <path location="${build.dir}" />
         <path location="." />
-    </path>
-    <path id="test.classpath">
-        <path refid="run.classpath" />
     </path>
     <path id="dist.classpath">
         <path location="." />
@@ -120,7 +117,7 @@
     </target>
 
     
-    <target name="init.sableCC">
+    <target name="sableCC.init">
         <!-- create SableCC directories -->
         <mkdir dir="${src.dir}/arden/compiler/analysis" />
         <mkdir dir="${src.dir}/arden/compiler/lexer" />
@@ -152,12 +149,12 @@
     </target>
 
     
-    <target name="sableCC.compiler" depends="init.sableCC" if="sableCC.compiler.update.necessary">
+    <target name="sableCC.compiler" depends="sableCC.init" if="sableCC.compiler.update.necessary">
         <sablecc src="${src.dir}" includes="arden.scc" outputdirectory="${src.dir}"/>
     </target>
 
     
-    <target name="sableCC.constants" depends="init.sableCC" if="sableCC.constants.update.necessary">
+    <target name="sableCC.constants" depends="sableCC.init" if="sableCC.constants.update.necessary">
         <sablecc src="${src.dir}" includes="ardenConstants.scc" outputdirectory="${src.dir}"/>
     </target>
 
@@ -228,15 +225,7 @@
         </zip>
     </target>
 
-    
-    <target name="run" depends="compile" description="Run the program from the bin directory">
-        <property name="echoclasspath" refid="run.classpath" />
-        <echo message="Running ${mainclass} with classpath: ${echoclasspath}" />
-        <java classname="${mainclass}" classpathref="run.classpath" fork="true">
-        </java>
-    </target>
-
-    
+      
     <target name="test" depends="test.specification, test.implementation"
         description="Generate report of the test suites (implementation and standard compliance)">
         <junitreport todir="${test.report.dir}">

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "$(dirname "$(realpath "$0")")"; # set script location as working directory
+java -cp bin/:lib/jewelcli-0.8.9.jar arden.MainClass "$@"

--- a/src/arden/CommandLineOptions.java
+++ b/src/arden/CommandLineOptions.java
@@ -35,8 +35,8 @@ import com.lexicalscope.jewel.cli.Unparsed;
 
 @CommandLineInterface(application = "arden2bytecode")
 public interface CommandLineOptions {
-	
-	//*** Mode (run, compile, engine) ***
+
+	// *** Mode (run, compile, engine) ***
 	@Option(shortName = "r",
 			description = "Run MLM file or already compiled MLM class file.")
 	boolean getRun();
@@ -46,12 +46,12 @@ public interface CommandLineOptions {
 	boolean getCompile();
 
 	@Option(shortName = "e",
-	        description = "Run event engine that waits for events or evoke triggers and \n"
-	                + "\t  executes MLMs when they are scheduled.")
+			description = "Run event engine that waits for events or evoke triggers and "
+					+ "executes MLMs when they are scheduled.")
 	boolean getEngine();
 
 	
-	//*** Output options ***
+	// *** Output options ***
 	@Option(shortName = "v",
 			description = "Verbose mode.")
 	boolean getVerbose();
@@ -66,44 +66,50 @@ public interface CommandLineOptions {
 	boolean getHelp();
 
 	
-	//*** Arguments for Compiler/Runtime ***
-	@Option(longName = {"classpath", "cp"},
-			description = "Additional classpath. \n"
-					+ "\t  E.g. a database driver like \"mysql-connector-java-[version]-bin.jar\".")
+	// *** Arguments for Compiler/Runtime ***
+	@Option(longName = { "classpath", "cp" },
+			description = "Additional classpath. "
+					+ "E.g. a database driver like \"mysql-connector-java-[version]-bin.jar\".")
 	String getClasspath();
+
 	boolean isClasspath();
-	
+
 	@Option(shortName = "o",
-			description = "Output file name to compile .MLM file to. \n"
-					+ "\t  You can also specify a directory in order to compile multiple MLMs.")
+			description = "Output file name to compile .MLM file to. "
+					+ "You can also specify a directory in order to compile multiple MLMs.")
 	String getOutput();
+
 	boolean isOutput();
 
 	@Option(shortName = "a",
-			description = "Arguments to MLM if running an MLM.")
+			description = "Arguments to MLM if running an MLM. "
+					+ "Arguments must be Arden Syntax constants (strings in quotes). "
+					+ "Multiple arguments are separated by spaces.")
 	List<String> getArguments();
+
 	boolean isArguments();
 
-	@Option(longName = {"environment", "env"},
-			description = "Set arguments to execution environment if \n\t  running an MLM. \n"
-					+ "\t  In case of using JDBC, this may be a connection URL e.g. \n"
-					+ "\t   \"jdbc:mysql://host:port/database?options\".",
+	@Option(longName = { "environment",	"env" },
+			description = "Set arguments to execution environment if running an MLM. "
+					+ "In case of using JDBC, this may be a connection URL "
+					+ "e.g. \"jdbc:mysql://host:port/database?options\".",
 			defaultValue = "stdio")
 	String getEnvironment();
 
 	@Option(shortName = "d",
-			description = "Class name of database driver to load \n"
-					+ "\t  (e.g. \"com.mysql.jdbc.Driver\").")
+			description = "Class name of database driver to load (e.g. \"com.mysql.jdbc.Driver\").")
 	String getDbdriver();
+
 	boolean isDbdriver();
 
 	@Option(shortName = "p",
-	        description = "Port on which to listen for events. \n" +
-	            "\t  Will start a server if specified.")
+			description = "Port on which to listen for events. Will start a server if specified.")
 	int getPort();
+
 	boolean isPort();
-	
+
 	@Unparsed
 	List<String> getFiles();
+
 	boolean isFiles();
 }

--- a/src/arden/MainClass.java
+++ b/src/arden/MainClass.java
@@ -66,6 +66,11 @@ public class MainClass {
 	private final static Pattern JAVA_CLASS_NAME = Pattern
 			.compile("[A-Za-z$_][A-Za-z0-9$_]*(?:\\.[A-Za-z$_][A-Za-z0-9$_]*)*");
 
+	// wrap and indent help message
+	public static final int MAX_LINE_LENGTH = 80;
+	private static final String ARGUMENTS_INDENT = "    ";
+	private static final String DESCRIPTION_INDENT = "    ";
+
 	private CommandLineOptions options;
 
 	public static void main(String[] args) {
@@ -81,7 +86,7 @@ public class MainClass {
 		if (args.length < 1) {
 			printLogo();
 			Cli<CommandLineOptions> cli = CliFactory.createCli(CommandLineOptions.class);
-			System.err.println(cli.getHelpMessage());
+			System.out.println(formatHelpMessage(cli.getHelpMessage()));
 			printAdditionalHelp();
 			return false;
 		}
@@ -92,7 +97,7 @@ public class MainClass {
 		} catch (HelpRequestedException e) {
 			printLogo();
 			String message = e.getMessage();
-			System.err.println(message);
+			System.out.println(formatHelpMessage(message));
 			printAdditionalHelp();
 			return false;
 		} catch (ArgumentValidationException e) {
@@ -144,9 +149,9 @@ public class MainClass {
 	}
 
 	private void printAdditionalHelp() {
-		System.err.println("All further command line arguments that are non-options are regarded as input files.");
-		System.err.println("For a command-line reference, see:");
-		System.err.println("https://plri.github.io/arden2bytecode/docs/command-line-options/");
+		System.out.println("All further command line arguments that are non-options are regarded as input files.");
+		System.out.println("For a command-line reference, see:");
+		System.out.println("https://plri.github.io/arden2bytecode/docs/command-line-options/");
 	}
 
 	private static void printLogo() {
@@ -340,9 +345,9 @@ public class MainClass {
 				}
 			}
 		});
-		
+
 		BaseExecutionContext context = createExecutionContext();
-		
+
 		// start event server
 		if (options.isPort()) {
 			new EventServer(context, options.getVerbose(), options.getPort()).startServer();
@@ -457,6 +462,26 @@ public class MainClass {
 			return filename.substring(sepindex + 1);
 		}
 		return filename.substring(sepindex + 1, fnindex);
+	}
+
+	public static String formatHelpMessage(String message) {
+		String newline = System.getProperty("line.separator");
+		String indentline = newline + ARGUMENTS_INDENT + DESCRIPTION_INDENT;
+
+		StringBuilder messageBuilder = new StringBuilder(message.length() * 2);
+		for (String line : message.split(newline)) {
+			line = line.replaceAll("\t", ARGUMENTS_INDENT);
+			StringBuilder lineBuilder = new StringBuilder(line);
+			// wrap message
+			int spacePos = 0;
+			while (spacePos + MAX_LINE_LENGTH < lineBuilder.length()) {
+				spacePos = lineBuilder.lastIndexOf(" ", spacePos + MAX_LINE_LENGTH);
+				lineBuilder.replace(spacePos, spacePos + 1, indentline);
+			}
+			messageBuilder.append(lineBuilder.toString() + newline);
+		}
+
+		return messageBuilder.toString();
 	}
 
 	@SuppressWarnings("serial")

--- a/test/arden/tests/implementation/CliTest.java
+++ b/test/arden/tests/implementation/CliTest.java
@@ -1,5 +1,7 @@
 package arden.tests.implementation;
 
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -12,5 +14,35 @@ public class CliTest extends ImplementationTest {
 		Assert.assertEquals("basename", MainClass.getFilenameBase("sdvnj/\\$%&../\\//./4e5\\v.s..df.v/basename.bfgb"));
 		Assert.assertEquals("", MainClass.getFilenameBase("sdvnj/\\$%&../\\//./4e5\\v.s..df.v/..fg.bfgb\\"));
 		Assert.assertEquals(".", MainClass.getFilenameBase(".."));
+	}
+
+	@Test
+	public void testFormatHelpMessage() throws Exception {
+		String testString = String.format("Usage: arden2bytecode [options] ARGUMENTS...%n" + 
+				"	[--arguments -a value...] : Arguments to MLM if running an MLM. Arguments must be Arden Syntax constants (Strings in quotes). Multiple arguments are separated by spaces.%n" + 
+				"	[--classpath --cp value] : Additional classpath. E.g. a database driver like \"mysql-connector-java-[version]-bin.jar\".%n" + 
+				"	[--compile -c] : Compile input file.%n" + 
+				"	[--dbdriver -d value] : Class name of database driver to load (e.g. \"com.mysql.jdbc.Driver\").%n" + 
+				"	[--engine -e] : Run event engine that waits for events or evoke triggers and executes MLMs when they are scheduled.%n" + 
+				"	[--environment --env value] : Set arguments to execution environment if running an MLM. In case of using JDBC, this may be a connection URL e.g. \"jdbc:mysql://host:port/database?options\".%n" + 
+				"	[--help -h -?] : Display help.%n" + 
+				"	[--nologo -n] : Don't print logo.%n" + 
+				"	[--output -o value] : Output file name to compile .MLM file to. You can also specify a directory in order to compile multiple MLMs.%n" + 
+				"	[--port -p value] : Port on which to listen for events. Will start a server if specified.%n" + 
+				"	[--run -r] : Run MLM file or already compiled MLM class file.%n" + 
+				"	[--verbose -v] : Verbose mode.");
+		
+		String newline = System.getProperty("line.separator");
+		String[] foldedLines = MainClass.formatHelpMessage(testString).split(newline);
+		assertTrue(foldedLines.length >= 13);
+		
+		int max = 0;
+		for (String line : foldedLines) {
+			max = line.length() > max? line.length() : max;
+			assertTrue(line.length()<=80);
+		}
+		
+		// not too short
+		assertTrue(max >= MainClass.MAX_LINE_LENGTH * 0.8);
 	}
 }


### PR DESCRIPTION
This adds automatic wrapping and indentation for the command line `--help` message, so this has not to be done by hand every time a description is updated or a new parameter is added. 
Wrapping is currently set to 80 characters, as 80*24 seem to be the usual terminal dimensions.

I also added a bash run script for visual inspection in a terminal, instead of the eclipse console or creating a jar every time.