### PR TITLE
Fix CyclicTrigger only supporting fixed time triggers

### DIFF
--- a/src/arden/runtime/ExpressionHelpers.java
+++ b/src/arden/runtime/ExpressionHelpers.java
@@ -807,12 +807,7 @@ public final class ExpressionHelpers {
 	
 	public static Trigger createCycleTrigger(ArdenValue interval, ArdenValue length, Trigger start, ExecutionContext context) {
 		if (interval instanceof ArdenDuration && length instanceof ArdenDuration) {
-			ArdenTime starting = start.getNextRunTime(context);
-			if (starting != null) {
-				return new CyclicTrigger((ArdenDuration) interval, (ArdenDuration) length, starting);
-			} else {
-				return new NeverTrigger();
-			}
+			return new CyclicTrigger((ArdenDuration) interval, (ArdenDuration) length, start);
 		}
 		throw new RuntimeException("cannot create cycle trigger with these types: " + 
 						getClassName(interval) + ", " +

--- a/src/arden/runtime/evoke/CyclicTrigger.java
+++ b/src/arden/runtime/evoke/CyclicTrigger.java
@@ -1,5 +1,9 @@
 package arden.runtime.evoke;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
 import arden.runtime.ArdenDuration;
 import arden.runtime.ArdenEvent;
 import arden.runtime.ArdenTime;
@@ -8,46 +12,70 @@ import arden.runtime.ExecutionContext;
 public class CyclicTrigger implements Trigger {
 
 	private ArdenDuration interval;
-	private ArdenTime starting; // FIXME Should be a a Trigger
-	private ArdenTime next;
-	private boolean triggered = false;
-	private ArdenTime limit;
+	private ArdenDuration length;
+	private Trigger starting;
+	private List<ScheduledCycle> scheduledCycles = new ArrayList<>();
+	private long currentDelay = 0;
 
-	public CyclicTrigger(ArdenDuration interval, ArdenDuration length, ArdenTime starting) {
+	public CyclicTrigger(ArdenDuration interval, ArdenDuration length, Trigger starting) {
 		this.interval = interval;
+		this.length = length;
 		this.starting = starting;
-		this.next = this.starting;
-		this.limit = new ArdenTime(starting.add(length));
 	}
 
 	@Override
 	public ArdenTime getNextRunTime(ExecutionContext context) {
 		ArdenTime current = context.getCurrentTime();
 
-		// Check if already finished, but return starting time once, even if
-		// finished
-		if (next != starting && next.compareTo(limit) > 0) {
-			// Already finished
-			return null;
+		// Check if the starting trigger has happened
+		ArdenTime startTime = starting.getNextRunTime(context);
+		if (startTime != null) {
+			ArdenTime end = new ArdenTime(startTime.add(length));
+			ScheduledCycle cycle = new ScheduledCycle(startTime, end);
+			scheduledCycles.add(cycle);
 		}
 
-		// Calculate next cycle
-		while (current.compareTo(next) >= 0) {
-			next = new ArdenTime(next.add(interval));
-			triggered = false;
-			if (next.compareTo(limit) > 0) {
-				// Already finished
-				return null;
+		ScheduledCycle closestCycle = null;
+		Iterator<ScheduledCycle> iterator = scheduledCycles.iterator();
+		while (iterator.hasNext()) {
+			ScheduledCycle cycle = iterator.next();
+
+			// Calculate next run time
+			boolean sameTimeButNotStartTime = current.compareTo(cycle.next) == 0 && current.compareTo(cycle.start) != 0;
+			while (cycle.next.compareTo(cycle.end) <= 0 && ( // cycle has not ended
+						current.compareTo(cycle.next) > 0 // cycles next value lies in the past 
+						|| sameTimeButNotStartTime)) { // or value is same, but not the start (start is inclusive)
+				cycle.next = new ArdenTime(cycle.next.add(interval));
+				cycle.nextReturned = false;
+			}
+
+			if (cycle.next.compareTo(cycle.end) > 0) {
+				// Cycle is already finished.
+				iterator.remove();
+				continue;
+			}
+
+			if (cycle.nextReturned) {
+				// This run time was already returned
+				continue;
+			}
+
+			// Calculate cycle, which runtime is closest to the current time
+			if (closestCycle == null) {
+				closestCycle = cycle;
+			} else if (cycle.next.compareTo(closestCycle.next) < 0) {
+				closestCycle = cycle;
 			}
 		}
 
-		if (triggered) {
-			// this cycle was already returned
+		if (closestCycle == null) {
 			return null;
 		}
 
-		triggered = true;
-		return next;
+		closestCycle.nextReturned = true;
+		currentDelay = closestCycle.next.value - closestCycle.start.value;
+		return closestCycle.next;
+
 	}
 
 	@Override
@@ -57,16 +85,37 @@ public class CyclicTrigger implements Trigger {
 
 	@Override
 	public void scheduleEvent(ArdenEvent event) {
+		starting.scheduleEvent(event);
+		if (starting.runOnEvent(event)) {
+			ArdenEvent startEvent = starting.getTriggeringEvent();
 
+			ArdenTime startTime = new ArdenTime(startEvent.eventTime);
+			ArdenTime end = new ArdenTime(startTime.add(length));
+			ScheduledCycle cycle = new ScheduledCycle(startTime, end);
+			scheduledCycles.add(cycle);
+		}
 	}
 
 	public ArdenEvent getTriggeringEvent() {
-		return null;
+		return starting.getTriggeringEvent();
 	}
 
 	@Override
 	public long getDelay() {
-		return 0;
+		return currentDelay + starting.getDelay();
+	}
+
+	private class ScheduledCycle {
+		ArdenTime start;
+		ArdenTime next;
+		ArdenTime end;
+		boolean nextReturned = false;
+
+		public ScheduledCycle(ArdenTime start, ArdenTime end) {
+			this.start = start;
+			this.next = this.start;
+			this.end = end;
+		}
 	}
 
 }


### PR DESCRIPTION
It was only possible to use triggers like this:
- `EVERY 1 SECONDS FOR 2 WEEKS STARTING 2016-07-16T16:21:00`

Now the following is possible:
- `EVERY 5 SECONDS FOR 1 MINUTE STARTING TIME OF an_event`
- `EVERY 5 SECONDS FOR 1 MINUTE STARTING 10 SECONDS AFTER THE TIME OF an_event`