### PR TITLE
Command line changes

### DIFF
--- a/src/arden/CommandLineOptions.java
+++ b/src/arden/CommandLineOptions.java
@@ -37,22 +37,26 @@ import com.lexicalscope.jewel.cli.Unparsed;
 @CommandLineInterface(application = "arden2bytecode")
 public interface CommandLineOptions {
 
-	// *** Mode (run, compile, engine) ***
+	// *** Mode (run, compile, engine, help) ***
+	@Option(shortName = { "h", "?" },
+			description = "Display help.",
+			helpRequest = true)
+	boolean getHelp();
+	
 	@Option(shortName = "r",
-			description = "Run MLM file or already compiled MLM class file.")
+			description = "Run MLM files or already compiled MLM class files.")
 	boolean getRun();
 
 	@Option(shortName = "c",
-			description = "Compile input file.")
+			description = "Compile input files.")
 	boolean getCompile();
 
 	@Option(shortName = "e",
-			description = "Run event engine that waits for events or evoke triggers and "
-					+ "executes MLMs when they are scheduled.")
+			description = "Run event engine that executes MLMs when they are evoked.")
 	boolean getEngine();
-
+		
 	
-	// *** Output options ***
+	// *** Control options ***
 	@Option(shortName = "v",
 			description = "Verbose mode.")
 	boolean getVerbose();
@@ -60,50 +64,43 @@ public interface CommandLineOptions {
 	@Option(shortName = "n",
 			description = "Don't print logo.")
 	boolean getNologo();
-
-	@Option(shortName = { "h", "?" },
-			description = "Display help.",
-			helpRequest = true)
-	boolean getHelp();
-
 	
-	// *** Arguments for Compiler/Runtime ***
-	@Option(longName = { "classpath", "cp" },
-			description = "Additional classpath. "
-					+ "E.g. a database driver like \"mysql-connector-java-[version]-bin.jar\".")
-	String getClasspath();
-	boolean isClasspath();
-
 	@Option(shortName = "d",
-			description = "Output directory into which compiled MLM class files are placed.")
+			description = "Output directory for compiled MLM class files.")
 	File getDirectory();
 	boolean isDirectory();
-
+	
 	@Option(shortName = "a",
-			description = "Arguments to MLM if running an MLM. "
-					+ "Arguments must be Arden Syntax constants (strings in quotes). "
-					+ "Multiple arguments are separated by spaces.")
+			description = "Arguments for MLM as Arden Syntax constants.")
 	List<String> getArguments();
 	boolean isArguments();
-
-	@Option(longName = { "environment",	"env" },
-			description = "Set arguments to execution environment if running an MLM. "
-					+ "In case of using JDBC, this may be a connection URL "
-					+ "e.g. \"jdbc:mysql://host:port/database?options\".",
-			defaultValue = "stdio")
-	String getEnvironment();
-
-	@Option(longName = { "db", "dbdriver" },
-			description = "Class name of database driver to load (e.g. \"com.mysql.jdbc.Driver\").")
-	String getDbdriver();
-	boolean isDbdriver();
-
+	
 	@Option(shortName = "p",
-			description = "Port on which to listen for events. Will start a server if specified.")
+			description = "Port on which to listen for events.")
 	int getPort();
 	boolean isPort();
 
+	
+	// *** Execution Environment ***
+	@Option(longName = { "classpath", "cp" },
+			description = "Classpath with callable MLMs or a JDBC driver.")
+	String getClasspath();
+	boolean isClasspath();
+
+	@Option(longName = { "dbdriver", "db" },
+			description = "Class name of a JDBC driver to load.")
+	String getDbdriver();
+	boolean isDbdriver();
+
+	@Option(longName = { "environment", "env" },
+			description = "Argument for the execution environment.",
+			defaultValue = "stdio")
+	String getEnvironment();
+
+
+	// *** Files ***
 	@Unparsed
 	List<String> getFiles();
 	boolean isFiles();
+	
 }

--- a/src/arden/CommandLineOptions.java
+++ b/src/arden/CommandLineOptions.java
@@ -27,6 +27,7 @@
 
 package arden;
 
+import java.io.File;
 import java.util.List;
 
 import com.lexicalscope.jewel.cli.CommandLineInterface;
@@ -71,22 +72,18 @@ public interface CommandLineOptions {
 			description = "Additional classpath. "
 					+ "E.g. a database driver like \"mysql-connector-java-[version]-bin.jar\".")
 	String getClasspath();
-
 	boolean isClasspath();
 
-	@Option(shortName = "o",
-			description = "Output file name to compile .MLM file to. "
-					+ "You can also specify a directory in order to compile multiple MLMs.")
-	String getOutput();
-
-	boolean isOutput();
+	@Option(shortName = "d",
+			description = "Output directory into which compiled MLM class files are placed.")
+	File getDirectory();
+	boolean isDirectory();
 
 	@Option(shortName = "a",
 			description = "Arguments to MLM if running an MLM. "
 					+ "Arguments must be Arden Syntax constants (strings in quotes). "
 					+ "Multiple arguments are separated by spaces.")
 	List<String> getArguments();
-
 	boolean isArguments();
 
 	@Option(longName = { "environment",	"env" },
@@ -96,20 +93,17 @@ public interface CommandLineOptions {
 			defaultValue = "stdio")
 	String getEnvironment();
 
-	@Option(shortName = "d",
+	@Option(longName = { "db", "dbdriver" },
 			description = "Class name of database driver to load (e.g. \"com.mysql.jdbc.Driver\").")
 	String getDbdriver();
-
 	boolean isDbdriver();
 
 	@Option(shortName = "p",
 			description = "Port on which to listen for events. Will start a server if specified.")
 	int getPort();
-
 	boolean isPort();
 
 	@Unparsed
 	List<String> getFiles();
-
 	boolean isFiles();
 }

--- a/src/arden/MainClass.java
+++ b/src/arden/MainClass.java
@@ -255,7 +255,7 @@ public class MainClass {
 		ExecutionContext context = createExecutionContext();
 		for (MedicalLogicModule mlm : mlms) {
 			if (options.getVerbose()) {
-				System.out.println("Running MLM...");
+				System.out.println("Running MLM " + mlm.getName() + "...");
 				System.out.println();
 			}
 
@@ -272,9 +272,25 @@ public class MainClass {
 
 	public boolean compileFiles(List<File> files) {
 		boolean success = true;
-		boolean outputFileUsed = false;
+
+		// get output directory
+		File outputDir = null;
+		if (options.isDirectory()) {
+			outputDir = options.getDirectory();
+			if (!outputDir.exists()) {
+				if (options.getVerbose()) {
+					System.out.println("Creating directory: " + outputDir.getPath());
+				}
+				outputDir.mkdirs();
+			}
+		}
+
 		for (File file : files) {
+			// compile
 			CompiledMlm mlm;
+			if (options.getVerbose()) {
+				System.out.println("Compiling " + file.getPath());
+			}
 			try {
 				mlm = compileMlm(file);
 			} catch (MainException e) {
@@ -283,30 +299,25 @@ public class MainClass {
 				// skip MLM
 				continue;
 			}
+
+			// get output file name
+			String outName = mlm.getName() + COMPILED_MLM_FILE_EXTENSION;
 			File outputFile;
-			if (options.isOutput() && !outputFileUsed) {
-				// output file name given
-				outputFile = new File(options.getOutput());
-				outputFileUsed = true;
-			} else {
-				// output file name unknown or already used
-				// assume MLM name + '.class' extension
-				String assumedName = mlm.getName() + COMPILED_MLM_FILE_EXTENSION;
-				File assumed = new File(file.getParentFile(), assumedName);
-				if (!outputFileUsed) {
-					System.err.println(
-							"Warning: File " + file.getPath() + " compiled, but no output filename given. Assuming "
-									+ assumed.getPath() + " as output file.");
-				} else {
-					System.err.println("Warning: File " + file.getPath()
-							+ " compiled, but can't write to same output file again. Assuming " + assumed.getPath()
-							+ " as output file.");
+			if (outputDir != null) {
+				outputFile = new File(outputDir, outName);
+				if (options.getVerbose()) {
+					System.out.println("Saved to " + outputFile.getPath());
 				}
-				outputFile = assumed;
+			} else {
+				outputFile = new File(file.getParentFile(), outName);
+				System.err.println(
+						"Warning: File " + file.getPath() + " compiled, but no output directory given. Assuming "
+								+ outputFile.getPath() + " as output file.");
 			}
 
 			// write compiled MLM to file.
 			try {
+
 				BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(outputFile));
 				mlm.saveClassFile(bos);
 				bos.close();

--- a/src/arden/MainClass.java
+++ b/src/arden/MainClass.java
@@ -149,8 +149,9 @@ public class MainClass {
 	}
 
 	private void printAdditionalHelp() {
-		System.out.println("All further command line arguments that are non-options are regarded as input files.");
-		System.out.println("For a command-line reference, see:");
+		System.out.println("All further arguments that are non-options are regarded as input files.");
+		System.out.println();
+		System.out.println("For a detailed command-line reference, see:");
 		System.out.println("https://plri.github.io/arden2bytecode/docs/command-line-options/");
 	}
 


### PR DESCRIPTION
This	 replaces the outfile **-o** option with an outdir **-d** option, similar to javac.
Choosing an output directory for compiled MLMs will likely happen more often, than naming a single output file. 
The shorter database driver option is now **--db**.

I also shortened the help message a bit, as the examples would not be helpful without looking at the command line reference page on the homepage/wiki.
The --help option should output brief documentation for how to invoke the program. Specifics should be in the documentation (e.g. the "Arguments" or "Using databases" wiki page).