### PR TITLE
Update specification tests to Arden Syntax version 2.10

### DIFF
--- a/test/arden/tests/specification/DataTypesTest.java
+++ b/test/arden/tests/specification/DataTypesTest.java
@@ -2,12 +2,14 @@ package arden.tests.specification;
 
 import org.junit.Test;
 
+import arden.tests.specification.testcompiler.ArdenVersion;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class DataTypesTest extends SpecificationTest {
-	
+
 	private static final String DELAY = "FOR i IN 1 SEQTO 100000 DO x := 0; ENDDO;";
-	
+
 	@Test
 	public void testNull() throws Exception {
 		assertEvaluatesTo("NULL || 1/0 || TRUE +1", "\"nullnullnull\"");
@@ -20,43 +22,78 @@ public class DataTypesTest extends SpecificationTest {
 	}
 
 	@Test
-	public void testTime() throws Exception {
-		// time before 1800-01-01
-		//assertInvalidStatement("x := 1500-01-01T00:00:00;");
-		
+	@Compatibility(min = ArdenVersion.V2) // for loop
+	public void testNow() throws Exception {
 		String constantNow = createCodeBuilder()
 				.addData("n := NOW;")
-				.addAction(DELAY)
+				.clearSlotContent("logic:")
+				.addLogic(DELAY)
+				.addLogic("CONCLUDE TRUE;")
 				.addAction("RETURN n = NOW;")
 				.toString();
 		assertReturns(constantNow, "TRUE");
-		
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2)
+	public void testTriggerTime() throws Exception {
+		// event delay
+		String eventMapping = getMappings().createEventMapping();
+		String eventDelay = createCodeBuilder()
+				.addData("test_event := EVENT {" + eventMapping + "};")
+				.addEvoke(".5 SECONDS AFTER TIME OF test_event")
+				.addAction("WRITE EVENTTIME = TRIGGERTIME + .5 SECONDS;")
+				.addAction("WRITE TRIGGERTIME <= NOW;")
+				.toString();
+		assertWritesAfterEvent(eventDelay, eventMapping, "TRUE", "TRUE");
+
+		// event delay + call delay
+		String startEvent = getMappings().createEventMapping();
+		String callEvent = getMappings().createEventMapping();
+		String othermlm = createCodeBuilder()
+				.setName("other_mlm")
+				.addEvoke(".5 SECONDS AFTER TIME OF call_event") // 2. delay
+				.addAction("WRITE EVENTTIME = TRIGGERTIME + 1 SECOND;")
+				.toString();
+		String combinedDelay = createCodeBuilder()
+				.addMlm(othermlm)
+				.addData("start_event := EVENT {" + startEvent + "};")
+				.addData("call_event := EVENT {" + callEvent + "};")
+				.addEvoke("start_event")
+				.addAction("CALL call_event DELAY 0.5 SECONDS;") // 1. delay
+				.toString();
+		assertWritesAfterEvent(combinedDelay, startEvent, "TRUE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_1)
+	public void testCurrentTime() throws Exception {
 		String currentTime = createCodeBuilder()
 				.addData("c := CURRENTTIME;")
-				.addAction(DELAY)
+				.clearSlotContent("logic:")
+				.addLogic(DELAY)
+				.addLogic("CONCLUDE TRUE;")
 				.addAction("RETURN c < CURRENTTIME;")
 				.toString();
 		assertReturns(currentTime, "TRUE");
 
-		// EVENTTIME <= TRIGGERTIME <= NOW <= CURRENTTIME
 		assertEvaluatesTo("NOW <= CURRENTTIME", "TRUE");
-		assertEvaluatesTo("TRIGGERTIME <= NOW", "TRUE");
-		assertEvaluatesTo("EVENTTIME <= TRIGGERTIME", "TRUE");
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testDuration() throws Exception {
 		// time - time
 		assertEvaluatesTo("1990-03-01T00:00:00 - 1990-02-01T00:00:00", "2419200 seconds");
-		
+
 		// time + seconds
-		assertEvaluatesTo("1990-02-01T00:00:00 + 2419201 seconds" , "1990-03-01T00:00:01");
-		
+		assertEvaluatesTo("1990-02-01T00:00:00 + 2419201 seconds", "1990-03-01T00:00:01");
+
 		// time + months
-		assertEvaluatesTo("1991-01-31T00:00:00 + 1 month" , "1991-02-28T00:00:00");
-		assertEvaluatesTo("1991-01-31T00:00:00 + 1.1 months" , "1991-03-03T01:02:54.6");
-		assertEvaluatesTo("1991-04-30T00:00:00 - 0.1 months" , "1991-04-26T22:57:05.4");
-		
+		assertEvaluatesTo("1991-01-31T00:00:00 + 1 month", "1991-02-28T00:00:00");
+		assertEvaluatesTo("1991-01-31T00:00:00 + 1.1 months", "1991-03-03T01:02:54.6");
+		assertEvaluatesTo("1991-04-30T00:00:00 - 0.1 months", "1991-04-26T22:57:05.4");
+
 		// month/seconds
 		assertEvaluatesTo("1 month / 1 second", "2629746");
 	}
@@ -64,16 +101,122 @@ public class DataTypesTest extends SpecificationTest {
 	@Test
 	public void testList() throws Exception {
 		assertValidStatement("x := \"Milk\", 5, TRUE, NULL, 1 second");
-		
+
 		// empty List
 		assertValidStatement("x := ();");
 		assertValidStatement("x := (         );");
-		
+
 		// single element list
 		assertValidStatement("x := ,5;");
 		assertValidStatement("x := ,NULL;");
-		
+
 		// conversion of single element to list
 		assertEvaluatesTo("COUNT 5", "1");
 	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testDayOfWeek() throws Exception {
+		assertEvaluatesTo("MONDAY = 1", "TRUE");
+		assertEvaluatesTo("TUESDAY = 2", "TRUE");
+		assertEvaluatesTo("WEDNESDAY = 3", "TRUE");
+		assertEvaluatesTo("THURSDAY = 4", "TRUE");
+		assertEvaluatesTo("FRIDAY = 5", "TRUE");
+		assertEvaluatesTo("SATURDAY = 6", "TRUE");
+		assertEvaluatesTo("SUNDAY = 7", "TRUE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testTruthValue() throws Exception {
+		assertEvaluatesTo("TRUTH VALUE 0 = FALSE", "TRUE");
+		assertEvaluatesTo("TRUTH VALUE 0.5 = FALSE", "FALSE");
+		assertEvaluatesTo("TRUTH VALUE 0.5 = TRUE", "FALSE");
+		assertEvaluatesTo("TRUTH VALUE 1 = TRUE", "TRUE");
+		assertEvaluatesTo("TRUTH VALUE TRUE", "TRUE");
+		assertEvaluatesTo("TRUTH VALUE FALSE", "FALSE");
+
+		// truth value type is a generalizations of boolean type
+		assertEvaluatesTo("TRUTH VALUE 1 IS BOOLEAN", "TRUE");
+		assertEvaluatesTo("TRUTH VALUE 0.5 IS BOOLEAN", "FALSE");
+		assertEvaluatesTo("TRUTH VALUE 0 IS BOOLEAN", "TRUE");
+
+		assertEvaluatesTo("TRUE IS TRUTH VALUE", "TRUE");
+		assertEvaluatesTo("FALSE IS TRUTH VALUE", "TRUE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testFuzzyNumber() throws Exception {
+		String trapezoid = createCodeBuilder()
+				.addData("one_to_four := FUZZY SET (1, TRUTH VALUE 0), (2, TRUTH VALUE 1), (2, TRUTH VALUE 1), (3, TRUTH VALUE 1), (4, TRUTH VALUE 0);")
+				.toString();
+		assertEvaluatesToWithData(trapezoid, "1 IS IN one_to_four", "FALSE");
+		assertEvaluatesToWithData(trapezoid, "(1.5 IS IN one_to_four) IS WITHIN TRUTH VALUE 0.49 TO TRUTH VALUE 0.51", "TRUE");
+		assertEvaluatesToWithData(trapezoid, "2 IS IN one_to_four", "TRUE");
+		assertEvaluatesToWithData(trapezoid, "3 IS IN one_to_four", "TRUE");
+		assertEvaluatesToWithData(trapezoid, "(3.5 IS IN one_to_four) IS WITHIN TRUTH VALUE 0.49 TO TRUTH VALUE 0.51", "TRUE");
+		assertEvaluatesToWithData(trapezoid, "4 IS IN one_to_four", "FALSE");
+
+		String plateau = createCodeBuilder()
+				.addData("two_to_three := FUZZY SET (2, TRUTH VALUE 0), (2, TRUTH VALUE 1), (3, TRUTH VALUE 1), (3, TRUTH VALUE 0);")
+				.toString();
+		assertEvaluatesToWithData(plateau, "1.999 IS IN two_to_three", "FALSE");
+		assertEvaluatesToWithData(plateau, "2 IS IN two_to_three", "FALSE");
+		assertEvaluatesToWithData(plateau, "2.001 IS IN two_to_three", "TRUE");
+		assertEvaluatesToWithData(plateau, "3 IS IN two_to_three", "TRUE");
+		assertEvaluatesToWithData(plateau, "3.001 IS IN two_to_three", "FALSE");
+
+		String plateauLeftMembership = createCodeBuilder()
+				.addData("two_to_three := FUZZY SET (2, TRUTH VALUE 0), (2, TRUTH VALUE 1), (2, TRUTH VALUE 1), (3, TRUTH VALUE 1), (3, TRUTH VALUE 0);")
+				.toString();
+		assertEvaluatesToWithData(plateauLeftMembership, "1.999 IS IN two_to_three", "FALSE");
+		assertEvaluatesToWithData(plateauLeftMembership, "2 IS IN two_to_three", "TRUE");
+		assertEvaluatesToWithData(plateauLeftMembership, "2.001 IS IN two_to_three", "TRUE");
+		assertEvaluatesToWithData(plateauLeftMembership, "3 IS IN two_to_three", "TRUE");
+		assertEvaluatesToWithData(plateauLeftMembership, "3.001 IS IN two_to_three", "FALSE");
+
+		String triangular = createCodeBuilder()
+				.addData("two := 2 FUZZIFIED BY 1;")
+				.toString();
+		assertEvaluatesToWithData(triangular, "1 IS IN two", "FALSE");
+		assertEvaluatesToWithData(triangular, "(1.5 IS IN two) IS WITHIN TRUTH VALUE 0.49 TO TRUTH VALUE 0.51", "TRUE");
+		assertEvaluatesToWithData(triangular, "2 IS IN two", "TRUE");
+		assertEvaluatesToWithData(triangular, "(2.5 IS IN two) IS WITHIN TRUTH VALUE 0.49 TO TRUTH VALUE 0.51", "TRUE");
+		assertEvaluatesToWithData(triangular, "3 IS IN two", "FALSE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testFuzzyTime() throws Exception {
+		String trapezoid = createCodeBuilder()
+				.addData("important_time := FUZZY SET (2000-01-01T00:00:00, TRUTH VALUE 0), (2000-06-01, TRUTH VALUE 1), (2001-01-01, TRUTH VALUE 1), (2001-06-01, TRUTH VALUE 0);")
+				.toString();
+		assertEvaluatesToWithData(trapezoid, "2000-09-01 IS IN important_time", "TRUE");
+		assertEvaluatesToWithData(trapezoid, "(2000-02-01 IS IN important_time) IS WITHIN TRUTH VALUE 0.2 TO TRUTH VALUE 0.21", "TRUE");
+
+		String triangular = createCodeBuilder()
+				.addData("year_2k := 2000-01-01T00:00:00 FUZZIFIED BY 1 DAY;")
+				.toString();
+		assertEvaluatesToWithData(triangular, "2000-01-01 IS IN year_2k", "TRUE");
+		assertEvaluatesToWithData(triangular, "(2000-01-01T12:00:00 IS IN year_2k) IS WITHIN TRUTH VALUE 0.49 TO TRUTH VALUE 0.51", "TRUE");
+		assertEvaluatesToWithData(triangular, "1990-01-01 IS IN year_2k", "FALSE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testFuzzyDuration() throws Exception {
+		String trapezoid = createCodeBuilder()
+				.addData("time_for_a_walk := FUZZY SET (5 MINUTES, TRUTH VALUE 0), (15, TRUTH VALUE 1), (1 HOUR, TRUTH VALUE 1), (2 HOURS, TRUTH VALUE 0);")
+				.toString();
+		assertEvaluatesToWithData(trapezoid, "30 MINUTES IS IN time_for_a_walk", "TRUE");
+		assertEvaluatesToWithData(trapezoid, "1 MONTH IS IN time_for_a_walk", "FALSE");
+
+		String triangular = createCodeBuilder()
+				.addData("length_of_a_month := 1 MONTH FUZZIFIED BY 5 DAYS;")
+				.toString();
+		assertEvaluatesToWithData(triangular, "1 MONTH IS IN length_of_a_month", "TRUE");
+		assertEvaluatesToWithData(triangular, "1 WEEK IS IN length_of_a_month", "FALSE");
+	}
+
 }

--- a/test/arden/tests/specification/DataTypesTest.java
+++ b/test/arden/tests/specification/DataTypesTest.java
@@ -2,7 +2,6 @@ package arden.tests.specification;
 
 import org.junit.Test;
 
-import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class DataTypesTest extends SpecificationTest {
@@ -25,14 +24,14 @@ public class DataTypesTest extends SpecificationTest {
 		// time before 1800-01-01
 		//assertInvalidStatement("x := 1500-01-01T00:00:00;");
 		
-		String constantNow = new ArdenCodeBuilder()
+		String constantNow = createCodeBuilder()
 				.addData("n := NOW;")
 				.addAction(DELAY)
 				.addAction("RETURN n = NOW;")
 				.toString();
 		assertReturns(constantNow, "TRUE");
 		
-		String currentTime = new ArdenCodeBuilder()
+		String currentTime = createCodeBuilder()
 				.addData("c := CURRENTTIME;")
 				.addAction(DELAY)
 				.addAction("RETURN c < CURRENTTIME;")

--- a/test/arden/tests/specification/MlmFormatTest.java
+++ b/test/arden/tests/specification/MlmFormatTest.java
@@ -3,18 +3,20 @@ package arden.tests.specification;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import arden.tests.specification.testcompiler.ArdenCodeBuilder;
+import arden.tests.specification.testcompiler.ArdenVersion;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class MlmFormatTest extends SpecificationTest {
 
 	@Test
+	@Compatibility(min=ArdenVersion.V2)
 	public void testFileFormat() throws Exception {
-		String otherMlm = new ArdenCodeBuilder().replaceSlotContent("mlmname:", "other_mlm").toString();
-		String multipleMlms = new ArdenCodeBuilder().addMlm(otherMlm).toString();
+		String otherMlm = createCodeBuilder().replaceSlotContent("mlmname:", "other_mlm").toString();
+		String multipleMlms = createCodeBuilder().addMlm(otherMlm).toString();
 		assertValid(multipleMlms);
 		
-		String missingEnd = new ArdenCodeBuilder().renameSlot("end:", "").toString();
+		String missingEnd = createCodeBuilder().renameSlot("end:", "").toString();
 		assertInvalid(missingEnd);
 	}
 
@@ -26,34 +28,34 @@ public class MlmFormatTest extends SpecificationTest {
 
 	@Test
 	public void testSlots() throws Exception {
-		String duplicateSlot = new ArdenCodeBuilder()
+		String duplicateSlot = createCodeBuilder()
 				.renameSlot("citations:", "links:")
 				.toString();
 		assertInvalid(duplicateSlot);
 		
-		String wrongOrder = new ArdenCodeBuilder()
+		String wrongOrder = createCodeBuilder()
 				.renameSlot("specialist:", "temp:")
 				.renameSlot("author:", "specialist:")
 				.renameSlot("temp:", "author:")
 				.toString();
 		assertInvalid(wrongOrder);
 		
-		String doubleSemicolonInSlot = new ArdenCodeBuilder().replaceSlotContent("institution:", "abc;;xyz").toString();
+		String doubleSemicolonInSlot = createCodeBuilder().replaceSlotContent("institution:", "abc;;xyz").toString();
 		assertInvalid(doubleSemicolonInSlot);
 		
 		// double semicolon allowed in string constants
 		assertValidStatement("x := \";;\";");
 		
-		String doubleSemicolonInMapping = new ArdenCodeBuilder().addData("x := READ {;;};").toString();
+		String doubleSemicolonInMapping = createCodeBuilder().addData("x := READ {;;};").toString();
 		assertValid(doubleSemicolonInMapping);
 	}
 
 	@Test
 	public void testSlotBodyTypes() throws Exception {
-		String arbitrayTextInTextualSlot = new ArdenCodeBuilder().replaceSlotContent("title:", "the mlm at time of now & = + - * ; abs if else >= mlmname mlmname:").toString();
+		String arbitrayTextInTextualSlot = createCodeBuilder().replaceSlotContent("title:", "the mlm at time of now & = + - * ; abs if else >= mlmname mlmname:").toString();
 		assertValid(arbitrayTextInTextualSlot);
 		
-		String emptyTextualSlots = new ArdenCodeBuilder()
+		String emptyTextualSlots = createCodeBuilder()
 				.replaceSlotContent("title:", "")
 				.replaceSlotContent("version:", "")
 				.replaceSlotContent("institution:", "")
@@ -70,7 +72,7 @@ public class MlmFormatTest extends SpecificationTest {
 
 	@Test
 	public void testCaseInsensitivity() throws Exception {
-		String mixedCases = new ArdenCodeBuilder()
+		String mixedCases = createCodeBuilder()
 				.renameSlot("end:", "eNd:")
 				.renameSlot("library:", "LIBraRy:")
 				.renameSlot("author:", "aUTHOr:")

--- a/test/arden/tests/specification/README.md
+++ b/test/arden/tests/specification/README.md
@@ -1,7 +1,7 @@
 # Arden Syntax Test Suite
-This directory contains a **compiler independent** test suite to test the standard conformance of Arden Syntax compilers.
+This directory contains a **compiler independent** test suite to test the standard conformance of Arden Syntax compilers up to Arden Syntax **version 2.10**.
 
-Most of the statements made in the Arden Syntax language specification (v2.5) are backed by a test. This should lead to a very high test coverage.
+Nearly every statement made in the Arden Syntax language specifications is backed by a test. This should lead to a very high test coverage.
 
 
 ## Running
@@ -12,16 +12,16 @@ Using the command line go, to the project root and type `ant test`. A report, wh
 
 
 ## Writing tests
-The [ArdenCodeBuilder](testcompiler/ArdenCodeBuilder.java) can be used to easily create code and keep tests short. It works by adding code to a [template](testcompiler/Template.mlm).  
+The [ArdenCodeBuilder](testcompiler/ArdenCodeBuilder.java) can be used to easily create code and keep tests short. It works by adding code to a [template](testcompiler/Template.mlm), which is automatically chosen depending on the supported Arden Syntax version.  
 For custom asserts the base test class ([SpecificationTest](testcompiler/SpecificationTest.java)) should be used.
 
 Example:
 ```java
-String mlm1 = new ArdenCodeBuilder()
+String mlm1 = createCodeBuilder()
 	.replaceSlotContent("mlmname:", "mlm1")
 	.addData("Patient := OBJECT [Name, DateOfBirth, Id];")
 	.toString();
-String include = new ArdenCodeBuilder()
+String include = createCodeBuilder()
 	.addMlm(mlm1)
 	.addData("othermlm := MLM 'mlm1';")
 	.addData("INCLUDE othermlm;")
@@ -32,17 +32,23 @@ String include = new ArdenCodeBuilder()
 assertReturns(include, "5");
 ```
 
-Tests, which require backward compatibility, can be flagged via an annotation:
+Tests, which require backward compatibility, can be flagged via an [annotation](testcompiler/CompatibilityRule.java).  
+The annotation's min and max field describe when the tested feature was introduced to the language or removed/deprecated.
+Only compilers supporting versions between these two values will run the test.  
+
+Example:
 ```java
 @Test
-@Compatibility(ArdenVersion.V1)
-public void test() {…}
+@Compatibility(min = ArdenVersion.V2_6, max = ArdenVersion.V2_8, pedantic = true)
+public void testResourcesCategoryIsOptional() {…}
 ```
 
 ## Testing your compiler
 To test a different Arden Syntax compiler, the [TestCompiler](testcompiler/TestCompiler.java) interface has to be implemented and put as the compiler for the base test class ([SpecificationTest](testcompiler/SpecificationTest.java)) which all tests extend.  
+
+It must configure its supported Arden Syntax version(s) by providing a [TestCompilerSettings](testcompiler/TestCompilerSettings.java) object.  
 To test mapping statements (`READ`, `INTERFACE`, etc.) it should provide a [TestCompilerMappings](testcompiler/TestCompilerMappings.java) object with valid mappings.  
-The output has to be filtered to match the requirements of [TestCompilerResult](testcompiler/TestCompilerResult.java).  
+The output has to be filtered to match the requirements of [TestCompilerResult](testcompiler/TestCompilerResult.java).   
 When an error is encountered a [TestCompilerCompiletimeException](testcompiler/TestCompilerCompiletimeException.java) or a [TestCompilerRuntimeException](testcompiler/TestCompilerRuntimeException.java) should be thrown.
 
 For more information read the detailed [Javadoc](https://en.wikipedia.org/wiki/Javadoc) comments for the various files or have a look at the implementation for Arden2ByteCode in the [impl](testcompiler/impl) directory.

--- a/test/arden/tests/specification/SpecificationTestSuite.java
+++ b/test/arden/tests/specification/SpecificationTestSuite.java
@@ -7,9 +7,11 @@ import org.junit.runners.Suite.SuiteClasses;
 import arden.tests.specification.categories.KnowledgeCategoryTest;
 import arden.tests.specification.categories.LibraryCategoryTest;
 import arden.tests.specification.categories.MaintenanceCategoryTest;
+import arden.tests.specification.categories.ResourcesCategoryTest;
 import arden.tests.specification.operators.AggregationOperatorsTest;
 import arden.tests.specification.operators.ArithmeticOperatorsTest;
 import arden.tests.specification.operators.DurationOperatorsTest;
+import arden.tests.specification.operators.FuzzyOperatorsTest;
 import arden.tests.specification.operators.GeneralPropertiesTest;
 import arden.tests.specification.operators.IsComparisonOperatorsTest;
 import arden.tests.specification.operators.ListOperatorsTest;
@@ -24,6 +26,7 @@ import arden.tests.specification.operators.StringOperatorsTest;
 import arden.tests.specification.operators.TemporalOperatorsTest;
 import arden.tests.specification.operators.TimeFunctionOperatorsTest;
 import arden.tests.specification.operators.TransformationOperatorsTest;
+import arden.tests.specification.operators.TypeConversionOperatorsTest;
 import arden.tests.specification.operators.WhereOperatorTest;
 import arden.tests.specification.structureslots.ActionSlotTest;
 import arden.tests.specification.structureslots.DataSlotTest;
@@ -37,9 +40,11 @@ import arden.tests.specification.structureslots.TokensTest;
 	KnowledgeCategoryTest.class,
 	LibraryCategoryTest.class,
 	MaintenanceCategoryTest.class,
+	ResourcesCategoryTest.class,
 	AggregationOperatorsTest.class,
 	ArithmeticOperatorsTest.class,
 	DurationOperatorsTest.class,
+	FuzzyOperatorsTest.class,
 	GeneralPropertiesTest.class,
 	IsComparisonOperatorsTest.class,
 	ListOperatorsTest.class,
@@ -54,6 +59,7 @@ import arden.tests.specification.structureslots.TokensTest;
 	TemporalOperatorsTest.class,
 	TimeFunctionOperatorsTest.class,
 	TransformationOperatorsTest.class,
+	TypeConversionOperatorsTest.class,
 	WhereOperatorTest.class,
 	ActionSlotTest.class,
 	DataSlotTest.class,

--- a/test/arden/tests/specification/categories/KnowledgeCategoryTest.java
+++ b/test/arden/tests/specification/categories/KnowledgeCategoryTest.java
@@ -7,106 +7,80 @@ import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class KnowledgeCategoryTest extends SpecificationTest {
-	
+
 	@Test
 	public void testType() throws Exception {
-		String missingSlot = createCodeBuilder().removeSlot("type:").toString();
-		assertInvalid(missingSlot);
-		
-		String type = createCodeBuilder().replaceSlotContent("type:", "data_driven").toString();
-		assertValid(type);
-		
-		String invalid = createCodeBuilder().replaceSlotContent("type:", "experience").toString();
-		assertInvalid(invalid);
+		assertSlotIsRequired("type:");
+
+		/*
+		 * The ArdenCodeBuilder template is automatically set to the correct
+		 * data-driven or data_driven type.
+		 */
+		assertValid(createCodeBuilder().toString());
+
+		assertInvalidSlot("type:", "experience");
 	}
-	
+
 	@Test
-	@Compatibility(max=ArdenVersion.V1)
-	public void testTypeDash() throws Exception {
-		String typeDash = createCodeBuilder()
-				.removeSlot("arden:") // v1
-				.replaceSlotContent("type:", "data-driven").toString();
-		assertValid(typeDash);
+	@Compatibility(max = ArdenVersion.V1, pedantic = true)
+	public void testTypeUnderscoreInvalid() throws Exception {
+		// only valid since version 2
+		assertInvalidSlot("type:", "data_driven");
 	}
-	
+
 	@Test
 	public void testData() throws Exception {
-		String missingSlot = createCodeBuilder().removeSlot("data:").toString();
-		assertInvalid(missingSlot);
-		
-		String empty = createCodeBuilder().clearSlotContent("data:").toString();
-		assertValid(empty);
+		assertSlotIsRequired("data:");
+		assertValidSlot("data:", ""); // empty slot
 	}
 
 	@Test
 	public void testPriority() throws Exception {
-		String missingSlot = createCodeBuilder().removeSlot("priority:").toString();
-		assertValid(missingSlot);
-
-		String priority = createCodeBuilder().replaceSlotContent("priority:", "50").toString();
-		assertValid(priority);
-		
-		String invalid = createCodeBuilder().replaceSlotContent("priority:", "high").toString();
-		assertInvalid(invalid);
-		
-		String invalidRange1 = createCodeBuilder().replaceSlotContent("priority:", "0").toString();
-		assertInvalid(invalidRange1);
-		
-		String invalidRange2 = createCodeBuilder().replaceSlotContent("priority:", "-50").toString();
-		assertInvalid(invalidRange2);
-		
-		String invalidRange3 = createCodeBuilder().replaceSlotContent("priority:", "100").toString();
-		assertInvalid(invalidRange3);
+		assertSlotIsOptional("priority:");
+		assertValidSlot("priority:", "50");
+		assertValidSlot("priority:", "1");
+		assertValidSlot("priority:", "99");
+		assertValidSlot("priority:", "3.141");
+		assertInvalidSlot("priority:", "0");
+		assertInvalidSlot("priority:", "-50");
+		assertInvalidSlot("priority:", "100");
+		assertInvalidSlot("priority:", "");
+		assertInvalidSlot("priority:", "high");
 	}
 
 	@Test
 	public void testEvoke() throws Exception {
-		String missingSlot = createCodeBuilder().removeSlot("evoke:").toString();
-		assertInvalid(missingSlot);
-
-		String empty = createCodeBuilder().clearSlotContent("evoke:").toString();
-		assertValid(empty);
+		assertSlotIsRequired("evoke:");
+		assertValidSlot("evoke:", ""); // empty slot
 	}
 
 	@Test
 	public void testLogic() throws Exception {
-		String missingSlot = createCodeBuilder().removeSlot("logic:").toString();
-		assertInvalid(missingSlot);
-
-		String empty = createCodeBuilder().clearSlotContent("logic:").toString();
-		assertValid(empty);
+		assertSlotIsRequired("logic:");
+		assertValidSlot("logic:", ""); // empty slot
 	}
 
 	@Test
 	public void testAction() throws Exception {
-		String missingSlot = createCodeBuilder().removeSlot("action:").toString();
-		assertInvalid(missingSlot);
-
-		String empty = createCodeBuilder().clearSlotContent("action:").toString();
-		assertValid(empty);
+		assertSlotIsRequired("action:");
+		assertValidSlot("action:", ""); // empty slot
 	}
 
 	@Test
 	public void testUrgency() throws Exception {
-		String missingSlot = createCodeBuilder().removeSlot("urgency:").toString();
-		assertValid(missingSlot);
-		
-		String priority = createCodeBuilder().replaceSlotContent("urgency:", "50").toString();
-		assertValid(priority);
-		
-		String variable = createCodeBuilder()
-				.replaceSlotContent("data:", "urg := 10")
-				.replaceSlotContent("urgency:", "urg").toString();
-		assertValid(variable);
-		
-		String invalidRange1 = createCodeBuilder().replaceSlotContent("urgency:", "0").toString();
-		assertInvalid(invalidRange1);
-		
-		String invalidRange2 = createCodeBuilder().replaceSlotContent("urgency:", "-50").toString();
-		assertInvalid(invalidRange2);
-		
-		String invalidRange3 = createCodeBuilder().replaceSlotContent("urgency:", "100").toString();
-		assertInvalid(invalidRange3);
+		assertSlotIsOptional("urgency:");
+		assertValidSlot("urgency:", "50");
+		assertValidSlot("urgency:", "1");
+		assertValidSlot("urgency:", "99");
+		assertInvalidSlot("urgency:", "0");
+		assertInvalidSlot("urgency:", "-50");
+		assertInvalidSlot("urgency:", "100");
+		assertInvalidSlot("urgency:", "");
 
+		String variable = createCodeBuilder()
+				.addData("urg := 10")
+				.replaceSlotContent("urgency:", "urg")
+				.toString();
+		assertValid(variable);
 	}
 }

--- a/test/arden/tests/specification/categories/KnowledgeCategoryTest.java
+++ b/test/arden/tests/specification/categories/KnowledgeCategoryTest.java
@@ -22,7 +22,7 @@ public class KnowledgeCategoryTest extends SpecificationTest {
 	}
 	
 	@Test
-	@Compatibility(ArdenVersion.V1)
+	@Compatibility(max=ArdenVersion.V1)
 	public void testTypeDash() throws Exception {
 		String typeDash = new ArdenCodeBuilder()
 				.removeSlot("arden:") // v1

--- a/test/arden/tests/specification/categories/KnowledgeCategoryTest.java
+++ b/test/arden/tests/specification/categories/KnowledgeCategoryTest.java
@@ -2,7 +2,6 @@ package arden.tests.specification.categories;
 
 import org.junit.Test;
 
-import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.ArdenVersion;
 import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
@@ -11,20 +10,20 @@ public class KnowledgeCategoryTest extends SpecificationTest {
 	
 	@Test
 	public void testType() throws Exception {
-		String missingSlot = new ArdenCodeBuilder().removeSlot("type:").toString();
+		String missingSlot = createCodeBuilder().removeSlot("type:").toString();
 		assertInvalid(missingSlot);
 		
-		String type = new ArdenCodeBuilder().replaceSlotContent("type:", "data_driven").toString();
+		String type = createCodeBuilder().replaceSlotContent("type:", "data_driven").toString();
 		assertValid(type);
 		
-		String invalid = new ArdenCodeBuilder().replaceSlotContent("type:", "experience").toString();
+		String invalid = createCodeBuilder().replaceSlotContent("type:", "experience").toString();
 		assertInvalid(invalid);
 	}
 	
 	@Test
 	@Compatibility(max=ArdenVersion.V1)
 	public void testTypeDash() throws Exception {
-		String typeDash = new ArdenCodeBuilder()
+		String typeDash = createCodeBuilder()
 				.removeSlot("arden:") // v1
 				.replaceSlotContent("type:", "data-driven").toString();
 		assertValid(typeDash);
@@ -32,81 +31,81 @@ public class KnowledgeCategoryTest extends SpecificationTest {
 	
 	@Test
 	public void testData() throws Exception {
-		String missingSlot = new ArdenCodeBuilder().removeSlot("data:").toString();
+		String missingSlot = createCodeBuilder().removeSlot("data:").toString();
 		assertInvalid(missingSlot);
 		
-		String empty = new ArdenCodeBuilder().clearSlotContent("data:").toString();
+		String empty = createCodeBuilder().clearSlotContent("data:").toString();
 		assertValid(empty);
 	}
 
 	@Test
 	public void testPriority() throws Exception {
-		String missingSlot = new ArdenCodeBuilder().removeSlot("priority:").toString();
+		String missingSlot = createCodeBuilder().removeSlot("priority:").toString();
 		assertValid(missingSlot);
 
-		String priority = new ArdenCodeBuilder().replaceSlotContent("priority:", "50").toString();
+		String priority = createCodeBuilder().replaceSlotContent("priority:", "50").toString();
 		assertValid(priority);
 		
-		String invalid = new ArdenCodeBuilder().replaceSlotContent("priority:", "high").toString();
+		String invalid = createCodeBuilder().replaceSlotContent("priority:", "high").toString();
 		assertInvalid(invalid);
 		
-		String invalidRange1 = new ArdenCodeBuilder().replaceSlotContent("priority:", "0").toString();
+		String invalidRange1 = createCodeBuilder().replaceSlotContent("priority:", "0").toString();
 		assertInvalid(invalidRange1);
 		
-		String invalidRange2 = new ArdenCodeBuilder().replaceSlotContent("priority:", "-50").toString();
+		String invalidRange2 = createCodeBuilder().replaceSlotContent("priority:", "-50").toString();
 		assertInvalid(invalidRange2);
 		
-		String invalidRange3 = new ArdenCodeBuilder().replaceSlotContent("priority:", "100").toString();
+		String invalidRange3 = createCodeBuilder().replaceSlotContent("priority:", "100").toString();
 		assertInvalid(invalidRange3);
 	}
 
 	@Test
 	public void testEvoke() throws Exception {
-		String missingSlot = new ArdenCodeBuilder().removeSlot("evoke:").toString();
+		String missingSlot = createCodeBuilder().removeSlot("evoke:").toString();
 		assertInvalid(missingSlot);
 
-		String empty = new ArdenCodeBuilder().clearSlotContent("evoke:").toString();
+		String empty = createCodeBuilder().clearSlotContent("evoke:").toString();
 		assertValid(empty);
 	}
 
 	@Test
 	public void testLogic() throws Exception {
-		String missingSlot = new ArdenCodeBuilder().removeSlot("logic:").toString();
+		String missingSlot = createCodeBuilder().removeSlot("logic:").toString();
 		assertInvalid(missingSlot);
 
-		String empty = new ArdenCodeBuilder().clearSlotContent("logic:").toString();
+		String empty = createCodeBuilder().clearSlotContent("logic:").toString();
 		assertValid(empty);
 	}
 
 	@Test
 	public void testAction() throws Exception {
-		String missingSlot = new ArdenCodeBuilder().removeSlot("action:").toString();
+		String missingSlot = createCodeBuilder().removeSlot("action:").toString();
 		assertInvalid(missingSlot);
 
-		String empty = new ArdenCodeBuilder().clearSlotContent("action:").toString();
+		String empty = createCodeBuilder().clearSlotContent("action:").toString();
 		assertValid(empty);
 	}
 
 	@Test
 	public void testUrgency() throws Exception {
-		String missingSlot = new ArdenCodeBuilder().removeSlot("urgency:").toString();
+		String missingSlot = createCodeBuilder().removeSlot("urgency:").toString();
 		assertValid(missingSlot);
 		
-		String priority = new ArdenCodeBuilder().replaceSlotContent("urgency:", "50").toString();
+		String priority = createCodeBuilder().replaceSlotContent("urgency:", "50").toString();
 		assertValid(priority);
 		
-		String variable = new ArdenCodeBuilder()
+		String variable = createCodeBuilder()
 				.replaceSlotContent("data:", "urg := 10")
 				.replaceSlotContent("urgency:", "urg").toString();
 		assertValid(variable);
 		
-		String invalidRange1 = new ArdenCodeBuilder().replaceSlotContent("urgency:", "0").toString();
+		String invalidRange1 = createCodeBuilder().replaceSlotContent("urgency:", "0").toString();
 		assertInvalid(invalidRange1);
 		
-		String invalidRange2 = new ArdenCodeBuilder().replaceSlotContent("urgency:", "-50").toString();
+		String invalidRange2 = createCodeBuilder().replaceSlotContent("urgency:", "-50").toString();
 		assertInvalid(invalidRange2);
 		
-		String invalidRange3 = new ArdenCodeBuilder().replaceSlotContent("urgency:", "100").toString();
+		String invalidRange3 = createCodeBuilder().replaceSlotContent("urgency:", "100").toString();
 		assertInvalid(invalidRange3);
 
 	}

--- a/test/arden/tests/specification/categories/LibraryCategoryTest.java
+++ b/test/arden/tests/specification/categories/LibraryCategoryTest.java
@@ -7,97 +7,123 @@ import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class LibraryCategoryTest extends SpecificationTest {
-	
+
 	@Test
 	public void testPurpose() throws Exception {
-		String missingSlot = createCodeBuilder().removeSlot("purpose:").toString();
-		assertInvalid(missingSlot);
-		
-		String moreThan80Characters = createCodeBuilder()
-				.replaceSlotContent("purpose:",
-						"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
-						+ "Quisque libero felis, bibendum at ullamcorper ac, "
-						+ "dictum eget eros.")
-				.toString();
-		assertValid(moreThan80Characters);
+		assertSlotIsRequired("purpose:");
+
+		// more than 80 characters
+		assertValidSlot("purpose:", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+				+ "Quisque libero felis, bibendum at ullamcorper ac, dictum eget eros.");
 	}
 
 	@Test
 	public void testExplanation() throws Exception {
-		String missingSlot = createCodeBuilder().removeSlot("explanation:").toString();
-		assertInvalid(missingSlot);
-		
-		String moreThan80Characters = createCodeBuilder()
-				.replaceSlotContent("explanation:",
-						"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
-						+ "Quisque libero felis, bibendum at ullamcorper ac, "
-						+ "dictum eget eros.")
-				.toString();
-		assertValid(moreThan80Characters);
+		assertSlotIsRequired("explanation:");
 
+		// more than 80 characters
+		assertValidSlot("explanation:", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+				+ "Quisque libero felis, bibendum at ullamcorper ac, dictum eget eros.");
 	}
 
 	@Test
 	public void testKeywords() throws Exception {
-		String missingSlot = createCodeBuilder().removeSlot("keywords:").toString();
-		assertInvalid(missingSlot);
-		
-		String moreThan80Characters = createCodeBuilder()
-				.replaceSlotContent("keywords:",
-						"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
-						+ "Quisque libero felis, bibendum at ullamcorper ac, "
-						+ "dictum eget eros.")
-				.toString();
-		assertValid(moreThan80Characters);
+		assertSlotIsRequired("keywords:");
 
+		// more than 80 characters
+		assertValidSlot("keywords:", "Lorem ipsum dolor sit amet, consectetur adipiscing elit; "
+				+ "Quisque libero felis; bibendum at ullamcorper ac; dictum eget eros;");
 	}
 
 	@Test
 	public void testCitations() throws Exception {
-		String missingSlot = createCodeBuilder().removeSlot("citations:").toString();
-		assertValid(missingSlot);
+		assertSlotIsOptional("citations:");
 
+		/*
+		 * The specification BNF uses semicolon delimiters and double quotes,
+		 * but the examples do not. Weird. The example format would not be
+		 * correctly parsable as citations may contain a number followed by a
+		 * dot, which would start the next citation as linebreaks (whitespace)
+		 * are ignored.
+		 */
+		// valid in free-form text and structured format
 		String structuredFormat = createCodeBuilder()
-				.replaceSlotContent("citations:", "1. SUPPORT lorem ipsum.\n "
-						+ "2. REFUTE dolor sit amet. "
-						+ "3. consectetur adipiscing elit")
+				.appendSlotContent("citations:", "1. SUPPORT Gietzelt M, Goltz U, Grunwald D, Lochau M, Marschollek M, Song B and Wolf K-H. Arden2ByteCode: A one-pass Arden Syntax compiler for service-oriented decision support systems based on the OSGi platform. Comput Methods Programs Biomed. 2012;106(2):114-25.")
+				.appendSlotContent("citations:", System.lineSeparator())
+				.appendSlotContent("citations:", "2. REFUTE Wolf K-H, Klimek M. A Conformance Test Suite for Arden Syntax Compilers and Interpreters. Studies in health technology and informatics. 2016;228:379.")
+				.appendSlotContent("citations:", System.lineSeparator())
+				.appendSlotContent("citations:", "3. Levey A. A New Equation to Estimate Glomerular Filtration Rate. Annals of Internal Medicine. 2009;150(9):604.")
+				.appendSlotContent("citations:", System.lineSeparator())
 				.toString();
 		assertValid(structuredFormat);
 	}
-	
+
 	@Test
-	@Compatibility(max=ArdenVersion.V1)
-	public void testArbitrarySlotText() throws Exception {
-		String arbitraryCitationsText = createCodeBuilder()
-				.removeSlot("arden:") // v1
-				.replaceSlotContent("citations:", "Lorem ipsum, dolor sit amet; "
-						+ "consectetur adipiscing elit; "
-						+ "Quisque libero felis, bibendum at ullamcorper ac; "
-						+ "dictum eget eros")
-				.toString();
-		assertValid(arbitraryCitationsText);
-		
-		String arbitraryLinksText = createCodeBuilder()
-				.removeSlot("arden:") // v1
-				.replaceSlotContent("links:", "Lorem ipsum, dolor sit amet; "
-						+ "consectetur adipiscing elit; "
-						+ "Quisque libero felis, bibendum at ullamcorper ac; "
-						+ "dictum eget eros")
-				.toString();
-		assertValid(arbitraryLinksText);
+	@Compatibility(max = ArdenVersion.V1)
+	public void testCitationsTextualFormat() throws Exception {
+		// free-form text
+		assertValidSlot("citations:", "Wolf K-H, Klimek M. A Conformance Test Suite for Arden Syntax Compilers and Interpreters. Studies in health technology and informatics. 2016;228:379.");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2, pedantic = true)
+	public void testCitationsStructuredFormat() throws Exception {
+		assertInvalidSlot("citations:", "Lorem Ipsum");
+		assertInvalidSlot("citations:", "Wolf K-H, Klimek M. A Conformance Test Suite for Arden Syntax Compilers and Interpreters. Studies in health technology and informatics. 2016;228:379.");
 	}
 
 	@Test
 	public void testLinks() throws Exception {
-		String missingSlot = createCodeBuilder().removeSlot("links:").toString();
-		assertValid(missingSlot);
-		
+		assertSlotIsOptional("links:");
+	}
+
+	@Test
+	@Compatibility(max = ArdenVersion.V1)
+	public void testLinksTextualFormat() throws Exception {
+		// free-form text
+		assertValidSlot("links:", "https://www.ncbi.nlm.nih.gov/pubmed");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2, max = ArdenVersion.V2_5, pedantic = true)
+	public void testLinksStructuredFormatTerms() throws Exception {
+		/*
+		 * The specification BNF (version 2 to version 2.9) uses URL_LINK and
+		 * MESH_LINK, while the examples use just URL and MESH. Odd. In version
+		 * 2.10 both use the long URL_LINK form, so this is probably the right
+		 * format.
+		 */
 		String structuredFormat = createCodeBuilder()
-				.replaceSlotContent("links:", "'http://www.nlm.nih.gov/'; "
-						+ "OTHER_LINK 'lorem.ipsum'; "
-						+ "EXE_LINK \"exe file\", 'file://f.exe'")
+				.appendSlotContent("links:", "URL_LINK \"PubMed\", 'https://www.ncbi.nlm.nih.gov/pubmed'; ")
+				.appendSlotContent("links:", "MESH_LINK \"mesh\", 'lorem and ipsum'; ")
+				.appendSlotContent("links:", "OTHER_LINK \"doi\", '10.1000/xyz123'; ")
 				.toString();
 		assertValid(structuredFormat);
+
+		// only link text required
+		assertValidSlot("links:", "'https://www.ncbi.nlm.nih.gov/pubmed'");
+		assertValidSlot("links:", "OTHER_LINK 'lorem.ipsum'");
+
+		assertInvalidSlot("links:", "https://www.ncbi.nlm.nih.gov/pubmed");
+		assertInvalidSlot("links:", "XYZ 'https://www.ncbi.nlm.nih.gov/pubmed'");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_6, pedantic = true)
+	public void testLinksStructuredFormatStrings() throws Exception {
+		String structuredFormat = createCodeBuilder()
+				.appendSlotContent("links:", "URL_LINK 'PubMed', \"https://www.ncbi.nlm.nih.gov/pubmed\"; ")
+				.appendSlotContent("links:", "MESH_LINK 'mesh', \"lorem and ipsum\"; ")
+				.appendSlotContent("links:", "OTHER_LINK 'doi', \"10.1000/xyz123\"; ")
+				.toString();
+		assertValid(structuredFormat);
+
+		// only link text required
+		assertValidSlot("links:", "\"https://www.ncbi.nlm.nih.gov/pubmed\"");
+		assertValidSlot("links:", "OTHER_LINK \"lorem.ipsum\"");
+
+		assertInvalidSlot("links:", "https://www.ncbi.nlm.nih.gov/pubmed");
+		assertInvalidSlot("links:", "XYZ \"https://www.ncbi.nlm.nih.gov/pubmed\"");
 	}
 
 }

--- a/test/arden/tests/specification/categories/LibraryCategoryTest.java
+++ b/test/arden/tests/specification/categories/LibraryCategoryTest.java
@@ -67,7 +67,7 @@ public class LibraryCategoryTest extends SpecificationTest {
 	}
 	
 	@Test
-	@Compatibility(ArdenVersion.V1)
+	@Compatibility(max=ArdenVersion.V1)
 	public void testArbitrarySlotText() throws Exception {
 		String arbitraryCitationsText = new ArdenCodeBuilder()
 				.removeSlot("arden:") // v1

--- a/test/arden/tests/specification/categories/LibraryCategoryTest.java
+++ b/test/arden/tests/specification/categories/LibraryCategoryTest.java
@@ -2,7 +2,6 @@ package arden.tests.specification.categories;
 
 import org.junit.Test;
 
-import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.ArdenVersion;
 import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
@@ -11,10 +10,10 @@ public class LibraryCategoryTest extends SpecificationTest {
 	
 	@Test
 	public void testPurpose() throws Exception {
-		String missingSlot = new ArdenCodeBuilder().removeSlot("purpose:").toString();
+		String missingSlot = createCodeBuilder().removeSlot("purpose:").toString();
 		assertInvalid(missingSlot);
 		
-		String moreThan80Characters = new ArdenCodeBuilder()
+		String moreThan80Characters = createCodeBuilder()
 				.replaceSlotContent("purpose:",
 						"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
 						+ "Quisque libero felis, bibendum at ullamcorper ac, "
@@ -25,10 +24,10 @@ public class LibraryCategoryTest extends SpecificationTest {
 
 	@Test
 	public void testExplanation() throws Exception {
-		String missingSlot = new ArdenCodeBuilder().removeSlot("explanation:").toString();
+		String missingSlot = createCodeBuilder().removeSlot("explanation:").toString();
 		assertInvalid(missingSlot);
 		
-		String moreThan80Characters = new ArdenCodeBuilder()
+		String moreThan80Characters = createCodeBuilder()
 				.replaceSlotContent("explanation:",
 						"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
 						+ "Quisque libero felis, bibendum at ullamcorper ac, "
@@ -40,10 +39,10 @@ public class LibraryCategoryTest extends SpecificationTest {
 
 	@Test
 	public void testKeywords() throws Exception {
-		String missingSlot = new ArdenCodeBuilder().removeSlot("keywords:").toString();
+		String missingSlot = createCodeBuilder().removeSlot("keywords:").toString();
 		assertInvalid(missingSlot);
 		
-		String moreThan80Characters = new ArdenCodeBuilder()
+		String moreThan80Characters = createCodeBuilder()
 				.replaceSlotContent("keywords:",
 						"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
 						+ "Quisque libero felis, bibendum at ullamcorper ac, "
@@ -55,10 +54,10 @@ public class LibraryCategoryTest extends SpecificationTest {
 
 	@Test
 	public void testCitations() throws Exception {
-		String missingSlot = new ArdenCodeBuilder().removeSlot("citations:").toString();
+		String missingSlot = createCodeBuilder().removeSlot("citations:").toString();
 		assertValid(missingSlot);
 
-		String structuredFormat = new ArdenCodeBuilder()
+		String structuredFormat = createCodeBuilder()
 				.replaceSlotContent("citations:", "1. SUPPORT lorem ipsum.\n "
 						+ "2. REFUTE dolor sit amet. "
 						+ "3. consectetur adipiscing elit")
@@ -69,7 +68,7 @@ public class LibraryCategoryTest extends SpecificationTest {
 	@Test
 	@Compatibility(max=ArdenVersion.V1)
 	public void testArbitrarySlotText() throws Exception {
-		String arbitraryCitationsText = new ArdenCodeBuilder()
+		String arbitraryCitationsText = createCodeBuilder()
 				.removeSlot("arden:") // v1
 				.replaceSlotContent("citations:", "Lorem ipsum, dolor sit amet; "
 						+ "consectetur adipiscing elit; "
@@ -78,7 +77,7 @@ public class LibraryCategoryTest extends SpecificationTest {
 				.toString();
 		assertValid(arbitraryCitationsText);
 		
-		String arbitraryLinksText = new ArdenCodeBuilder()
+		String arbitraryLinksText = createCodeBuilder()
 				.removeSlot("arden:") // v1
 				.replaceSlotContent("links:", "Lorem ipsum, dolor sit amet; "
 						+ "consectetur adipiscing elit; "
@@ -90,10 +89,10 @@ public class LibraryCategoryTest extends SpecificationTest {
 
 	@Test
 	public void testLinks() throws Exception {
-		String missingSlot = new ArdenCodeBuilder().removeSlot("links:").toString();
+		String missingSlot = createCodeBuilder().removeSlot("links:").toString();
 		assertValid(missingSlot);
 		
-		String structuredFormat = new ArdenCodeBuilder()
+		String structuredFormat = createCodeBuilder()
 				.replaceSlotContent("links:", "'http://www.nlm.nih.gov/'; "
 						+ "OTHER_LINK 'lorem.ipsum'; "
 						+ "EXE_LINK \"exe file\", 'file://f.exe'")

--- a/test/arden/tests/specification/categories/MaintenanceCategoryTest.java
+++ b/test/arden/tests/specification/categories/MaintenanceCategoryTest.java
@@ -2,7 +2,6 @@ package arden.tests.specification.categories;
 
 import org.junit.Test;
 
-import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.ArdenVersion;
 import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
@@ -11,10 +10,10 @@ public class MaintenanceCategoryTest extends SpecificationTest {
 	
 	@Test
 	public void testTitle() throws Exception {
-		String missingSlot = new ArdenCodeBuilder().removeSlot("title:").toString();
+		String missingSlot = createCodeBuilder().removeSlot("title:").toString();
 		assertInvalid(missingSlot);
 		
-		String moreThan80Characters = new ArdenCodeBuilder()
+		String moreThan80Characters = createCodeBuilder()
 				.replaceSlotContent("title:",
 						"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
 						+ "Quisque libero felis, bibendum at ullamcorper ac, "
@@ -25,29 +24,29 @@ public class MaintenanceCategoryTest extends SpecificationTest {
 
 	@Test
 	public void testMlmname() throws Exception {
-		String missingSlot = new ArdenCodeBuilder().removeSlot("mlmname:").toString();
+		String missingSlot = createCodeBuilder().removeSlot("mlmname:").toString();
 		assertInvalid(missingSlot);
 		
-		String allowedCharacters = new ArdenCodeBuilder().replaceSlotContent("mlmname:", "my_mlm.123_X_.").toString();
+		String allowedCharacters = createCodeBuilder().replaceSlotContent("mlmname:", "my_mlm.123_X_.").toString();
 		assertValid(allowedCharacters);
 		
-		String invalidCharacter1 = new ArdenCodeBuilder().replaceSlotContent("mlmname:", "my mlm").toString();
+		String invalidCharacter1 = createCodeBuilder().replaceSlotContent("mlmname:", "my mlm").toString();
 		assertInvalid(invalidCharacter1);
 		
-		String invalidCharacter2 = new ArdenCodeBuilder().replaceSlotContent("mlmname:", "1mlm").toString();
+		String invalidCharacter2 = createCodeBuilder().replaceSlotContent("mlmname:", "1mlm").toString();
 		assertInvalid(invalidCharacter2);
 		
-		String invalidLength = new ArdenCodeBuilder().replaceSlotContent("mlmname:", "Lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_Quisque_libero_felis_bibendum_at_ullamcorper_ac_dictum_eget_eros").toString();
+		String invalidLength = createCodeBuilder().replaceSlotContent("mlmname:", "Lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_Quisque_libero_felis_bibendum_at_ullamcorper_ac_dictum_eget_eros").toString();
 		assertInvalid(invalidLength);
 		
-		String empty = new ArdenCodeBuilder().replaceSlotContent("mlmname:", "").toString();
+		String empty = createCodeBuilder().replaceSlotContent("mlmname:", "").toString();
 		assertInvalid(empty);
 	}
 	
 	@Test
 	@Compatibility(max=ArdenVersion.V1)
 	public void testFileName() throws Exception {
-		String alternative = new ArdenCodeBuilder()
+		String alternative = createCodeBuilder()
 				.removeSlot("arden:") // v1
 				.renameSlot("mlmname:", "filename:")
 				.replaceSlotContent("filename:", "my_mlm.mlm")
@@ -58,10 +57,10 @@ public class MaintenanceCategoryTest extends SpecificationTest {
 
 	@Test
 	public void testArdenSyntaxVersion() throws Exception {
-		String v25 = new ArdenCodeBuilder().replaceSlotContent("arden:", "Version 2.5").toString();
+		String v25 = createCodeBuilder().replaceSlotContent("arden:", "Version 2.5").toString();
 		assertValid(v25);
 		
-		String invalid = new ArdenCodeBuilder().replaceSlotContent("arden:", "x 2.5").toString();
+		String invalid = createCodeBuilder().replaceSlotContent("arden:", "x 2.5").toString();
 		assertInvalid(invalid);
 	}
 
@@ -69,33 +68,33 @@ public class MaintenanceCategoryTest extends SpecificationTest {
 	@Compatibility(max = ArdenVersion.V1)
 	public void testArdenSyntaxVersionV1() throws Exception {
 		// no arden version slot in v1
-		String v1 = new ArdenCodeBuilder().removeSlot("arden:").toString();
+		String v1 = createCodeBuilder().removeSlot("arden:").toString();
 		assertValid(v1);
 	}
 
 	@Test
 	@Compatibility(min = ArdenVersion.V2, max = ArdenVersion.V2)
 	public void testArdenSyntaxVersionV2() throws Exception {
-		String v2 = new ArdenCodeBuilder().replaceSlotContent("arden:", "Version 2").toString();
+		String v2 = createCodeBuilder().replaceSlotContent("arden:", "Version 2").toString();
 		assertValid(v2);
 	}
 
 	@Test
 	@Compatibility(min = ArdenVersion.V2_1, max = ArdenVersion.V2_1)
 	public void testArdenSyntaxVersionV21() throws Exception {
-		String v21 = new ArdenCodeBuilder().replaceSlotContent("arden:", "Version 2.1").toString();
+		String v21 = createCodeBuilder().replaceSlotContent("arden:", "Version 2.1").toString();
 		assertValid(v21);
 	}
 
 	@Test
 	public void testVersion() throws Exception {
-		String missingSlot = new ArdenCodeBuilder().removeSlot("version:").toString();
+		String missingSlot = createCodeBuilder().removeSlot("version:").toString();
 		assertInvalid(missingSlot);
 		
-		String version = new ArdenCodeBuilder().replaceSlotContent("version:", "1.00").toString();
+		String version = createCodeBuilder().replaceSlotContent("version:", "1.00").toString();
 		assertValid(version);
 		
-		String moreThan80Characters = new ArdenCodeBuilder()
+		String moreThan80Characters = createCodeBuilder()
 				.replaceSlotContent("version:",
 						"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
 						+ "Quisque libero felis, bibendum at ullamcorper ac, "
@@ -106,13 +105,13 @@ public class MaintenanceCategoryTest extends SpecificationTest {
 
 	@Test
 	public void testInstitution() throws Exception {
-		String missingSlot = new ArdenCodeBuilder().removeSlot("institution:").toString();
+		String missingSlot = createCodeBuilder().removeSlot("institution:").toString();
 		assertInvalid(missingSlot);
 		
-		String institution = new ArdenCodeBuilder().replaceSlotContent("institution:", "Lorem ipsum dolor sit amet").toString();
+		String institution = createCodeBuilder().replaceSlotContent("institution:", "Lorem ipsum dolor sit amet").toString();
 		assertValid(institution);
 		
-		String moreThan80Characters = new ArdenCodeBuilder()
+		String moreThan80Characters = createCodeBuilder()
 				.replaceSlotContent("institution:",
 						"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
 						+ "Quisque libero felis, bibendum at ullamcorper ac, "
@@ -123,10 +122,10 @@ public class MaintenanceCategoryTest extends SpecificationTest {
 
 	@Test
 	public void testAuthor() throws Exception {
-		String missingSlot = new ArdenCodeBuilder().removeSlot("author:").toString();
+		String missingSlot = createCodeBuilder().removeSlot("author:").toString();
 		assertInvalid(missingSlot);
 		
-		String moreThan80Characters = new ArdenCodeBuilder()
+		String moreThan80Characters = createCodeBuilder()
 				.replaceSlotContent("author:",
 						"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
 						+ "Quisque libero felis, bibendum at ullamcorper ac, "
@@ -137,10 +136,10 @@ public class MaintenanceCategoryTest extends SpecificationTest {
 
 	@Test
 	public void testSpecialist() throws Exception {
-		String missingSlot = new ArdenCodeBuilder().removeSlot("specialist:").toString();
+		String missingSlot = createCodeBuilder().removeSlot("specialist:").toString();
 		assertInvalid(missingSlot);
 		
-		String moreThan80Characters = new ArdenCodeBuilder()
+		String moreThan80Characters = createCodeBuilder()
 				.replaceSlotContent("specialist:",
 						"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
 						+ "Quisque libero felis, bibendum at ullamcorper ac, "
@@ -151,40 +150,41 @@ public class MaintenanceCategoryTest extends SpecificationTest {
 
 	@Test
 	public void testDate() throws Exception {
-		String missingSlot = new ArdenCodeBuilder().removeSlot("date:").toString();
+		String missingSlot = createCodeBuilder().removeSlot("date:").toString();
 		assertInvalid(missingSlot);
 
-		String date = new ArdenCodeBuilder().replaceSlotContent("date:", "1800-01-01").toString();
+		String date = createCodeBuilder().replaceSlotContent("date:", "1800-01-01").toString();
 		assertValid(date);
 		
-		String datetime = new ArdenCodeBuilder().replaceSlotContent("date:", "1800-01-01T00:00:00").toString();
+		String datetime = createCodeBuilder().replaceSlotContent("date:", "1800-01-01T00:00:00").toString();
 		assertValid(datetime);
 		
-		String datetimeZone = new ArdenCodeBuilder().replaceSlotContent("date:", "1800-01-01T00:00:00Z").toString();
+		String datetimeZone = createCodeBuilder().replaceSlotContent("date:", "1800-01-01T00:00:00Z").toString();
 		assertValid(datetimeZone);
 		
-		String invalid = new ArdenCodeBuilder().replaceSlotContent("date:", "1800").toString();
+		String invalid = createCodeBuilder().replaceSlotContent("date:", "1800").toString();
 		assertInvalid(invalid);
 	}
 
 	@Test
 	public void testValidation() throws Exception {
-		String missingSlot = new ArdenCodeBuilder().removeSlot("validation:").toString();
+		String missingSlot = createCodeBuilder().removeSlot("validation:").toString();
 		assertInvalid(missingSlot);
 		
-		String production = new ArdenCodeBuilder().replaceSlotContent("validation:", "production").toString();
+		String production = createCodeBuilder().replaceSlotContent("validation:", "production").toString();
 		assertValid(production);
 		
-		String research = new ArdenCodeBuilder().replaceSlotContent("validation:", "research").toString();
+		String research = createCodeBuilder().replaceSlotContent("validation:", "research").toString();
 		assertValid(research);
 		
-		String testing = new ArdenCodeBuilder().replaceSlotContent("validation:", "testing").toString();
+		String testing = createCodeBuilder().replaceSlotContent("validation:", "testing").toString();
 		assertValid(testing);
 		
-		String expired = new ArdenCodeBuilder().replaceSlotContent("validation:", "expired").toString();
+		String expired = createCodeBuilder().replaceSlotContent("validation:", "expired").toString();
 		assertValid(expired);
 		
-		String invalid = new ArdenCodeBuilder().replaceSlotContent("validation:", "none").toString();
+		String invalid = createCodeBuilder().replaceSlotContent("validation:", "none").toString();
 		assertInvalid(invalid);
 	}
+
 }

--- a/test/arden/tests/specification/categories/MaintenanceCategoryTest.java
+++ b/test/arden/tests/specification/categories/MaintenanceCategoryTest.java
@@ -2,189 +2,207 @@ package arden.tests.specification.categories;
 
 import org.junit.Test;
 
+import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.ArdenVersion;
 import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class MaintenanceCategoryTest extends SpecificationTest {
-	
+
 	@Test
 	public void testTitle() throws Exception {
-		String missingSlot = createCodeBuilder().removeSlot("title:").toString();
-		assertInvalid(missingSlot);
-		
-		String moreThan80Characters = createCodeBuilder()
-				.replaceSlotContent("title:",
-						"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
-						+ "Quisque libero felis, bibendum at ullamcorper ac, "
-						+ "dictum eget eros.")
-				.toString();
-		assertValid(moreThan80Characters);
+		assertSlotIsRequired("title:");
+		assertValidSlot("title:", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+				+ "Quisque libero felis, bibendum at ullamcorper ac, " + "dictum eget eros.");
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testMlmname() throws Exception {
-		String missingSlot = createCodeBuilder().removeSlot("mlmname:").toString();
-		assertInvalid(missingSlot);
-		
-		String allowedCharacters = createCodeBuilder().replaceSlotContent("mlmname:", "my_mlm.123_X_.").toString();
-		assertValid(allowedCharacters);
-		
-		String invalidCharacter1 = createCodeBuilder().replaceSlotContent("mlmname:", "my mlm").toString();
-		assertInvalid(invalidCharacter1);
-		
-		String invalidCharacter2 = createCodeBuilder().replaceSlotContent("mlmname:", "1mlm").toString();
-		assertInvalid(invalidCharacter2);
-		
-		String invalidLength = createCodeBuilder().replaceSlotContent("mlmname:", "Lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_Quisque_libero_felis_bibendum_at_ullamcorper_ac_dictum_eget_eros").toString();
-		assertInvalid(invalidLength);
-		
-		String empty = createCodeBuilder().replaceSlotContent("mlmname:", "").toString();
-		assertInvalid(empty);
-	}
-	
-	@Test
-	@Compatibility(max=ArdenVersion.V1)
-	public void testFileName() throws Exception {
-		String alternative = createCodeBuilder()
-				.removeSlot("arden:") // v1
-				.renameSlot("mlmname:", "filename:")
-				.replaceSlotContent("filename:", "my_mlm.mlm")
-				.toString();
-		assertValid(alternative);
-		
+		assertSlotIsRequired("mlmname:");
+		assertValidSlot("mlmname:", "my_mlm123_X_");
+		assertInvalidSlot("mlmname:", "my mlm");
+		assertInvalidSlot("mlmname:", "1mlm");
+		assertInvalidSlot("mlmname:", "");
+
+		// more than 80 characters
+		assertInvalidSlot("mlmname:", "Lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_"
+				+ "Quisque_libero_felis_bibendum_at_ullamcorper_ac_dictum_eget_eros");
 	}
 
 	@Test
-	public void testArdenSyntaxVersion() throws Exception {
-		String v25 = createCodeBuilder().replaceSlotContent("arden:", "Version 2.5").toString();
-		assertValid(v25);
-		
-		String invalid = createCodeBuilder().replaceSlotContent("arden:", "x 2.5").toString();
-		assertInvalid(invalid);
+	@Compatibility(min = ArdenVersion.V2_1)
+	public void testMlmnamePeriod() throws Exception {
+		// period (.) is allowed in "mlmname:" slot since version 2.1
+		assertValidSlot("mlmname:", "my_mlm.123_X_.");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2, max = ArdenVersion.V2, pedantic = true)
+	public void testMlmnamePeriodInvalid() throws Exception {
+		// no period allowed in version 2
+		assertInvalidSlot("mlmname:", "my_mlm.123_X_.");
+	}
+
+	@Test
+	@Compatibility(max = ArdenVersion.V1, pedantic = true)
+	public void testMlmnameInvalid() throws Exception {
+		// only valid since version 2
+		String mlmname = createCodeBuilder().renameSlot("filename:", "mlmname:").toString();
+		assertInvalid(mlmname);
 	}
 
 	@Test
 	@Compatibility(max = ArdenVersion.V1)
-	public void testArdenSyntaxVersionV1() throws Exception {
-		// no arden version slot in v1
-		String v1 = createCodeBuilder().removeSlot("arden:").toString();
-		assertValid(v1);
+	public void testFileName() throws Exception {
+		/*
+		 * The ArdenCodeBuilder template for version 1 already has the
+		 * "filename:" slot and an empty "arden:" slot.
+		 */
+		assertValid(createCodeBuilder().toString());
 	}
 
 	@Test
-	@Compatibility(min = ArdenVersion.V2, max = ArdenVersion.V2)
-	public void testArdenSyntaxVersionV2() throws Exception {
-		String v2 = createCodeBuilder().replaceSlotContent("arden:", "Version 2").toString();
-		assertValid(v2);
+	@Compatibility(min = ArdenVersion.V2, pedantic = true)
+	public void testFileNameInvalid() throws Exception {
+		// only valid in version 1
+		String filename = createCodeBuilder().renameSlot("mlmname:", "filename:").toString();
+		assertInvalid(filename);
 	}
 
 	@Test
-	@Compatibility(min = ArdenVersion.V2_1, max = ArdenVersion.V2_1)
-	public void testArdenSyntaxVersionV21() throws Exception {
-		String v21 = createCodeBuilder().replaceSlotContent("arden:", "Version 2.1").toString();
-		assertValid(v21);
+	public void testNameCaseInsensitive() throws Exception {
+		String mlm1 = createCodeBuilder()
+				.setName("Mlm1")
+				.addAction("RETURN 1;")
+				.toString();
+		String mlm2 = createCodeBuilder()
+				.addMlm(mlm1)
+				.addData("mlm1 := MLM 'mLM1';")
+				.clearSlotContent("logic:")
+				.addLogic("x := CALL mlm1;")
+				.addLogic("CONCLUDE TRUE;")
+				.addAction("RETURN x;")
+				.toString();
+		assertReturns(mlm2, "1");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2)
+	public void testArdenVersion() throws Exception {
+		// e.g. "version 2.10"
+		String verionString = getSettings().targetVersion.toString().toLowerCase();
+		String versionNumber = verionString.replace("version", "").trim();
+
+		assertValidSlot("arden:", verionString);
+		assertInvalidSlot("arden:", versionNumber);
+		assertInvalidSlot("arden:", "xyz " + versionNumber);
+		assertInvalidSlot("arden:", "version 1");
+		assertValidSlot("arden:", "vErSiOn " + versionNumber);
+	}
+
+	@Test
+	@Compatibility(max = ArdenVersion.V1)
+	public void testArdenVersionMissing() throws Exception {
+		// the ArdenCodeBuilder template for version 1 has no "arden:" slot.
+		assertValid(createCodeBuilder().toString());
+	}
+
+	@Test
+	@Compatibility(max = ArdenVersion.V1, pedantic = true)
+	public void testArdenVersionInvalid() throws Exception {
+		// insert arden slot
+		String code = createCodeBuilder().toString();
+		int versionIndex = code.indexOf("version:");
+		String arden = code.substring(0, versionIndex)
+				+ "arden: ;;" + System.lineSeparator()
+				+ code.substring(versionIndex, code.length());
+
+		String ardenV1 = new ArdenCodeBuilder(arden)
+				.replaceSlotContent("arden:", "Version 1")
+				.toString();
+		assertInvalid(ardenV1);
+
+		String ardenV1MlmName = new ArdenCodeBuilder(ardenV1)
+				.renameSlot("filename:", "mlmname:")
+				.replaceSlotContent("mlmname:", "test_mlm")
+				.toString();
+		assertInvalid(ardenV1MlmName);
+
+		String ardenV2 = new ArdenCodeBuilder(arden)
+				.replaceSlotContent("arden:", "Version 2")
+				.toString();
+		assertInvalid(ardenV2);
+
+		String ardenV2MlmName = new ArdenCodeBuilder(ardenV2)
+				.renameSlot("filename:", "mlmname:")
+				.replaceSlotContent("mlmname:", "test_mlm")
+				.toString();
+		assertInvalid(ardenV2MlmName);
 	}
 
 	@Test
 	public void testVersion() throws Exception {
-		String missingSlot = createCodeBuilder().removeSlot("version:").toString();
-		assertInvalid(missingSlot);
-		
-		String version = createCodeBuilder().replaceSlotContent("version:", "1.00").toString();
-		assertValid(version);
-		
-		String moreThan80Characters = createCodeBuilder()
-				.replaceSlotContent("version:",
-						"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
-						+ "Quisque libero felis, bibendum at ullamcorper ac, "
-						+ "dictum eget eros.")
-				.toString();
-		assertInvalid(moreThan80Characters);
+		assertSlotIsRequired("version:");
+		assertValidSlot("version:", "1.00");
+		assertValidSlot("version:", "0.2.5-alpha");
+
+		// more than 80 characters
+		assertInvalidSlot("version:", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+				+ "Quisque libero felis, bibendum at ullamcorper ac, dictum eget eros.");
 	}
 
 	@Test
 	public void testInstitution() throws Exception {
-		String missingSlot = createCodeBuilder().removeSlot("institution:").toString();
-		assertInvalid(missingSlot);
-		
-		String institution = createCodeBuilder().replaceSlotContent("institution:", "Lorem ipsum dolor sit amet").toString();
-		assertValid(institution);
-		
-		String moreThan80Characters = createCodeBuilder()
-				.replaceSlotContent("institution:",
-						"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
-						+ "Quisque libero felis, bibendum at ullamcorper ac, "
-						+ "dictum eget eros.")
-				.toString();
-		assertInvalid(moreThan80Characters);
+		assertSlotIsRequired("institution:");
+		assertValidSlot("institution:", "Peter L. Reichertz Institute for Medical Informatics");
+
+		// more than 80 characters
+		assertInvalidSlot("institution:", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+				+ "Quisque libero felis, bibendum at ullamcorper ac, dictum eget eros.");
 	}
 
 	@Test
 	public void testAuthor() throws Exception {
-		String missingSlot = createCodeBuilder().removeSlot("author:").toString();
-		assertInvalid(missingSlot);
-		
-		String moreThan80Characters = createCodeBuilder()
-				.replaceSlotContent("author:",
-						"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
-						+ "Quisque libero felis, bibendum at ullamcorper ac, "
-						+ "dictum eget eros.")
-				.toString();
-		assertValid(moreThan80Characters);
+		assertSlotIsRequired("author:");
+		assertValidSlot("author:", "John M. Doe, Jr., M.D. (john@doe.com); Jane Roe, Ph.D.");
+
+		// more than 80 characters
+		assertValidSlot("author:", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+				+ "Quisque libero felis, bibendum at ullamcorper ac, dictum eget eros.");
 	}
 
 	@Test
 	public void testSpecialist() throws Exception {
-		String missingSlot = createCodeBuilder().removeSlot("specialist:").toString();
-		assertInvalid(missingSlot);
-		
-		String moreThan80Characters = createCodeBuilder()
-				.replaceSlotContent("specialist:",
-						"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
-						+ "Quisque libero felis, bibendum at ullamcorper ac, "
-						+ "dictum eget eros.")
-				.toString();
-		assertValid(moreThan80Characters);
+		assertSlotIsRequired("specialist:");
+		assertValidSlot("specialist:", "John M. Doe, Jr., M.D. (john@doe.com); Jane Roe, Ph.D.");
+
+		// more than 80 characters
+		assertValidSlot("specialist:", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+				+ "Quisque libero felis, bibendum at ullamcorper ac, dictum eget eros.");
 	}
 
 	@Test
 	public void testDate() throws Exception {
-		String missingSlot = createCodeBuilder().removeSlot("date:").toString();
-		assertInvalid(missingSlot);
-
-		String date = createCodeBuilder().replaceSlotContent("date:", "1800-01-01").toString();
-		assertValid(date);
-		
-		String datetime = createCodeBuilder().replaceSlotContent("date:", "1800-01-01T00:00:00").toString();
-		assertValid(datetime);
-		
-		String datetimeZone = createCodeBuilder().replaceSlotContent("date:", "1800-01-01T00:00:00Z").toString();
-		assertValid(datetimeZone);
-		
-		String invalid = createCodeBuilder().replaceSlotContent("date:", "1800").toString();
-		assertInvalid(invalid);
+		assertSlotIsRequired("date:");
+		assertValidSlot("date:", "1900-05-01");
+		assertValidSlot("date:", "1970-12-01T15:30:05");
+		assertValidSlot("date:", "1800-01-01T00:00:00Z");
+		assertValidSlot("date:", "1900-03-15T23:30:05.50Z");
+		assertInvalidSlot("date:", "1900");
+		assertInvalidSlot("date:", "NOW");
+		assertInvalidSlot("date:", "");
 	}
 
 	@Test
 	public void testValidation() throws Exception {
-		String missingSlot = createCodeBuilder().removeSlot("validation:").toString();
-		assertInvalid(missingSlot);
-		
-		String production = createCodeBuilder().replaceSlotContent("validation:", "production").toString();
-		assertValid(production);
-		
-		String research = createCodeBuilder().replaceSlotContent("validation:", "research").toString();
-		assertValid(research);
-		
-		String testing = createCodeBuilder().replaceSlotContent("validation:", "testing").toString();
-		assertValid(testing);
-		
-		String expired = createCodeBuilder().replaceSlotContent("validation:", "expired").toString();
-		assertValid(expired);
-		
-		String invalid = createCodeBuilder().replaceSlotContent("validation:", "none").toString();
-		assertInvalid(invalid);
+		assertSlotIsRequired("validation:");
+		assertValidSlot("validation:", "production");
+		assertValidSlot("validation:", "research");
+		assertValidSlot("validation:", "testing");
+		assertValidSlot("validation:", "expired");
+		assertInvalidSlot("validation:", "none");
+		assertInvalidSlot("validation:", "");
 	}
 
 }

--- a/test/arden/tests/specification/categories/MaintenanceCategoryTest.java
+++ b/test/arden/tests/specification/categories/MaintenanceCategoryTest.java
@@ -45,7 +45,7 @@ public class MaintenanceCategoryTest extends SpecificationTest {
 	}
 	
 	@Test
-	@Compatibility(ArdenVersion.V1)
+	@Compatibility(max=ArdenVersion.V1)
 	public void testFileName() throws Exception {
 		String alternative = new ArdenCodeBuilder()
 				.removeSlot("arden:") // v1
@@ -64,24 +64,24 @@ public class MaintenanceCategoryTest extends SpecificationTest {
 		String invalid = new ArdenCodeBuilder().replaceSlotContent("arden:", "x 2.5").toString();
 		assertInvalid(invalid);
 	}
-	
+
 	@Test
-	@Compatibility(ArdenVersion.V1)
+	@Compatibility(max = ArdenVersion.V1)
 	public void testArdenSyntaxVersionV1() throws Exception {
 		// no arden version slot in v1
 		String v1 = new ArdenCodeBuilder().removeSlot("arden:").toString();
 		assertValid(v1);
 	}
-	
+
 	@Test
-	@Compatibility(ArdenVersion.V2)
+	@Compatibility(min = ArdenVersion.V2, max = ArdenVersion.V2)
 	public void testArdenSyntaxVersionV2() throws Exception {
 		String v2 = new ArdenCodeBuilder().replaceSlotContent("arden:", "Version 2").toString();
 		assertValid(v2);
 	}
-	
+
 	@Test
-	@Compatibility(ArdenVersion.V2_1)
+	@Compatibility(min = ArdenVersion.V2_1, max = ArdenVersion.V2_1)
 	public void testArdenSyntaxVersionV21() throws Exception {
 		String v21 = new ArdenCodeBuilder().replaceSlotContent("arden:", "Version 2.1").toString();
 		assertValid(v21);

--- a/test/arden/tests/specification/categories/ResourcesCategoryTest.java
+++ b/test/arden/tests/specification/categories/ResourcesCategoryTest.java
@@ -1,0 +1,116 @@
+package arden.tests.specification.categories;
+
+import org.junit.Test;
+
+import arden.tests.specification.testcompiler.ArdenVersion;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
+import arden.tests.specification.testcompiler.SpecificationTest;
+
+public class ResourcesCategoryTest extends SpecificationTest {
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_6, max = ArdenVersion.V2_8)
+	public void testOptional() throws Exception {
+		String mlmWithoutResources = createCodeBuilder()
+				.removeResourceSlots()
+				.toString()
+				.replace("resources:", "");
+		assertValid(mlmWithoutResources);
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9, pedantic = true)
+	public void testRequired() throws Exception {
+		// required since version 2.9
+		String mlmWithoutResources = createCodeBuilder()
+				.removeResourceSlots()
+				.toString()
+				.replace("resources:", "");
+		assertInvalid(mlmWithoutResources);
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testDefaultSlot() throws Exception {
+		assertSlotIsRequired("default:");
+
+		String defaultSlot = createCodeBuilder()
+				.removeResourceSlots()
+				.appendDefaultSlot("de")
+				.appendLanguageSlot("de")
+				.toString();
+		assertValid(defaultSlot);
+
+		String multipleDefaults = createCodeBuilder()
+				.removeResourceSlots()
+				.appendDefaultSlot("en")
+				.appendDefaultSlot("de")
+				.appendLanguageSlot("en")
+				.appendLanguageSlot("de")
+				.toString();
+		assertInvalid(multipleDefaults);
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testLanguageSlot() throws Exception {
+		String multipleSlots = createCodeBuilder()
+				.appendLanguageSlot("de")
+				.appendLanguageSlot("es")
+				.toString();
+		assertValid(multipleSlots);
+
+		String noSlots = createCodeBuilder()
+				.removeResourceSlots()
+				.appendDefaultSlot("en")
+				.toString();
+		assertInvalid(noSlots);
+
+		String textConstants = createCodeBuilder()
+				.addTextConstant("en", "msg", "A Message")
+				.appendLanguageSlot("de")
+				.addTextConstant("de", "msg", "Eine Nachricht")
+				.toString();
+		assertValid(textConstants);
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testRegionCode() throws Exception {
+		String regionCode = createCodeBuilder()
+				.removeResourceSlots()
+				.appendDefaultSlot("en_US")
+				.appendLanguageSlot("en_US")
+				.toString();
+		assertValid(regionCode);
+
+		String multipleRegionCodes = createCodeBuilder()
+				.removeResourceSlots()
+				.appendDefaultSlot("en_US")
+				.appendLanguageSlot("en_US")
+				.appendLanguageSlot("en_GB")
+				.toString();
+		assertValid(multipleRegionCodes);
+
+		String mixed = createCodeBuilder()
+				.removeResourceSlots()
+				.appendDefaultSlot("en_US")
+				.appendLanguageSlot("en")
+				.appendLanguageSlot("en_GB")
+				.toString();
+		assertInvalid(mixed);
+
+		String firstRegionIsChosen = createCodeBuilder()
+				.addData("msg := LOCALIZED 'msg' BY \"en\";")
+				.addAction("RETURN msg;")
+				.removeResourceSlots()
+				.appendDefaultSlot("en")
+				.appendLanguageSlot("en_GB")
+				.addTextConstant("en_GB", "msg", "colour")
+				.appendLanguageSlot("en_US")
+				.addTextConstant("en_US", "msg", "color")
+				.toString();
+		assertReturns(firstRegionIsChosen, "\"colour\"");
+	}
+
+}

--- a/test/arden/tests/specification/operators/AggregationOperatorsTest.java
+++ b/test/arden/tests/specification/operators/AggregationOperatorsTest.java
@@ -2,6 +2,8 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
+import arden.tests.specification.testcompiler.ArdenVersion;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class AggregationOperatorsTest extends SpecificationTest {
@@ -32,6 +34,7 @@ public class AggregationOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("EXIST OF NULL", "FALSE");
 		assertEvaluatesTo("EXIST ()", "FALSE");
 		assertEvaluatesTo("EXISTS (\"plugh\",NULL)", "TRUE");
+		
 		String data = createData();
 		assertEvaluatesToWithData(data, "TIME EXIST (x,y)", "1990-01-01T00:00:00");
 		assertEvaluatesToWithData(data, "TIME EXIST (x,z)", "NULL");
@@ -44,6 +47,7 @@ public class AggregationOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("AVG OF ()", "NULL");
 		assertEvaluatesTo("AVERAGE OF (1990-03-10T03:10:00, 1990-03-12T03:10:00)", "1990-03-11T03:10:00");
 		assertEvaluatesTo("AVERAGE (2 days, 3 days, 4 days) = 3 days", "TRUE");
+		
 		String data = createData();
 		assertEvaluatesToWithData(data, "TIME AVERAGE (x,y)", "1990-01-01T00:00:00");
 		assertEvaluatesToWithData(data, "TIME AVERAGE (x,z)", "NULL");
@@ -57,170 +61,241 @@ public class AggregationOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("MEDIAN (1990-03-10T03:10:00, 1990-03-11T03:10:00, 1990-03-28T03:10:00)", "1990-03-11T03:10:00");
 		assertEvaluatesTo("MEDIAN (1 hour, 3 days, 4 years) = 3 days", "TRUE");
 		assertEvaluatesTo("MEDIAN OF (0,5)", "2.5");
+		
 		String data = createData();
 		assertEvaluatesToWithData(data, "TIME MEDIAN (x,y,z)", "1990-01-01T00:00:00");
 		assertEvaluatesToWithData(data, "TIME MEDIAN (x,y)", "1990-01-01T00:00:00");
 		// latest of elements with primary time on tie
 		assertEvaluatesToWithData(data, "TIME MEDIAN (x,u,v)", "2000-01-01T00:00:00");
-		// tie -> average of middle 2 elements with latest time -> if same keep primary
+		// tie -> average of middle 2 elements with latest time -> if same keep
+		// primary
 		assertEvaluatesToWithData(data, "TIME MEDIAN (v,x,w,u)", "2000-01-01T00:00:00");
 		assertEvaluatesToWithData(data, "TIME MEDIAN (x,z)", "NULL");
 	}
 
 	@Test
 	public void testSum() throws Exception {
-		assertEvaluatesTo("SUM (12,13,14)","39");
-		assertEvaluatesTo("SUM 3","3");
-		assertEvaluatesTo("SUM ()","0");
-		assertEvaluatesTo("SUM (1 day, 6 days) = 7 days","TRUE");
+		assertEvaluatesTo("SUM (12,13,14)", "39");
+		assertEvaluatesTo("SUM 3", "3");
+		assertEvaluatesTo("SUM ()", "0");
+		assertEvaluatesTo("SUM (1 day, 6 days) = 7 days", "TRUE");
+		
 		String data = createData();
-		assertEvaluatesToWithData(data, "TIME SUM (x,y)","1990-01-01T00:00:00");
-		assertEvaluatesToWithData(data, "TIME SUM (x,z)","NULL");
+		assertEvaluatesToWithData(data, "TIME SUM (x,y)", "1990-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME SUM (x,z)", "NULL");
 	}
 
 	@Test
 	public void testStddev() throws Exception {
-		assertEvaluatesTo("STDDEV (12,13,14,15,16) FORMATTED WITH \"%.3f\"","\"1.581\"");
-		assertEvaluatesTo("STDDEV 3","NULL");
-		assertEvaluatesTo("STDDEV ()","NULL");
+		assertEvaluatesTo("STDDEV (12,13,14,15,16) IS WITHIN 1.58 TO 1.59", "TRUE");
+		assertEvaluatesTo("STDDEV 3", "NULL");
+		assertEvaluatesTo("STDDEV ()", "NULL");
+		
 		String data = createData();
-		assertEvaluatesToWithData(data, "TIME STDDEV (x,y)","1990-01-01T00:00:00");
-		assertEvaluatesToWithData(data, "TIME STDDEV (x,z)","NULL");
+		assertEvaluatesToWithData(data, "TIME STDDEV (x,y)", "1990-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME STDDEV (x,z)", "NULL");
 	}
 
 	@Test
 	public void testVariance() throws Exception {
-		assertEvaluatesTo("VARIANCE (12,13,14,15,16)","2.5");
-		assertEvaluatesTo("VARIANCE 3","NULL");
-		assertEvaluatesTo("VARIANCE ()","NULL");
+		assertEvaluatesTo("VARIANCE (12,13,14,15,16)", "2.5");
+		assertEvaluatesTo("VARIANCE 3", "NULL");
+		assertEvaluatesTo("VARIANCE ()", "NULL");
+		
 		String data = createData();
-		assertEvaluatesToWithData(data, "TIME VARIANCE (x,y)","1990-01-01T00:00:00");
-		assertEvaluatesToWithData(data, "TIME VARIANCE (x,z)","NULL");
+		assertEvaluatesToWithData(data, "TIME VARIANCE (x,y)", "1990-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME VARIANCE (x,z)", "NULL");
 	}
 
 	@Test
 	public void testMinMax() throws Exception {
 		String data = createData();
-		assertEvaluatesTo("MINIMUM (12,13,14)","12");
-		assertEvaluatesTo("MIN 3","3");
-		assertEvaluatesTo("MINIMUM ()","NULL");
-		assertEvaluatesTo("MINIMUM (1,\"abc\")","NULL");
-		assertEvaluatesToWithData(data, "TIME MINIMUM (x,y,z)","1990-01-03T00:00:00");
-		assertEvaluatesTo("MAXIMUM (12,13,14)","14");
-		assertEvaluatesTo("MAX 3","3");
-		assertEvaluatesTo("MAXIMUM ()","NULL");
-		assertEvaluatesTo("MAXIMUM (1,\"abc\")","NULL");
+		assertEvaluatesTo("MINIMUM (12,13,14)", "12");
+		assertEvaluatesTo("MIN 3", "3");
+		assertEvaluatesTo("MINIMUM ()", "NULL");
+		assertEvaluatesTo("MINIMUM (1,\"abc\")", "NULL");
+		assertEvaluatesToWithData(data, "TIME MINIMUM (x,y,z)", "1990-01-03T00:00:00");
+		assertEvaluatesTo("MAXIMUM (12,13,14)", "14");
+		assertEvaluatesTo("MAX 3", "3");
+		assertEvaluatesTo("MAXIMUM ()", "NULL");
+		assertEvaluatesTo("MAXIMUM (1,\"abc\")", "NULL");
+		
 		// latest time of tied elements
-		assertEvaluatesToWithData(data, "TIME MAXIMUM (v,x,y)","2000-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME MAXIMUM (v,x,y)", "2000-01-01T00:00:00");
 	}
 
 	@Test
-	public void testLastFirst() throws Exception {
-		assertEvaluatesTo("LAST (12,13,14)","14");
-		assertEvaluatesTo("LAST 3","3");
-		assertEvaluatesTo("LAST ()","NULL");
-		assertEvaluatesTo("FIRST (12,13,14)","12");
-		assertEvaluatesTo("FIRST 3","3");
-		assertEvaluatesTo("FIRST ()","NULL");
-		assertEvaluatesToWithData(createData(), "TIME LAST (x,y,z)","1990-01-03T00:00:00");
+	@Compatibility(min = ArdenVersion.V2_8)
+	public void testMinMaxUsing() throws Exception {
+		assertEvaluatesTo("MINIMUM (0,30,90,180,200,300) USING COSINE OF IT", "180");
+		assertEvaluatesTo("MAXIMUM (0,30,90,180,200,300) USING SINE OF IT", "90");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2)
+	public void testFirst() throws Exception {
+		assertEvaluatesTo("FIRST (12,13,14)", "12");
+		assertEvaluatesTo("FIRST 3", "3");
+		assertEvaluatesTo("FIRST ()", "NULL");
+	}
+
+	@Test
+	@Compatibility(max = ArdenVersion.V1, pedantic = true)
+	public void testFirstV1() throws Exception {
+		// FIRST from version 1 = EARLIEST from version 2
+		assertEvaluatesTo("FIRST ()", "NULL");
+		assertEvaluatesToWithData(createData(), "FIRST (v,x,z)", "5");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2)
+	public void testLast() throws Exception {
+		assertEvaluatesTo("LAST (12,13,14)", "14");
+		assertEvaluatesTo("LAST 3", "3");
+		assertEvaluatesTo("LAST ()", "NULL");
+		assertEvaluatesToWithData(createData(), "TIME LAST (x,y,z)", "1990-01-03T00:00:00");
+	}
+
+	@Test
+	@Compatibility(max = ArdenVersion.V1, pedantic = true)
+	public void testLastV1() throws Exception {
+		// LAST from version 1 = LATEST from version 2
+		assertEvaluatesTo("LAST ()", "NULL");
+		assertEvaluatesToWithData(createData(), "LAST (v,x,z)", "5");
 	}
 
 	@Test
 	public void testAny() throws Exception {
-		assertEvaluatesTo("ANY (TRUE,FALSE,FALSE)","TRUE");
-		assertEvaluatesTo("ANY FALSE","FALSE");
-		assertEvaluatesTo("ANY ()","FALSE");
-		assertEvaluatesTo("ANY (3, 5, \"red\")","NULL");
-		assertEvaluatesTo("ANY (FALSE, FALSE)","FALSE");
-		assertEvaluatesTo("ANY (FALSE, NULL)","NULL");
+		assertEvaluatesTo("ANY (TRUE,FALSE,FALSE)", "TRUE");
+		assertEvaluatesTo("ANY FALSE", "FALSE");
+		assertEvaluatesTo("ANY ()", "FALSE");
+		assertEvaluatesTo("ANY (3, 5, \"red\")", "NULL");
+		assertEvaluatesTo("ANY (FALSE, FALSE)", "FALSE");
+		assertEvaluatesTo("ANY (FALSE, NULL)", "NULL");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_8)
+	public void testAnyIsTrue() throws Exception {
+		assertEvaluatesTo("ANY IsTrue (TRUE,FALSE,FALSE)", "TRUE");
+		assertInvalidExpression("ANY AreTrue (TRUE,FALSE,FALSE)");
 	}
 
 	@Test
 	public void testAll() throws Exception {
-		assertEvaluatesTo("ALL (TRUE,FALSE,FALSE)","FALSE");
-		assertEvaluatesTo("ALL FALSE","FALSE");
-		assertEvaluatesTo("ALL ()","TRUE");
-		assertEvaluatesTo("ALL (3, 5, \"red\")","NULL");
-		assertEvaluatesTo("ALL (TRUE, NULL)","NULL");
+		assertEvaluatesTo("ALL (TRUE,FALSE,FALSE)", "FALSE");
+		assertEvaluatesTo("ALL FALSE", "FALSE");
+		assertEvaluatesTo("ALL ()", "TRUE");
+		assertEvaluatesTo("ALL (3, 5, \"red\")", "NULL");
+		assertEvaluatesTo("ALL (TRUE, NULL)", "NULL");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_8)
+	public void testAllAreTrue() throws Exception {
+		assertEvaluatesTo("ALL AreTrue (TRUE,FALSE,FALSE)", "FALSE");
+		assertInvalidExpression("ALL IsTrue (TRUE,FALSE,FALSE)");
 	}
 
 	@Test
 	public void testNo() throws Exception {
-		assertEvaluatesTo("NO (TRUE,FALSE,FALSE)","FALSE");
-		assertEvaluatesTo("NO FALSE","TRUE");
-		assertEvaluatesTo("NO ()","TRUE");
-		assertEvaluatesTo("NO (3, 5, \"red\")","NULL");
-		assertEvaluatesTo("NO (FALSE, NULL)","NULL");
+		assertEvaluatesTo("NO (TRUE,FALSE,FALSE)", "FALSE");
+		assertEvaluatesTo("NO FALSE", "TRUE");
+		assertEvaluatesTo("NO ()", "TRUE");
+		assertEvaluatesTo("NO (3, 5, \"red\")", "NULL");
+		assertEvaluatesTo("NO (FALSE, NULL)", "NULL");
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2_8)
+	public void testNoIsTrue() throws Exception {
+		assertEvaluatesTo("NO IsTrue (TRUE,FALSE,FALSE)", "FALSE");
+		assertInvalidExpression("NO AreTrue (TRUE,FALSE,FALSE)");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testLatestEarliest() throws Exception {
 		String data = createData();
-		assertEvaluatesTo("LATEST ()","NULL");
-		assertEvaluatesToWithData(data, "LATEST (v,x,z)","5");
-		assertEvaluatesTo("EARLIEST ()","NULL");
-		assertEvaluatesToWithData(data, "EARLIEST (v,z)","2");
+		assertEvaluatesTo("LATEST ()", "NULL");
+		assertEvaluatesToWithData(data, "LATEST (v,x,z)", "5");
+		assertEvaluatesTo("EARLIEST ()", "NULL");
+		assertEvaluatesToWithData(data, "EARLIEST (v,z)", "2");
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2_8)
+	public void testLatestEarliestUsing() throws Exception {
+		String data = createData();
+		assertEvaluatesToWithData(data, "LATEST (v,x,z) USING TIME OF IT", "5");
+		assertEvaluatesToWithData(data, "EARLIEST (v,z) USING TIME OF IT", "2");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testElement() throws Exception {
-		assertEvaluatesTo("(10,20,30,40)[2]","20");
-		assertEvaluatesTo("(10,20)[()]","()");
-		assertEvaluatesTo("(10,20)[1.5,2]","(NULL,20)");
-		assertEvaluatesTo("(10,20,30,40,50)[1,3,5]","(10,30,50)");
-		assertEvaluatesTo("(10,20,30,40,50)[1,(3,5)]","(10,30,50)");
-		assertEvaluatesTo("(10,20,30,40,50)[1 SEQTO 3]","(10,20,30)");
-		assertEvaluatesToWithData(createData(), "TIME FIRST (x,y,z)[2,3]","1990-01-01T00:00:00");
+		assertEvaluatesTo("(10,20,30,40)[2]", "20");
+		assertEvaluatesTo("(10,20)[()]", "()");
+		assertEvaluatesTo("(10,20)[1.5,2]", "(NULL,20)");
+		assertEvaluatesTo("(10,20,30,40,50)[1,3,5]", "(10,30,50)");
+		assertEvaluatesTo("(10,20,30,40,50)[1,(3,5)]", "(10,30,50)");
+		assertEvaluatesTo("(10,20,30,40,50)[1 SEQTO 3]", "(10,20,30)");
+		assertEvaluatesToWithData(createData(), "TIME FIRST (x,y,z)[2,3]", "1990-01-01T00:00:00");
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testExtractCharacters() throws Exception {
-		assertEvaluatesTo("EXTRACT CHARACTERS \"abc\"","(\"a\",\"b\",\"c\")");
-		assertEvaluatesTo("EXTRACT CHARACTERS (\"ab\",\"c\")","(\"a\",\"b\",\"c\")");
-		assertEvaluatesTo("EXTRACT CHARACTERS ()","()");
-		assertEvaluatesTo("EXTRACT CHARACTERS \"\"","()");
-		assertEvaluatesTo("STRING REVERSE EXTRACT CHARACTERS \"abcde\"","\"edcba\"");
+		assertEvaluatesTo("EXTRACT CHARACTERS \"abc\"", "(\"a\",\"b\",\"c\")");
+		assertEvaluatesTo("EXTRACT CHARACTERS (\"ab\",\"c\")", "(\"a\",\"b\",\"c\")");
+		assertEvaluatesTo("EXTRACT CHARACTERS ()", "()");
+		assertEvaluatesTo("EXTRACT CHARACTERS \"\"", "()");
+		assertEvaluatesTo("STRING REVERSE EXTRACT CHARACTERS \"abcde\"", "\"edcba\"");
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testSeqto() throws Exception {
-		assertEvaluatesTo("2 SEQTO 4","(2,3,4)");
-		assertEvaluatesTo("4 SEQTO 2","()");
-		assertEvaluatesTo("4.5 SEQTO 2","NULL");
+		assertEvaluatesTo("2 SEQTO 4", "(2,3,4)");
+		assertEvaluatesTo("4 SEQTO 2", "()");
+		assertEvaluatesTo("4.5 SEQTO 2", "NULL");
 		// written as (2) instead of (,2) in specification, faulty example?
-		assertEvaluatesTo("2 SEQTO 2","(,2)");
-		assertEvaluatesTo("-3 SEQTO -1","(-3,-2,-1)");
-		assertEvaluatesTo("2 * (1 SEQTO 4)","(2,4,6,8)");
-		assertEvaluatesTo("(1.5 SEQTO 5)","NULL");
-		
+		assertEvaluatesTo("2 SEQTO 2", "(,2)");
+		assertEvaluatesTo("-3 SEQTO -1", "(-3,-2,-1)");
+		assertEvaluatesTo("2 * (1 SEQTO 4)", "(2,4,6,8)");
+		assertEvaluatesTo("(1.5 SEQTO 5)", "NULL");
+
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testReverse() throws Exception {
-		assertEvaluatesTo("REVERSE (1,2,3)","(3,2,1)");
-		assertEvaluatesTo("REVERSE (1 SEQTO 6)","(6,5,4,3,2,1)");
-		assertEvaluatesTo("REVERSE ()","()");
+		assertEvaluatesTo("REVERSE (1,2,3)", "(3,2,1)");
+		assertEvaluatesTo("REVERSE (1 SEQTO 6)", "(6,5,4,3,2,1)");
+		assertEvaluatesTo("REVERSE ()", "()");
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testIndexExtraction() throws Exception {
 		String data = createData();
-		assertEvaluatesTo("INDEX EARLIEST ()","NULL");
-		assertEvaluatesToWithData(data, "INDEX EARLIEST (v,x,y)","2");
-		assertEvaluatesToWithData(data, "TIME INDEX EARLIEST (v,x,y)","1990-01-01T00:00:00");
-		assertEvaluatesTo("INDEX LATEST ()","NULL");
-		assertEvaluatesToWithData(data, "INDEX LATEST (v,x,y)","1");
-		assertEvaluatesTo("INDEX MINIMUM (12,13,14)","1");
-		assertEvaluatesTo("INDEX MIN 3","1");
-		assertEvaluatesTo("INDEX MINIMUM ()","NULL");
-		assertEvaluatesTo("INDEX MINIMUM (1,\"abc\")","NULL");
-		assertEvaluatesTo("INDEX MAXIMUM (12,13,14)","3");
-		assertEvaluatesTo("INDEX MAX 3","1");
-		assertEvaluatesTo("INDEX MAXIMUM ()","NULL");
-		assertEvaluatesTo("INDEX MAXIMUM (1,\"abc\")","NULL");
+		assertEvaluatesTo("INDEX EARLIEST ()", "NULL");
+		assertEvaluatesToWithData(data, "INDEX EARLIEST (v,x,y)", "2");
+		assertEvaluatesToWithData(data, "TIME INDEX EARLIEST (v,x,y)", "1990-01-01T00:00:00");
+		assertEvaluatesTo("INDEX LATEST ()", "NULL");
+		assertEvaluatesToWithData(data, "INDEX LATEST (v,x,y)", "1");
+		assertEvaluatesTo("INDEX MINIMUM (12,13,14)", "1");
+		assertEvaluatesTo("INDEX MIN 3", "1");
+		assertEvaluatesTo("INDEX MINIMUM ()", "NULL");
+		assertEvaluatesTo("INDEX MINIMUM (1,\"abc\")", "NULL");
+		assertEvaluatesTo("INDEX MAXIMUM (12,13,14)", "3");
+		assertEvaluatesTo("INDEX MAX 3", "1");
+		assertEvaluatesTo("INDEX MAXIMUM ()", "NULL");
+		assertEvaluatesTo("INDEX MAXIMUM (1,\"abc\")", "NULL");
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testIndexFirstLast() throws Exception {
 		assertInvalidExpression("INDEX FIRST (12,13,14)");
 		assertInvalidExpression("INDEX LAST (12,13,14)");

--- a/test/arden/tests/specification/operators/AggregationOperatorsTest.java
+++ b/test/arden/tests/specification/operators/AggregationOperatorsTest.java
@@ -2,27 +2,28 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
-import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class AggregationOperatorsTest extends SpecificationTest {
-	
-	private static final String DATA = new ArdenCodeBuilder()
-			.addData("u := 5; TIME u := 1995-01-01T00:00:00;")
-			.addData("v := 5; TIME v := 2000-01-01T00:00:00;")
-			.addData("w := 5; TIME w := TIME v;")
-			.addData("x := 5; TIME x := 1990-01-01T00:00:00;")
-			.addData("y := 3; TIME y := TIME x;")
-			.addData("z := 2; TIME z := 1990-01-03T00:00:00;")
-			.toString();
-			
+
+	private String createData() {
+		return createCodeBuilder()
+				.addData("u := 5; TIME u := 1995-01-01T00:00:00;")
+				.addData("v := 5; TIME v := 2000-01-01T00:00:00;")
+				.addData("w := 5; TIME w := TIME v;")
+				.addData("x := 5; TIME x := 1990-01-01T00:00:00;")
+				.addData("y := 3; TIME y := TIME x;")
+				.addData("z := 2; TIME z := 1990-01-03T00:00:00;")
+				.toString();
+	}
+
 	@Test
 	public void testCount() throws Exception {
 		assertEvaluatesTo("COUNT(12,13,14,NULL)", "4");
 		assertEvaluatesTo("COUNT OF \"asdf\"", "1");
 		assertEvaluatesTo("COUNT OF()", "0");
 		assertEvaluatesTo("COUNT NULL", "1");
-		assertEvaluatesToWithData(DATA, "TIME COUNT (x,y)", "NULL");
+		assertEvaluatesToWithData(createData(), "TIME COUNT (x,y)", "NULL");
 	}
 
 	@Test
@@ -31,8 +32,9 @@ public class AggregationOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("EXIST OF NULL", "FALSE");
 		assertEvaluatesTo("EXIST ()", "FALSE");
 		assertEvaluatesTo("EXISTS (\"plugh\",NULL)", "TRUE");
-		assertEvaluatesToWithData(DATA, "TIME EXIST (x,y)", "1990-01-01T00:00:00");
-		assertEvaluatesToWithData(DATA, "TIME EXIST (x,z)", "NULL");
+		String data = createData();
+		assertEvaluatesToWithData(data, "TIME EXIST (x,y)", "1990-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME EXIST (x,z)", "NULL");
 	}
 
 	@Test
@@ -42,8 +44,9 @@ public class AggregationOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("AVG OF ()", "NULL");
 		assertEvaluatesTo("AVERAGE OF (1990-03-10T03:10:00, 1990-03-12T03:10:00)", "1990-03-11T03:10:00");
 		assertEvaluatesTo("AVERAGE (2 days, 3 days, 4 days) = 3 days", "TRUE");
-		assertEvaluatesToWithData(DATA, "TIME AVERAGE (x,y)", "1990-01-01T00:00:00");
-		assertEvaluatesToWithData(DATA, "TIME AVERAGE (x,z)", "NULL");
+		String data = createData();
+		assertEvaluatesToWithData(data, "TIME AVERAGE (x,y)", "1990-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME AVERAGE (x,z)", "NULL");
 	}
 
 	@Test
@@ -54,14 +57,14 @@ public class AggregationOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("MEDIAN (1990-03-10T03:10:00, 1990-03-11T03:10:00, 1990-03-28T03:10:00)", "1990-03-11T03:10:00");
 		assertEvaluatesTo("MEDIAN (1 hour, 3 days, 4 years) = 3 days", "TRUE");
 		assertEvaluatesTo("MEDIAN OF (0,5)", "2.5");
-		assertEvaluatesToWithData(DATA, "TIME MEDIAN (x,y,z)", "1990-01-01T00:00:00");
-		assertEvaluatesToWithData(DATA, "TIME MEDIAN (x,y)", "1990-01-01T00:00:00");
-		
+		String data = createData();
+		assertEvaluatesToWithData(data, "TIME MEDIAN (x,y,z)", "1990-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME MEDIAN (x,y)", "1990-01-01T00:00:00");
 		// latest of elements with primary time on tie
-		assertEvaluatesToWithData(DATA, "TIME MEDIAN (x,u,v)", "2000-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME MEDIAN (x,u,v)", "2000-01-01T00:00:00");
 		// tie -> average of middle 2 elements with latest time -> if same keep primary
-		assertEvaluatesToWithData(DATA, "TIME MEDIAN (v,x,w,u)", "2000-01-01T00:00:00");
-		assertEvaluatesToWithData(DATA, "TIME MEDIAN (x,z)", "NULL");
+		assertEvaluatesToWithData(data, "TIME MEDIAN (v,x,w,u)", "2000-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME MEDIAN (x,z)", "NULL");
 	}
 
 	@Test
@@ -70,8 +73,9 @@ public class AggregationOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("SUM 3","3");
 		assertEvaluatesTo("SUM ()","0");
 		assertEvaluatesTo("SUM (1 day, 6 days) = 7 days","TRUE");
-		assertEvaluatesToWithData(DATA, "TIME SUM (x,y)","1990-01-01T00:00:00");
-		assertEvaluatesToWithData(DATA, "TIME SUM (x,z)","NULL");
+		String data = createData();
+		assertEvaluatesToWithData(data, "TIME SUM (x,y)","1990-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME SUM (x,z)","NULL");
 	}
 
 	@Test
@@ -79,8 +83,9 @@ public class AggregationOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("STDDEV (12,13,14,15,16) FORMATTED WITH \"%.3f\"","\"1.581\"");
 		assertEvaluatesTo("STDDEV 3","NULL");
 		assertEvaluatesTo("STDDEV ()","NULL");
-		assertEvaluatesToWithData(DATA, "TIME STDDEV (x,y)","1990-01-01T00:00:00");
-		assertEvaluatesToWithData(DATA, "TIME STDDEV (x,z)","NULL");
+		String data = createData();
+		assertEvaluatesToWithData(data, "TIME STDDEV (x,y)","1990-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME STDDEV (x,z)","NULL");
 	}
 
 	@Test
@@ -88,23 +93,25 @@ public class AggregationOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("VARIANCE (12,13,14,15,16)","2.5");
 		assertEvaluatesTo("VARIANCE 3","NULL");
 		assertEvaluatesTo("VARIANCE ()","NULL");
-		assertEvaluatesToWithData(DATA, "TIME VARIANCE (x,y)","1990-01-01T00:00:00");
-		assertEvaluatesToWithData(DATA, "TIME VARIANCE (x,z)","NULL");
+		String data = createData();
+		assertEvaluatesToWithData(data, "TIME VARIANCE (x,y)","1990-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME VARIANCE (x,z)","NULL");
 	}
 
 	@Test
 	public void testMinMax() throws Exception {
+		String data = createData();
 		assertEvaluatesTo("MINIMUM (12,13,14)","12");
 		assertEvaluatesTo("MIN 3","3");
 		assertEvaluatesTo("MINIMUM ()","NULL");
 		assertEvaluatesTo("MINIMUM (1,\"abc\")","NULL");
-		assertEvaluatesToWithData(DATA, "TIME MINIMUM (x,y,z)","1990-01-03T00:00:00");
+		assertEvaluatesToWithData(data, "TIME MINIMUM (x,y,z)","1990-01-03T00:00:00");
 		assertEvaluatesTo("MAXIMUM (12,13,14)","14");
 		assertEvaluatesTo("MAX 3","3");
 		assertEvaluatesTo("MAXIMUM ()","NULL");
 		assertEvaluatesTo("MAXIMUM (1,\"abc\")","NULL");
 		// latest time of tied elements
-		assertEvaluatesToWithData(DATA, "TIME MAXIMUM (v,x,y)","2000-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME MAXIMUM (v,x,y)","2000-01-01T00:00:00");
 	}
 
 	@Test
@@ -115,7 +122,7 @@ public class AggregationOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("FIRST (12,13,14)","12");
 		assertEvaluatesTo("FIRST 3","3");
 		assertEvaluatesTo("FIRST ()","NULL");
-		assertEvaluatesToWithData(DATA, "TIME LAST (x,y,z)","1990-01-03T00:00:00");
+		assertEvaluatesToWithData(createData(), "TIME LAST (x,y,z)","1990-01-03T00:00:00");
 	}
 
 	@Test
@@ -148,10 +155,11 @@ public class AggregationOperatorsTest extends SpecificationTest {
 
 	@Test
 	public void testLatestEarliest() throws Exception {
+		String data = createData();
 		assertEvaluatesTo("LATEST ()","NULL");
-		assertEvaluatesToWithData(DATA, "LATEST (v,x,z)","5");
+		assertEvaluatesToWithData(data, "LATEST (v,x,z)","5");
 		assertEvaluatesTo("EARLIEST ()","NULL");
-		assertEvaluatesToWithData(DATA, "EARLIEST (v,z)","2");
+		assertEvaluatesToWithData(data, "EARLIEST (v,z)","2");
 	}
 
 	@Test
@@ -162,7 +170,7 @@ public class AggregationOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("(10,20,30,40,50)[1,3,5]","(10,30,50)");
 		assertEvaluatesTo("(10,20,30,40,50)[1,(3,5)]","(10,30,50)");
 		assertEvaluatesTo("(10,20,30,40,50)[1 SEQTO 3]","(10,20,30)");
-		assertEvaluatesToWithData(DATA, "TIME FIRST (x,y,z)[2,3]","1990-01-01T00:00:00");
+		assertEvaluatesToWithData(createData(), "TIME FIRST (x,y,z)[2,3]","1990-01-01T00:00:00");
 	}
 
 	@Test
@@ -196,11 +204,12 @@ public class AggregationOperatorsTest extends SpecificationTest {
 
 	@Test
 	public void testIndexExtraction() throws Exception {
+		String data = createData();
 		assertEvaluatesTo("INDEX EARLIEST ()","NULL");
-		assertEvaluatesToWithData(DATA, "INDEX EARLIEST (v,x,y)","2");
-		assertEvaluatesToWithData(DATA, "TIME INDEX EARLIEST (v,x,y)","1990-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "INDEX EARLIEST (v,x,y)","2");
+		assertEvaluatesToWithData(data, "TIME INDEX EARLIEST (v,x,y)","1990-01-01T00:00:00");
 		assertEvaluatesTo("INDEX LATEST ()","NULL");
-		assertEvaluatesToWithData(DATA, "INDEX LATEST (v,x,y)","1");
+		assertEvaluatesToWithData(data, "INDEX LATEST (v,x,y)","1");
 		assertEvaluatesTo("INDEX MINIMUM (12,13,14)","1");
 		assertEvaluatesTo("INDEX MIN 3","1");
 		assertEvaluatesTo("INDEX MINIMUM ()","NULL");

--- a/test/arden/tests/specification/operators/ArithmeticOperatorsTest.java
+++ b/test/arden/tests/specification/operators/ArithmeticOperatorsTest.java
@@ -2,21 +2,24 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
+import arden.tests.specification.testcompiler.ArdenVersion;
 import arden.tests.specification.testcompiler.SpecificationTest;
- 
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
+
 public class ArithmeticOperatorsTest extends SpecificationTest {
-	
+
 	@Test
 	public void testUnary() throws Exception {
 		// +
 		assertEvaluatesTo("+ 2", "2");
 		assertEvaluatesTo("+ \"asdf\"", "NULL");
 		assertEvaluatesTo("+ 2 days", "172800 seconds");
-		
+
 		// -
 		assertEvaluatesTo("- 2", "-2");
 		assertEvaluatesTo("- (2 days)", "-172800 seconds");
-		
+		assertEvaluatesTo("-(3,4,5)", "(-3,-4,-5)");
+
 		assertInvalidExpression("3 + -4");
 	}
 
@@ -26,46 +29,67 @@ public class ArithmeticOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("4 + 2", "6");
 		assertEvaluatesTo("5 + ()", "()");
 		assertEvaluatesTo("(1,2,3) + ()", "NULL");
+		assertEvaluatesTo("(1,2)+(3,4)", "(4,6)");
+		assertEvaluatesTo("()+()", "()");
 		assertEvaluatesTo("NULL + ()", "()");
 		assertEvaluatesTo("5 + NULL", "NULL");
 		assertEvaluatesTo("(1,2,3) + NULL", "(NULL,NULL,NULL)");
 		assertEvaluatesTo("NULL + NULL", "NULL");
 		assertEvaluatesTo("1 day + 2 days", "259200 seconds");
-		assertEvaluatesTo("1990-03-13T00:00:00 + 2 days", "1990-03-15T00:00:00");
-		// date before 1800-01-01? faulty example in language specification? 
-		//assertEvaluatesTo("0000-00-00 + 1993 years + 5 months + 17 days", "1993-05-17T00:00:00");
-		assertEvaluatesTo("2 days + 1990-03-13T00:00:00", "1990-03-15T00:00:00");
-		
+
 		// -
 		assertEvaluatesTo("6 - 2", "4");
 		assertEvaluatesTo("3 days - 2 days", "86400 seconds");
-		assertEvaluatesTo("1990-03-15T00:00:00 - 2 days", "1990-03-13T00:00:00");
 		assertEvaluatesTo("1990-03-15T00:00:00 - 1990-03-13T00:00:00", "172800 seconds");
-		
+
 		// *
 		assertEvaluatesTo("4 * 2", "8");
 		assertEvaluatesTo("3 * 2 days", "518400 seconds");
 		assertEvaluatesTo("2 days * 3", "518400 seconds");
-		
+
 		// /
 		assertEvaluatesTo("8 / 2", "4");
 		assertEvaluatesTo("6 days / 3", "172800 seconds");
 		assertEvaluatesTo("2 minutes / 1 second", "120");
 		assertEvaluatesTo("3 years / 1 month", "36");
-		assertEvaluatesTo("5/0", "NULL");
-		
+
 		// **
 		assertEvaluatesTo("3 ** 2", "9");
+	}
+
+	@Test
+	public void testOverflow() throws Exception {
+		assertEvaluatesTo("999 ** 999", "NULL");
 	}
 
 	@Test
 	public void testInvalidOperand() throws Exception {
 		assertEvaluatesTo("3**1991-03-24T00:00:00", "NULL");
 	}
-	
+
 	@Test
-	public void testOverflow() throws Exception {
-		assertEvaluatesTo("999 ** 999", "NULL");
+	public void testDivisionByZero() throws Exception {
+		assertEvaluatesTo("1/0", "NULL");
+		assertEvaluatesTo("123/(0+0)", "NULL");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2)
+	public void testConstructingTime() throws Exception {
+		assertEvaluatesTo("1990-03-13T00:00:00 + 2 days", "1990-03-15T00:00:00");
+		assertEvaluatesTo("2 days + 1990-03-13T00:00:00", "1990-03-15T00:00:00");
+		assertEvaluatesTo("1990-03-15T00:00:00 - 2 days", "1990-03-13T00:00:00");
+		assertEvaluatesTo("1800-01-01 + (1993-1800)years + (5-1)months + (17-1)days", "1993-05-17T00:00:00");
+
+		// date before 1800-01-01? faulty example in language specification?
+		// assertEvaluatesTo("0000-00-00 + 1993 years + 5 months + 17 days", "1993-05-17T00:00:00");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testConstructingTimeOfDay() throws Exception {
+		assertEvaluatesTo("23:00:00 - 1 HOUR", "22:00:00");
+		assertEvaluatesTo("23:00:00 + 1 HOUR", "00:00:00");
 	}
 
 }

--- a/test/arden/tests/specification/operators/DurationOperatorsTest.java
+++ b/test/arden/tests/specification/operators/DurationOperatorsTest.java
@@ -19,21 +19,10 @@ public class DurationOperatorsTest extends SpecificationTest {
 	}
 
 	@Test
-	public void testExtract() throws Exception {
-		assertEvaluatesTo("EXTRACT YEAR 1990-01-03T14:23:17.3", "1990");
-		assertEvaluatesTo("EXTRACT YEAR (1 YEAR)", "NULL");
-		assertEvaluatesTo("EXTRACT MONTH 1990-01-03T14:23:17.3", "1");
-		assertEvaluatesTo("EXTRACT MONTH 1", "NULL");
-		assertEvaluatesTo("EXTRACT DAY 1990-01-03T14:23:17.3", "3");
-		assertEvaluatesTo("EXTRACT DAY \"this is not a time\"", "NULL");
-		assertEvaluatesTo("EXTRACT HOUR 1990-01-03T14:23:17.3", "14");
-		assertEvaluatesTo("EXTRACT HOUR (1 HOUR)", "NULL");
-		assertEvaluatesTo("EXTRACT MINUTE 1990-01-03T14:23:17.3", "23");
-		assertEvaluatesTo("EXTRACT MINUTE 1990-01-03", "0");
-		// date before 1800-01-01? faulty example in language specification? 
-		// assertEvaluatesTo("EXTRACT MINUTE 0000-00-00", "NULL");
-		assertEvaluatesTo("EXTRACT SECOND 1990-01-03T14:23:17.3", "17.3");
-		assertEvaluatesTo("EXTRACT SECOND (1 second)", "NULL");
+	public void testDecimal() throws Exception {
+		assertEvaluatesTo("0.5 YEARS", "6 months");
+		assertEvaluatesTo("0.5 MINUTES", "30 seconds");
+		assertEvaluatesTo("0.5 SECONDS", "0.5 seconds");
 	}
 
 }

--- a/test/arden/tests/specification/operators/FuzzyOperatorsTest.java
+++ b/test/arden/tests/specification/operators/FuzzyOperatorsTest.java
@@ -1,0 +1,118 @@
+package arden.tests.specification.operators;
+
+import org.junit.Test;
+
+import arden.tests.specification.testcompiler.ArdenCodeBuilder;
+import arden.tests.specification.testcompiler.ArdenVersion;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
+import arden.tests.specification.testcompiler.SpecificationTest;
+
+public class FuzzyOperatorsTest extends SpecificationTest {
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testFuzzySet() throws Exception {
+		assertEvaluatesTo("(FUZZY SET (1, TRUTH VALUE 0), (\"2\", TRUTH VALUE 1)) IS PRESENT", "FALSE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testFuzzified() throws Exception {
+		assertEvaluatesTo("(7 FUZZIFIED BY \"x\") IS PRESENT", "FALSE");
+		assertEvaluatesTo("(7 FUZZIFIED BY 2) IS PRESENT", "TRUE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testDefuzzified() throws Exception {
+		assertEvaluatesTo("DEFUZZIFIED 7 FUZZIFIED BY 2;", "7");
+
+		String p0 = "(0, TRUTH VALUE 0), ";
+		String p2 = "(2, TRUTH VALUE 0), ";
+		String p3 = "(3, TRUTH VALUE 0.5), ";
+		String p4 = "(4, TRUTH VALUE 0.5), ";
+		String p5 = "(5, TRUTH VALUE 1), ";
+		String p6 = "(6, TRUTH VALUE 1), ";
+		String p7 = "(7, TRUTH VALUE 0)";
+		String meanOfMaximum = createCodeBuilder()
+				.addData("s := FUZZY SET " + p0 + p2 + p3 + p4 + p5 + p6 + p7 + ";")
+				.addAction("RETURN (DEFUZZIFIED s) IS WITHIN TRUTH VALUE 5.49 TO TRUTH VALUE 5.51;")
+				.toString();
+		assertReturns(meanOfMaximum, "TRUE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testApplicability() throws Exception {
+		assertEvaluatesTo("APPLICABILITY \"xyz\"", "TRUE");
+		assertEvaluatesTo("APPLICABILITY APPLICABILITY \"xyz\"", "TRUE");
+		assertEvaluatesTo("NOT APPLICABILITY \"xyz\"", "FALSE");
+
+		String data = createCodeBuilder()
+				.addData("x := 5; APPLICABILITY OF x := TRUTH VALUE 0.3; TIME OF x := 1990-01-01T10:00:00;")
+				.addData("y := 3; APPLICABILITY OF y := TRUE;")
+				.toString();
+		assertEvaluatesToWithData(data, "(APPLICABILITY x) IS WITHIN TRUTH VALUE 0.29 TO TRUTH VALUE 0.31", "TRUE");
+		assertEvaluatesToWithData(data, "(APPLICABILITY APPLICABILITY x) IS WITHIN TRUTH VALUE 0.29 TO TRUTH VALUE 0.31", "TRUE");
+		assertEvaluatesToWithData(data, "APPLICABILITY OF y", "TRUE");
+		assertEvaluatesToWithData(data, "APPLICABILITY OF APPLICABILITY OF y", "TRUE");
+
+		// primary time preserved
+		assertEvaluatesToWithData(data, "TIME APPLICABILITY x", "1990-01-01T10:00:00");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testApplicabilityObjects() throws Exception {
+		String data = createCodeBuilder()
+				.addData("obj := OBJECT [attr1, attr2];")
+				.addData("empty_obj := OBJECT [];")
+				.addData("x := 1; APPLICABILITY x := TRUTH VALUE 0.4;")
+				.addData("y := 2.0; APPLICABILITY y := TRUE;")
+				.toString();
+
+		/*
+		 * Applicability of objects returns NULL sometimes, but the
+		 * specification also says "Since null is not allowed as degree of
+		 * applicability, a value is always returned".
+		 */
+
+		String noAttrs = new ArdenCodeBuilder(data)
+				.addData("result := NEW empty_obj;")
+				.addAction("RETURN APPLICABILITY OF result;")
+				.toString();
+		assertReturns(noAttrs, "NULL");
+
+		String attrTime = new ArdenCodeBuilder(data)
+				.addData("result := NEW obj WITH x, x;")
+				.addAction("RETURN (APPLICABILITY OF result.attr1) IS WITHIN TRUTH VALUE 0.39 TO TRUTH VALUE 0.41;")
+				.toString();
+		assertReturns(attrTime, "TRUE");
+
+		String sameAttrTimes = new ArdenCodeBuilder(data)
+				.addData("result := NEW obj WITH x, x;")
+				.addAction("RETURN (APPLICABILITY OF result) IS WITHIN TRUTH VALUE 0.39 TO TRUTH VALUE 0.41;")
+				.toString();
+		assertReturns(sameAttrTimes, "TRUE");
+
+		String differentAttrTimes = new ArdenCodeBuilder(data)
+				.addData("result := NEW obj WITH x, y;")
+				.addAction("RETURN APPLICABILITY OF result;")
+				.toString();
+		assertReturns(differentAttrTimes, "NULL");
+
+		String listAttr = new ArdenCodeBuilder(data)
+				.addData("result := NEW obj WITH x, (x,x);")
+				.addAction("RETURN APPLICABILITY OF result;")
+				.toString();
+		assertReturns(listAttr, "NULL");
+
+		/*
+		 * Is "APPLICABILITY OF result.value := ..." valid? It is given as an
+		 * example in the specification, but the the grammar rule
+		 * <<applicability_becomes>> only allows <identifier> not
+		 * <identifier_or_object_ref>. Also "value" is a reserved word.
+		 */
+	}
+
+}

--- a/test/arden/tests/specification/operators/GeneralPropertiesTest.java
+++ b/test/arden/tests/specification/operators/GeneralPropertiesTest.java
@@ -2,9 +2,9 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
-import arden.tests.specification.testcompiler.ArdenCodeBuilder;
+import arden.tests.specification.testcompiler.ArdenVersion;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
-import arden.tests.specification.testcompiler.TestCompilerException;
 
 public class GeneralPropertiesTest extends SpecificationTest {
 
@@ -19,38 +19,6 @@ public class GeneralPropertiesTest extends SpecificationTest {
 	}
 
 	@Test
-	public void testPrecedence() throws Exception {
-		assertEvaluatesTo("1+2*3", "7");
-		
-		assertEvaluatesTo("LENGTH (TRIM \" x  \")", "1");
-		assertInvalidExpression("LENGTH TRIM \" x  \"");
-		
-		// TODO is this really invalid?
-		// the specifications grammar and precedence table seem to be incompatible
-		//assertInvalidExpression("TIME UPPERCASE \" x  \"");
-		assertEvaluatesTo("TIME (UPPERCASE \" x  \")", "NULL");
-		
-		
-		assertEvaluatesTo("(COUNT (SQRT 5)) DAYS BEFORE 2015-01-05T00:00:00", "2015-01-04T00:00:00");
-		assertEvaluatesTo("COUNT SQRT 5 DAYS BEFORE 2015-01-05T00:00:00", "2015-01-04T00:00:00");
-		
-		assertEvaluatesTo("SUBSTRING (FLOOR (SQRT 5)) CHARACTERS STARTING AT (LENGTH OF \"123\") FROM \"abcdefg\"", "\"cd\"");
-		assertEvaluatesTo("SUBSTRING FLOOR SQRT 5 CHARACTERS STARTING AT LENGTH OF \"123\" FROM \"abcdefg\"", "\"cd\"");
-	}
-
-	@Test
-	public void testAssociativity() throws Exception {
-		// left associative
-		assertEvaluatesTo("3-4-5", "-6");
-		
-		// right associative
-		assertEvaluatesTo("FLOOR ABS SQRT 5", "2");
-		
-		// non associative
-		assertInvalidExpression("2**3**4");
-	}
-
-	@Test
 	public void testPrimaryTimeHandling() throws Exception {
 		String data = createCodeBuilder()
 				.addData("w := 1;")
@@ -58,23 +26,49 @@ public class GeneralPropertiesTest extends SpecificationTest {
 				.addData("y := 3; TIME y := TIME x;")
 				.addData("z := 2; TIME z := 1995-01-01T00:00:00;")
 				.toString();
-		
-		assertVariableReturnsTimeWithData(data, "COS x", "1990-01-01T00:00:00");
-		assertVariableReturnsTimeWithData(data, "x * y", "1990-01-01T00:00:00");
-		assertVariableReturnsTimeWithData(data, "x > y", "1990-01-01T00:00:00");
-		assertVariableReturnsTimeWithData(data, "x * z", "NULL");
-		assertVariableReturnsTimeWithData(data, "y * w", "NULL");
+
+		assertEvaluatesToWithData(data, "TIME COS x", "1990-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME (x * y)", "1990-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME (x > y)", "1990-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME (x * z)", "NULL");
+		assertEvaluatesToWithData(data, "TIME (y * w)", "NULL");
 	}
-	
-	/**
-	 * Saves expression into a variable and returns its time
-	 */
-	private void assertVariableReturnsTimeWithData(String data, String expression, String expectedTime)
-			throws TestCompilerException {
-		String time = new ArdenCodeBuilder(data)
-				.addData("v :=" + expression + ";")
-				.addAction("RETURN TIME v;")
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testApplicabilityHandling() throws Exception {
+		assertEvaluatesTo("APPLICABILITY 1", "TRUE");
+		assertEvaluatesTo("APPLICABILITY COS 1", "TRUE");
+
+		// minimum applicability of parameters
+		String data = createCodeBuilder().addData("x := 1;")
+				.addData("y := 2;")
+				.addData("APPLICABILITY x := TRUTH VALUE 0.5;")
+				.addData("APPLICABILITY y := TRUTH VALUE 0.7;")
 				.toString();
-		assertReturns(time, expectedTime);
+		assertEvaluatesToWithData(data, "APPLICABILITY COS y", "TRUE");
+		assertEvaluatesToWithData(data, "APPLICABILITY (x * y)", "truth value 0.5");
+		assertEvaluatesToWithData(data, "APPLICABILITY (y * x)", "truth value 0.5");
+	}
+
+	@Test
+	public void testPrecedence() throws Exception {
+		assertEvaluatesTo("1+2*3", "7");
+		assertEvaluatesTo("(COUNT (SQRT 5)) DAYS BEFORE 2015-01-05T00:00:00", "2015-01-04T00:00:00");
+		assertEvaluatesTo("COUNT SQRT 5 DAYS BEFORE 2015-01-05T00:00:00", "2015-01-04T00:00:00");
+	}
+
+	@Test
+	public void testAssociativity() throws Exception {
+		// left associative
+		assertEvaluatesTo("3-4-5", "-6");
+
+		// right associative
+		assertEvaluatesTo("ABS SQRT LOG10 10000", "2");
+
+		// non associative
+		assertInvalidExpression("2**3**4");
+		assertEvaluatesTo("(2**3)**4", "4096");
+
 	}
 }

--- a/test/arden/tests/specification/operators/GeneralPropertiesTest.java
+++ b/test/arden/tests/specification/operators/GeneralPropertiesTest.java
@@ -52,7 +52,7 @@ public class GeneralPropertiesTest extends SpecificationTest {
 
 	@Test
 	public void testPrimaryTimeHandling() throws Exception {
-		String data = new ArdenCodeBuilder()
+		String data = createCodeBuilder()
 				.addData("w := 1;")
 				.addData("x := 5; TIME x := 1990-01-01T00:00:00;")
 				.addData("y := 3; TIME y := TIME x;")

--- a/test/arden/tests/specification/operators/IsComparisonOperatorsTest.java
+++ b/test/arden/tests/specification/operators/IsComparisonOperatorsTest.java
@@ -2,7 +2,6 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
-import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class IsComparisonOperatorsTest extends SpecificationTest {
@@ -40,7 +39,7 @@ public class IsComparisonOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("2 IS NOT IN (4,5,6)", "TRUE");
 		assertEvaluatesTo("2 IN (4,5,6)", "FALSE");
 		
-		String data = new ArdenCodeBuilder()
+		String data = createCodeBuilder()
 				.addData("x := 5; TIME x := 1990-01-01T00:00:00;")
 				.addData("y := 3; TIME y := 1990-01-02T00:00:00;")
 				.addData("z := 2; TIME z := 1990-01-03T00:00:00;")
@@ -72,7 +71,7 @@ public class IsComparisonOperatorsTest extends SpecificationTest {
 
 	@Test
 	public void testObjectCheck() throws Exception {
-		String pixelObject = new ArdenCodeBuilder()
+		String pixelObject = createCodeBuilder()
 				.addData("Pixel := OBJECT [x, y];")
 				.addData("p := new Pixel;")
 				.toString();

--- a/test/arden/tests/specification/operators/IsComparisonOperatorsTest.java
+++ b/test/arden/tests/specification/operators/IsComparisonOperatorsTest.java
@@ -2,20 +2,40 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
+import arden.tests.specification.testcompiler.ArdenVersion;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class IsComparisonOperatorsTest extends SpecificationTest {
 
 	@Test
-	public void testIsWithinTo() throws Exception {
+	public void testWithinTo() throws Exception {
 		assertEvaluatesTo("3 IS WITHIN 2 TO 5", "TRUE");
 		assertEvaluatesTo("1990-03-10T00:00:00 IS WITHIN 1990-03-05T00:00:00 TO 1990-03-15T00:00:00", "TRUE");
 		assertEvaluatesTo("3 DAYS WERE WITHIN 2 DAYS TO 5 MONTHS", "TRUE");
 		assertEvaluatesTo("\"ccc\" WAS WITHIN \"a\" TO \"d\"", "TRUE");
+		assertEvaluatesTo("(1,2) IS WITHIN (0,2) TO (3,4)", "(TRUE,TRUE)");
+		assertEvaluatesTo("(1,2) IS WITHIN 2 TO (3,4)", "(FALSE,TRUE)");
 	}
 
 	@Test
-	public void testIsWithin() throws Exception {
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testWithinToTimeOfDay() throws Exception {
+		assertEvaluatesTo("2000-06-06T13:00:00 IS WITHIN 12:30:00 TO 14:00:00", "TRUE");
+		assertEvaluatesTo("2000-06-06T13:00:00 IS WITHIN 13:30:00 TO 22:00:00", "FALSE");
+		assertEvaluatesTo("2000-06-06T01:00:00 IS WITHIN 22:00:00 TO 02:00:00", "TRUE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testWithinToDayOfWeek() throws Exception {
+		assertEvaluatesTo("WEDNESDAY IS WITHIN MONDAY TO FRIDAY", "TRUE");
+		assertEvaluatesTo("WEDNESDAY IS WITHIN FRIDAY TO SUNDAY", "FALSE");
+		assertEvaluatesTo("SUNDAY IS WITHIN SATURDAY TO MONDAY", "FALSE");
+	}
+
+	@Test
+	public void testWithin() throws Exception {
 		assertEvaluatesTo("1990-03-08T00:00:00 WERE WITHIN 3 days PRECEDING 1990-03-10T00:00:00", "TRUE");
 		assertEvaluatesTo("1990-03-08T00:00:00 IS WITHIN 3 days FOLLOWING 1990-03-10T00:00:00", "FALSE");
 		assertEvaluatesTo("1990-03-08T00:00:00 IS WITHIN 3 days SURROUNDING 1990-03-10T00:00:00", "TRUE");
@@ -24,21 +44,55 @@ public class IsComparisonOperatorsTest extends SpecificationTest {
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testWithinTimeOfDay() throws Exception {
+		assertEvaluatesTo("1990-03-10T15:00:00 IS WITHIN 5 HOURS PRECEDING 17:00:00", "TRUE");
+		assertEvaluatesTo("1990-03-10T15:00:00 IS WITHIN 1 HOUR PRECEDING 17:00:00", "FALSE");
+		assertEvaluatesTo("1990-03-10T15:00:00 IS WITHIN 2 HOURS FOLLOWING 14:00:00", "TRUE");
+		assertEvaluatesTo("1990-03-10T15:00:00 IS WITHIN 30 MINUTES FOLLOWING 14:00:00", "FALSE");
+		assertEvaluatesTo("1990-03-10T15:00:00 IS WITHIN 2 HOURS SURROUNDING 16:00:00", "TRUE");
+		assertEvaluatesTo("1990-03-10T15:00:00 IS WITHIN 2 HOURS SURROUNDING 14:00:00", "TRUE");
+		assertEvaluatesTo("1990-03-10T15:00:00 IS WITHIN 1 HOUR SURROUNDING 13:00:00", "FALSE");
+		assertEvaluatesTo("1990-03-10T15:00:00 IS WITHIN SAME DAY AS 15:00:00", "NULL");
+		assertEvaluatesTo("15:00:00 IS WITHIN SAME DAY AS 1990-03-10T15:00:00", "NULL");
+		assertEvaluatesTo("16:00:00 IS WITHIN PAST 5 DAYS", "NULL");
+	}
+
+	@Test
 	public void testBeforeAfter() throws Exception {
 		assertEvaluatesTo("1990-03-08T00:00:00 IS BEFORE 1990-03-07T00:00:00", "FALSE");
 		assertEvaluatesTo("1990-03-08T00:00:00 IS AFTER 1990-03-07T00:00:00", "TRUE");
 		assertEvaluatesTo("1990-03-08T00:00:00 IS BEFORE 1990-03-08T00:00:01", "TRUE");
 		assertEvaluatesTo("1990-03-08T00:00:02 IS BEFORE 1990-03-08T00:00:01", "FALSE");
+
+		// not inclusive
+		assertEvaluatesTo("1990-03-08T00:50:00 IS BEFORE 1990-03-08T00:50:00", "FALSE");
+		assertEvaluatesTo("1990-03-08T00:50:00 IS AFTER 1990-03-08T00:50:00", "FALSE");
 	}
 
 	@Test
-	public void testIn() throws Exception {
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testBeforeAfterTimeOfDay() throws Exception {
+		assertEvaluatesTo("1990-03-08T05:00:00 IS AFTER 18:00:00", "FALSE");
+		assertEvaluatesTo("1990-03-08T05:00:00 IS BEFORE 18:00:00", "TRUE");
+		assertEvaluatesTo("1990-03-08T20:00:00 IS AFTER 18:00:00", "TRUE");
+		assertEvaluatesTo("1990-03-08T20:00:00 IS BEFORE 18:00:00", "FALSE");
+
+		// not inclusive
+		assertEvaluatesTo("1990-03-08T18:00:00 IS BEFORE 18:00:00", "FALSE");
+		assertEvaluatesTo("1990-03-08T18:00:00 IS BEFORE 18:00:00", "FALSE");
+	}
+
+	@Test
+	public void testIsIn() throws Exception {
+		assertEvaluatesTo("2 IS IN (3,2,6)", "TRUE");
 		assertEvaluatesTo("2 IS IN (4,5,6)", "FALSE");
 		assertEvaluatesTo("(3,4) IS IN (4,5,6)", "(FALSE,TRUE)");
-		assertEvaluatesTo("NULL IN (1/0,2)", "TRUE");
+		assertEvaluatesTo("(1,2,3) IS IN (0,3)", "(FALSE,FALSE,TRUE)");
+		assertEvaluatesTo("NULL IS IN (1/0,2)", "TRUE");
 		assertEvaluatesTo("2 IS NOT IN (4,5,6)", "TRUE");
-		assertEvaluatesTo("2 IN (4,5,6)", "FALSE");
-		
+		assertEvaluatesTo("2 IS IN (4,5,6)", "FALSE");
+
 		String data = createCodeBuilder()
 				.addData("x := 5; TIME x := 1990-01-01T00:00:00;")
 				.addData("y := 3; TIME y := 1990-01-02T00:00:00;")
@@ -46,6 +100,31 @@ public class IsComparisonOperatorsTest extends SpecificationTest {
 				.toString();
 		assertEvaluatesToWithData(data, "TIME FIRST ((x,y) IS IN (x,y,z))", "1990-01-01T00:00:00");
 		assertEvaluatesToWithData(data, "TIME FIRST ((5,y) IS IN (x,y,z))", "NULL");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testIsInFuzzy() throws Exception {
+		String data = createCodeBuilder()
+				.addData("middle_aged := FUZZY SET (15, truth value 0),(20, truth value 1),(60, truth value 1), (70, truth value 0);")
+				.addData("cook_time := 5 MINUTES FUZZIFIED BY 1 MINUTE;")
+				.toString();
+		assertEvaluatesToWithData(data, "40 IS IN middle_aged", "TRUE");
+		assertEvaluatesToWithData(data, "10 IN middle_aged", "FALSE");
+		assertEvaluatesToWithData(data, "(17.5 IS IN middle_aged) IS WITHIN TRUTH VALUE 0.49 TO TRUTH VALUE 0.51", "TRUE");
+		assertEvaluatesToWithData(data, "5 MINUTES IS IN cook_time", "TRUE");
+		assertEvaluatesToWithData(data, "(5.5 MINUTES IS IN cook_time) IS WITHIN TRUTH VALUE 0.49 TO TRUTH VALUE 0.51", "TRUE");
+		assertEvaluatesToWithData(data, "2 HOURS IS IN cook_time", "FALSE");
+		assertEvaluatesToWithData(data, "(4 IS IN 5 FUZZIFIED BY 2) IS WITHIN TRUTH VALUE 0.49 TO TRUTH VALUE 0.51", "TRUE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_1)
+	public void testIn() throws Exception {
+		assertEvaluatesTo("2 IN (3,2,6)", "TRUE");
+		assertEvaluatesTo("2 IN (4,5,6)", "FALSE");
+		assertEvaluatesTo("2 NOT IN (4,5,6)", "TRUE");
+		assertEvaluatesTo("NULL IN (1/0,2)", "TRUE");
 	}
 
 	@Test
@@ -57,8 +136,9 @@ public class IsComparisonOperatorsTest extends SpecificationTest {
 	}
 
 	@Test
-	public void testTypeCheck() throws Exception {
+	public void testType() throws Exception {
 		assertEvaluatesTo("FALSE IS BOOLEAN", "TRUE");
+		assertEvaluatesTo("FALSE IS NOT BOOLEAN", "FALSE");
 		assertEvaluatesTo("NULL IS BOOLEAN", "FALSE");
 		assertEvaluatesTo("(NULL, FALSE, \"asdf\") IS BOOLEAN", "(FALSE,TRUE,FALSE)");
 		assertEvaluatesTo("3 IS NUMBER", "TRUE");
@@ -70,13 +150,80 @@ public class IsComparisonOperatorsTest extends SpecificationTest {
 	}
 
 	@Test
-	public void testObjectCheck() throws Exception {
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testTypeTruthValue() throws Exception {
+		assertEvaluatesTo("TRUTH VALUE 1 IS BOOLEAN", "TRUE");
+		assertEvaluatesTo("TRUTH VALUE 0 IS BOOLEAN", "TRUE");
+		assertEvaluatesTo("TRUTH VALUE 0.5 IS BOOLEAN", "FALSE");
+		assertEvaluatesTo("TRUTH VALUE 0.5 IS TRUTH VALUE", "TRUE");
+		assertEvaluatesTo("TRUTH VALUE 0.5 IS NOT TRUTH VALUE", "FALSE");
+		assertEvaluatesTo("3 IS TRUTH VALUE", "FALSE");
+		assertEvaluatesTo("TRUTH VALUE 1 IS TRUTH VALUE", "TRUE");
+		assertEvaluatesTo("TRUE IS TRUTH VALUE", "TRUE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testTypeTimeOfDay() throws Exception {
+		assertEvaluatesTo("20:00:00 IS TIME", "FALSE");
+		assertEvaluatesTo("20:00:00 IS TIME OF DAY", "TRUE");
+		assertEvaluatesTo("10:30:12.123 IS TIME OF DAY", "TRUE");
+		assertEvaluatesTo("1990-01-01T20:00:00 IS TIME OF DAY", "FALSE");
+		assertEvaluatesTo("NULL IS TIME OF DAY", "FALSE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testTypeLinguisticVariable() throws Exception {
+		String data = createCodeBuilder()
+				.addData("RangeOfAge := LINGUISTIC VARIABLE [young, middleAge, old];")
+				.addData("Age := new RangeOfAge;")
+				.addData("Age.young := FUZZY SET (0 YEARS, TRUE), (25 YEARS, TRUE),(35 YEARS, FALSE);")
+				.addData("Age.middleAge := FUZZY SET (25 YEARS, FALSE), (35 YEARS, TRUE), (55 YEARS, TRUE), (65 YEARS, FALSE);")
+				.addData("Age.old := FUZZY SET (55 YEARS, FALSE), (65 YEARS, TRUE);")
+				.toString();
+		assertEvaluatesToWithData(data, "RangeOfAge IS LINGUISTIC VARIABLE", "TRUE");
+		assertEvaluatesTo("3 IS LINGUISTIC VARIABLE", "FALSE");
+		assertEvaluatesTo("3 IS NOT LINGUISTIC VARIABLE", "TRUE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_5)
+	public void testTypeObject() throws Exception {
 		String pixelObject = createCodeBuilder()
 				.addData("Pixel := OBJECT [x, y];")
-				.addData("p := new Pixel;")
+				.addData("Image := OBJECT [pixel_list];")
+				.addData("p := NEW Pixel;")
 				.toString();
-		
 		assertEvaluatesToWithData(pixelObject, "p IS OBJECT", "TRUE");
 		assertEvaluatesToWithData(pixelObject, "p IS Pixel", "TRUE");
+		assertEvaluatesToWithData(pixelObject, "p IS Image", "FALSE");
+		assertEvaluatesToWithData(pixelObject, "3 IS Image", "FALSE");
+		assertEvaluatesTo("3 IS OBJECT", "FALSE");
 	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testTypeFuzzy() throws Exception {
+		assertEvaluatesTo("3 IS FUZZY", "FALSE");
+		assertEvaluatesTo("3 IS NOT FUZZY", "TRUE");
+		assertEvaluatesTo("TRUTH VALUE 0.5 IS FUZZY", "FALSE");
+		assertEvaluatesTo("(FUZZY SET (0, TRUTH VALUE 0), (1, TRUTH VALUE 1)) IS FUZZY", "TRUE");
+		assertEvaluatesTo("(2000-01-01T00:00:00 FUZZIFIED BY 2 days) IS FUZZY", "TRUE");
+		assertEvaluatesTo("(1 WEEK FUZZIFIED BY 2 days) IS FUZZY", "TRUE");
+		assertEvaluatesTo("(1 WEEK FUZZIFIED BY 2 days) IS NOT FUZZY", "FALSE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testTypeCrisp() throws Exception {
+		assertEvaluatesTo("3 IS CRISP", "TRUE");
+		assertEvaluatesTo("3 IS NOT CRISP", "FALSE");
+		assertEvaluatesTo("TRUTH VALUE 0.5 IS CRISP", "TRUE");
+		assertEvaluatesTo("(FUZZY SET (0, TRUTH VALUE 0), (1, TRUTH VALUE 1)) IS CRISP", "FALSE");
+		assertEvaluatesTo("(2000-01-01T00:00:00 FUZZIFIED BY 2 days) IS CRISP", "FALSE");
+		assertEvaluatesTo("(1 WEEK FUZZIFIED BY 2 days) IS CRISP", "FALSE");
+		assertEvaluatesTo("(1 WEEK FUZZIFIED BY 2 days) IS NOT CRISP", "TRUE");
+	}
+
 }

--- a/test/arden/tests/specification/operators/ListOperatorsTest.java
+++ b/test/arden/tests/specification/operators/ListOperatorsTest.java
@@ -2,6 +2,8 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
+import arden.tests.specification.testcompiler.ArdenVersion;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class ListOperatorsTest extends SpecificationTest {
@@ -17,7 +19,9 @@ public class ListOperatorsTest extends SpecificationTest {
 
 	@Test
 	public void testConcatenation() throws Exception {
+		assertEvaluatesTo("1,2", "(1,2)");
 		assertEvaluatesTo("(1,2), 3", "(1,2,3)");
+		assertEvaluatesTo("1, (3,4)", "(1,3,4)");
 	}
 
 	@Test
@@ -36,6 +40,7 @@ public class ListOperatorsTest extends SpecificationTest {
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testSortData() throws Exception {
 		assertEvaluatesTo("SORT (3,2,1)", "(1,2,3)");
 		assertEvaluatesTo("SORT DATA (3,2,1)", "(1,2,3)");
@@ -45,6 +50,7 @@ public class ListOperatorsTest extends SpecificationTest {
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testSortTime() throws Exception {
 		String data = createData();
 		assertEvaluatesToWithData(data, "SORT TIME (y,x)", "(1,2)");
@@ -52,6 +58,60 @@ public class ListOperatorsTest extends SpecificationTest {
 		assertEvaluatesToWithData(data, "SORT TIME (data1, 5)", "NULL");
 		assertEvaluatesToWithData(data, "SORT TIME ()", "()");
 	}
-	
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testSortApplicability() throws Exception {
+		String data = createCodeBuilder()
+				.addData("x := 1; APPLICABILITY x := TRUTH VALUE 0.3;")
+				.addData("y := 2; APPLICABILITY y := TRUTH VALUE 0.9;")
+				.addData("z := 3; APPLICABILITY z := FALSE;")
+				.addData("data2 := (x,y);")
+				.toString();
+		assertEvaluatesToWithData(data, "SORT APPLICABILITY (x,y,z)", "(3,1,2)");
+		assertEvaluatesToWithData(data, "SORT APPLICABILITY (x,y,5)", "(1,2,3)");
+
+		/*
+		 * The example implies that NULL has NULL as applicability, but the
+		 * specification also says "Since null is not allowed as degree of
+		 * applicability, a value is always returned".
+		 */
+		// assertEvaluatesTo("SORT APPLICABILITY (3,1,2,NULL)", "NULL");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_8)
+	public void testSortUsing() throws Exception {
+		String data = createData();
+		assertEvaluatesToWithData(data, "SORT (x,y) USING TIME OF IT", "(1,2)");
+		assertEvaluatesTo("SORT (3,2,1) USING IT", "(1,2,3)");
+		assertEvaluatesTo("SORT (20:00:00,10:00:00,15:00:00) USING EXTRACT HOUR IT", "(10:00:00,15:00:00,20:00:00)");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_8)
+	public void testAddTo() throws Exception {
+		assertEvaluatesTo("ADD 4 TO (1,2,3)", "(1,2,3,4)");
+		assertEvaluatesTo("ADD NULL TO (1,2,3) AT 2", "(1,NULL,2,3)");
+		assertEvaluatesTo("ADD NULL TO (1,2,3) AT 1+1", "(1,NULL,2,3)");
+		assertEvaluatesTo("ADD \"xyz\" TO NULL", "(NULL,\"xyz\")");
+		assertEvaluatesTo("ADD \"xyz\" TO NULL", "(NULL,\"xyz\")");
+		assertEvaluatesTo("ADD 4 TO (1,2,3) AT 5", "(1,2,3,4)");
+		assertEvaluatesTo("ADD 4 TO (1,2,3) AT 0", "(4,1,2,3)");
+		assertEvaluatesTo("ADD 4 TO (1,2,3) AT (-1)", "(4,1,2,3)");
+		assertEvaluatesTo("ADD 4 TO (1,2,3) AT (1,2)", "(4,1,4,2,3)");
+		assertEvaluatesTo("ADD (4,5) TO (1,2,3)", "(1,2,3,4,5)");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_8)
+	public void testRemoveFrom() throws Exception {
+		assertEvaluatesTo("REMOVE 1 FROM (3,2,1)", "(2,1)");
+		assertEvaluatesTo("REMOVE (2,4) FROM (5,4,3,2,1)", "(5,3,1)");
+		assertEvaluatesTo("REMOVE NULL FROM (1,2,3)", "(1,2,3)");
+		assertEvaluatesTo("REMOVE 5 FROM (1,2,3)", "(1,2,3)");
+		assertEvaluatesTo("REMOVE 2 FROM NULL", "(,NULL)");
+		assertEvaluatesTo("REMOVE 1 FROM NULL", "()");
+	}
 
 }

--- a/test/arden/tests/specification/operators/ListOperatorsTest.java
+++ b/test/arden/tests/specification/operators/ListOperatorsTest.java
@@ -2,10 +2,18 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
-import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class ListOperatorsTest extends SpecificationTest {
+
+	private String createData() {
+		return createCodeBuilder()
+				.addData("data1 := 3; TIME data1 := 1991-01-02T00:00:00;")
+				.addData("x := 1; TIME x := 1991-01-01T00:00:00;")
+				.addData("y := 2; TIME y := 1991-01-03T00:00:00;")
+				.addData("data2 := (x,y);")
+				.toString();
+	}
 
 	@Test
 	public void testConcatenation() throws Exception {
@@ -20,13 +28,7 @@ public class ListOperatorsTest extends SpecificationTest {
 
 	@Test
 	public void testMerge() throws Exception {
-		String data = new ArdenCodeBuilder()
-				.addData("data1 := 3; TIME data1 := 1991-01-02T00:00:00;")
-				.addData("x := 1; TIME x := 1991-01-01T00:00:00;")
-				.addData("y := 2; TIME y := 1991-01-03T00:00:00;")
-				.addData("data2 := (x,y);")
-				.toString();
-		
+		String data = createData();
 		assertEvaluatesToWithData(data, "data1 MERGE data2", "(1,3,2)");
 		assertEvaluatesToWithData(data, "(1,2) MERGE (3,4)", "NULL");
 		assertEvaluatesToWithData(data, "(data1, 4) MERGE data2", "NULL");
@@ -44,13 +46,7 @@ public class ListOperatorsTest extends SpecificationTest {
 
 	@Test
 	public void testSortTime() throws Exception {
-		String data = new ArdenCodeBuilder()
-				.addData("data1 := 3; TIME data1 := 1991-01-02T00:00:00;")
-				.addData("x := 1; TIME x := 1991-01-01T00:00:00;")
-				.addData("y := 2; TIME y := 1991-01-03T00:00:00;")
-				.addData("data2 := (x,y);")
-				.toString();
-		
+		String data = createData();
 		assertEvaluatesToWithData(data, "SORT TIME (y,x)", "(1,2)");
 		assertEvaluatesToWithData(data, "SORT TIME (data1, data2)", "(1,3,2)");
 		assertEvaluatesToWithData(data, "SORT TIME (data1, 5)", "NULL");

--- a/test/arden/tests/specification/operators/LogicalOperatorsTest.java
+++ b/test/arden/tests/specification/operators/LogicalOperatorsTest.java
@@ -2,6 +2,8 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
+import arden.tests.specification.testcompiler.ArdenVersion;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class LogicalOperatorsTest extends SpecificationTest {
@@ -23,12 +25,50 @@ public class LogicalOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("TRUE AND TRUE", "TRUE");
 		assertEvaluatesTo("TRUE AND NULL", "NULL");
 		assertEvaluatesTo("FALSE AND NULL", "FALSE");
+		assertEvaluatesTo("NULL AND FALSE", "FALSE");
 	}
 
 	@Test
 	public void testNot() throws Exception {
 		assertEvaluatesTo("NOT FALSE", "TRUE");
+		assertEvaluatesTo("NOT 5", "NULL");
 		assertEvaluatesTo("NOT NULL", "NULL");
+		assertEvaluatesTo("NOT (FALSE, TRUE)", "(TRUE,FALSE)");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testOrTruthValue() throws Exception {
+		assertEvaluatesTo("TRUTH VALUE 0.1 OR TRUTH VALUE 0.7", "truth value 0.7");
+		assertEvaluatesTo("TRUTH VALUE 0.7 OR TRUTH VALUE 0.1", "truth value 0.7");
+		assertEvaluatesTo("TRUTH VALUE 0.1 OR TRUTH VALUE 1", "TRUE");
+		assertEvaluatesTo("FALSE OR TRUTH VALUE 0.3", "truth value 0.3");
+		assertEvaluatesTo("TRUE OR TRUTH VALUE 0.3", "TRUE");
+		assertEvaluatesTo("FALSE OR TRUTH VALUE 0", "FALSE");
+		assertEvaluatesTo("TRUTH VALUE 0.5 OR 5", "NULL");
+		assertEvaluatesTo("TRUTH VALUE 0.5 OR NULL", "NULL");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testAndTruthValue() throws Exception {
+		assertEvaluatesTo("TRUTH VALUE 0.1 AND TRUTH VALUE 0.7", "truth value 0.1");
+		assertEvaluatesTo("TRUTH VALUE 0.7 AND TRUTH VALUE 0.1", "truth value 0.1");
+		assertEvaluatesTo("TRUTH VALUE 0.1 AND TRUTH VALUE 1", "truth value 0.1");
+		assertEvaluatesTo("FALSE AND TRUTH VALUE 0.3", "FALSE");
+		assertEvaluatesTo("TRUE AND TRUTH VALUE 0.3", "truth value 0.3");
+		assertEvaluatesTo("FALSE AND TRUTH VALUE 0", "FALSE");
+		assertEvaluatesTo("TRUTH VALUE 0.5 AND 5", "NULL");
+		assertEvaluatesTo("TRUTH VALUE 0.5 AND NULL", "NULL");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testNotTruthValue() throws Exception {
+		assertEvaluatesTo("NOT TRUTH VALUE 0.4", "TRUTH VALUE 0.6");
+		assertEvaluatesTo("NOT TRUTH VALUE 0.6", "TRUTH VALUE 0.4");
+		assertEvaluatesTo("NOT TRUTH VALUE 1", "FALSE");
+		assertEvaluatesTo("NOT TRUTH VALUE 0", "TRUE");
 	}
 
 }

--- a/test/arden/tests/specification/operators/NumericFunctionOperatorsTest.java
+++ b/test/arden/tests/specification/operators/NumericFunctionOperatorsTest.java
@@ -2,7 +2,6 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
-import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class NumericFunctionOperatorsTest extends SpecificationTest {
@@ -66,7 +65,9 @@ public class NumericFunctionOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("() AS NUMBER","()");
 		
 		// primary time is preserved
-		String data = new ArdenCodeBuilder().addData("x := \"5\"; TIME x := 1997-10-31T00:00:00;").toString();
+		String data = createCodeBuilder()
+				.addData("x := \"5\"; TIME x := 1997-10-31T00:00:00;")
+				.toString();
 		assertEvaluatesToWithData(data, "TIME (x AS NUMBER)", "1997-10-31T00:00:00");
 	}
 	

--- a/test/arden/tests/specification/operators/NumericFunctionOperatorsTest.java
+++ b/test/arden/tests/specification/operators/NumericFunctionOperatorsTest.java
@@ -2,73 +2,59 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
+import arden.tests.specification.testcompiler.ArdenVersion;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class NumericFunctionOperatorsTest extends SpecificationTest {
 
 	@Test
 	public void testNumericFunctions() throws Exception {
-		assertEvaluatesTo("ARCCOS 1","0");
-		assertEvaluatesTo("ARCCOS (-1) FORMATTED WITH \"%.2f\"", "\"3.14\"");
-		assertEvaluatesTo("ARCSIN 0","0");
-		assertEvaluatesTo("ARCSIN .5 FORMATTED WITH \"%.2f\"", "\"0.52\"");
-		assertEvaluatesTo("ARCTAN 0","0");
-		assertEvaluatesTo("ARCTAN .5 FORMATTED WITH \"%.2f\"", "\"0.46\"");
-		assertEvaluatesTo("COSINE 0","1");
-		assertEvaluatesTo("COS 0","1");
-		assertEvaluatesTo("SINE 0","0");
-		assertEvaluatesTo("SIN 0","0");
-		assertEvaluatesTo("TANGENT 0","0");
-		assertEvaluatesTo("TAN 0","0");
-		assertEvaluatesTo("EXP 0","1");
-		assertEvaluatesTo("LOG 1","0");
-		assertEvaluatesTo("LOG 10 FORMATTED WITH \"%.2f\"", "\"2.30\"");
-		assertEvaluatesTo("LOG 0","NULL");
-		assertEvaluatesTo("LOG10 100","2");
-		assertEvaluatesTo("SQRT 4","2");
-		assertEvaluatesTo("SQRT(-1)","NULL");
-		assertEvaluatesTo("ABS (-1.5)","1.5");
+		assertEvaluatesTo("ARCCOS 1", "0");
+		assertEvaluatesTo("ARCCOS (-1) IS WITHIN 3.141 TO 3.142", "TRUE");
+		assertEvaluatesTo("ARCSIN 0", "0");
+		assertEvaluatesTo("ARCSIN .5 IS WITHIN 0.523 TO 0.524", "TRUE");
+		assertEvaluatesTo("ARCTAN 0", "0");
+		assertEvaluatesTo("ARCTAN .5 IS WITHIN 0.463 TO 0.464", "TRUE");
+		assertEvaluatesTo("COSINE 0", "1");
+		assertEvaluatesTo("COS 0", "1");
+		assertEvaluatesTo("SINE 0", "0");
+		assertEvaluatesTo("SIN 0", "0");
+		assertEvaluatesTo("TANGENT 0", "0");
+		assertEvaluatesTo("TAN 0", "0");
+		assertEvaluatesTo("EXP 0", "1");
+		assertEvaluatesTo("LOG 1", "0");
+		assertEvaluatesTo("LOG 10 IS WITHIN 2.302 TO 2.303", "TRUE");
+		assertEvaluatesTo("LOG 0", "NULL");
+		assertEvaluatesTo("LOG10 100", "2");
+		assertEvaluatesTo("SQRT 4", "2");
+		assertEvaluatesTo("SQRT(-1)", "NULL");
+		assertEvaluatesTo("ABS (-1.5)", "1.5");
 	}
-	
+
 	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testRounding() throws Exception {
-		assertEvaluatesTo("INT (-1.5)","-2");
-		assertEvaluatesTo("INT (-2.0)","-2");
-		assertEvaluatesTo("INT (1.5)","1");
-		assertEvaluatesTo("FLOOR (-2.5)","-3");
-		assertEvaluatesTo("FLOOR (-3.1)","-4");
-		assertEvaluatesTo("FLOOR (-4)","-4");
-		assertEvaluatesTo("CEILING (-1.5)","-1");
-		assertEvaluatesTo("CEILING (-1.0)","-1");
-		assertEvaluatesTo("CEILING 1.5","2");
-		assertEvaluatesTo("CEILING (-2.5)","-2");
-		assertEvaluatesTo("CEILING (-3.9)","-3");
-		assertEvaluatesTo("TRUNCATE (-1.5)","-1");
-		assertEvaluatesTo("TRUNCATE (-1.0)","-1");
-		assertEvaluatesTo("TRUNCATE 1.5","1");
-		assertEvaluatesTo("ROUND 0.5","1");
-		assertEvaluatesTo("ROUND 3.4","3");
-		assertEvaluatesTo("ROUND 3.5","4");
-		assertEvaluatesTo("ROUND (-3.5)","-4");
-		assertEvaluatesTo("ROUND (-3.4)","-3");
-		assertEvaluatesTo("ROUND (-3.7)","-4");
+		assertEvaluatesTo("INT (-1.5)", "-2");
+		assertEvaluatesTo("INT (-2.0)", "-2");
+		assertEvaluatesTo("INT (1.5)", "1");
+		assertEvaluatesTo("FLOOR (-2.5)", "-3");
+		assertEvaluatesTo("FLOOR (-3.1)", "-4");
+		assertEvaluatesTo("FLOOR (-4)", "-4");
+		assertEvaluatesTo("CEILING (-1.5)", "-1");
+		assertEvaluatesTo("CEILING (-1.0)", "-1");
+		assertEvaluatesTo("CEILING 1.5", "2");
+		assertEvaluatesTo("CEILING (-2.5)", "-2");
+		assertEvaluatesTo("CEILING (-3.9)", "-3");
+		assertEvaluatesTo("TRUNCATE (-1.5)", "-1");
+		assertEvaluatesTo("TRUNCATE (-1.0)", "-1");
+		assertEvaluatesTo("TRUNCATE 1.5", "1");
+		assertEvaluatesTo("ROUND 0.5", "1");
+		assertEvaluatesTo("ROUND 3.4", "3");
+		assertEvaluatesTo("ROUND 3.5", "4");
+		assertEvaluatesTo("ROUND (-3.5)", "-4");
+		assertEvaluatesTo("ROUND (-3.4)", "-3");
+		assertEvaluatesTo("ROUND (-3.7)", "-4");
 	}
-	
-	@Test
-	public void testAsNumber() throws Exception {
-		assertEvaluatesTo("\"5\" AS NUMBER","5");
-		assertEvaluatesTo("\"xyz\" AS NUMBER","NULL");
-		assertEvaluatesTo("TRUE AS NUMBER","1");
-		assertEvaluatesTo("FALSE AS NUMBER","0");
-		assertEvaluatesTo("6 AS NUMBER","6");
-		assertEvaluatesTo("(\"7\", 8, \"2.3E+2\", 4.1E+3, \"ABC\", NULL, TRUE, FALSE, 1997-10-31T00:00:00, now, 3 days) AS NUMBER","(7,8,230,4100,NULL,NULL,1,0,NULL,NULL,NULL)");
-		assertEvaluatesTo("() AS NUMBER","()");
-		
-		// primary time is preserved
-		String data = createCodeBuilder()
-				.addData("x := \"5\"; TIME x := 1997-10-31T00:00:00;")
-				.toString();
-		assertEvaluatesToWithData(data, "TIME (x AS NUMBER)", "1997-10-31T00:00:00");
-	}
-	
+
 }

--- a/test/arden/tests/specification/operators/ObjectOperatorsTest.java
+++ b/test/arden/tests/specification/operators/ObjectOperatorsTest.java
@@ -3,6 +3,8 @@ package arden.tests.specification.operators;
 import org.junit.Test;
 
 import arden.tests.specification.testcompiler.ArdenCodeBuilder;
+import arden.tests.specification.testcompiler.ArdenVersion;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class ObjectOperatorsTest extends SpecificationTest {
@@ -19,18 +21,20 @@ public class ObjectOperatorsTest extends SpecificationTest {
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2_5)
 	public void testDot() throws Exception {
 		String data = createData();
-		assertEvaluatesToWithData(data, "namelist.FirstName","(\"John\",\"Paul\")");
-		assertEvaluatesToWithData(data, "namelist.LastName","(\"Lennon\",\"McCartney\")");
-		assertEvaluatesToWithData(data, "namelist[1].FirstName","\"John\"");
-		assertEvaluatesToWithData(data, "namelist[1].Height","NULL");
-		assertEvaluatesToWithData(data, "namelist.Height","(NULL,NULL)");
-		assertEvaluatesToWithData(data, "LENGTH johnName.FirstName + LENGTH paulName.FirstName","8");
-		assertEvaluatesToWithData(data, "john.FullName.FirstName","\"John\"");
+		assertEvaluatesToWithData(data, "namelist.FirstName", "(\"John\",\"Paul\")");
+		assertEvaluatesToWithData(data, "namelist.LastName", "(\"Lennon\",\"McCartney\")");
+		assertEvaluatesToWithData(data, "namelist[1].FirstName", "\"John\"");
+		assertEvaluatesToWithData(data, "namelist[1].Height", "NULL");
+		assertEvaluatesToWithData(data, "namelist.Height", "(NULL,NULL)");
+		assertEvaluatesToWithData(data, "LENGTH johnName.FirstName + LENGTH paulName.FirstName", "8");
+		assertEvaluatesToWithData(data, "john.FullName.FirstName", "\"John\"");
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2_5)
 	public void testClone() throws Exception {
 		String data = createData();
 
@@ -39,17 +43,17 @@ public class ObjectOperatorsTest extends SpecificationTest {
 				.addAction("RETURN namelist2[3].FirstName;")
 				.toString();
 		assertReturns(list, "\"John\"");
-		
+
 		String deepcopy = new ArdenCodeBuilder(data)
 				.addData("john2 := CLONE OF john;")
 				.addAction("john2.FullName.FirstName := \"John2\";")
 				.addAction("RETURN john.FullName.FirstName <> john2.FullName.FirstName;")
 				.toString();
 		assertReturns(deepcopy, "TRUE");
-		
-		assertEvaluatesTo("CLONE OF 1990-03-15T15:00:00","1990-03-15T15:00:00");
-		assertEvaluatesTo("CLONE NULL","NULL");
-		
+
+		assertEvaluatesTo("CLONE OF 1990-03-15T15:00:00", "1990-03-15T15:00:00");
+		assertEvaluatesTo("CLONE NULL", "NULL");
+
 		String preserveTime = new ArdenCodeBuilder(data)
 				.addData("ringoFirstName := \"Ringo\"; TIME ringoFirstName := 1950-07-07T00:00:00;")
 				.addData("ringoName := NEW Name WITH ringoFirstName, \"Starr\";")
@@ -60,18 +64,20 @@ public class ObjectOperatorsTest extends SpecificationTest {
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2_5)
 	public void testExtract() throws Exception {
 		String data = createData();
-		assertEvaluatesToWithData(data, "EXTRACT ATTRIBUTE NAMES john","(\"FullName\",\"Birthdate\")");
-		assertEvaluatesToWithData(data, "EXTRACT ATTRIBUTE NAMES 5","NULL");
+		assertEvaluatesToWithData(data, "EXTRACT ATTRIBUTE NAMES john", "(\"FullName\",\"Birthdate\")");
+		assertEvaluatesToWithData(data, "EXTRACT ATTRIBUTE NAMES 5", "NULL");
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2_5)
 	public void testAttribute() throws Exception {
 		String data = createData();
-		assertEvaluatesToWithData(data, "ATTRIBUTE \"LastName\" FROM paulName","\"McCartney\"");
-		assertEvaluatesToWithData(data, "ATTRIBUTE \"x\" FROM paulName","NULL");
-		assertEvaluatesTo("ATTRIBUTE \"LastName\" FROM NULL","NULL");
-		assertEvaluatesTo("ATTRIBUTE \"LastName\" FROM 5","NULL");
+		assertEvaluatesToWithData(data, "ATTRIBUTE \"LastName\" FROM paulName", "\"McCartney\"");
+		assertEvaluatesToWithData(data, "ATTRIBUTE \"x\" FROM paulName", "NULL");
+		assertEvaluatesTo("ATTRIBUTE \"LastName\" FROM NULL", "NULL");
+		assertEvaluatesTo("ATTRIBUTE \"LastName\" FROM 5", "NULL");
 	}
 }

--- a/test/arden/tests/specification/operators/ObjectOperatorsTest.java
+++ b/test/arden/tests/specification/operators/ObjectOperatorsTest.java
@@ -6,36 +6,41 @@ import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class ObjectOperatorsTest extends SpecificationTest {
-	
-	private static final String DATA = new ArdenCodeBuilder()
-			.addData("Name := OBJECT [FirstName, LastName];")
-			.addData("johnName := NEW Name WITH \"John\", \"Lennon\";")
-			.addData("paulName := NEW Name WITH \"Paul\", \"McCartney\";")
-			.addData("namelist := (johnName, paulName);")
-			.addData("Person := OBJECT [FullName, Birthdate];")
-			.addData("john := NEW Person WITH johnName, 1940-10-09T00:00:00;")
-			.toString();
-	
+
+	private String createData() {
+		return createCodeBuilder()
+				.addData("Name := OBJECT [FirstName, LastName];")
+				.addData("johnName := NEW Name WITH \"John\", \"Lennon\";")
+				.addData("paulName := NEW Name WITH \"Paul\", \"McCartney\";")
+				.addData("namelist := (johnName, paulName);")
+				.addData("Person := OBJECT [FullName, Birthdate];")
+				.addData("john := NEW Person WITH johnName, 1940-10-09T00:00:00;")
+				.toString();
+	}
+
 	@Test
 	public void testDot() throws Exception {
-		assertEvaluatesToWithData(DATA, "namelist.FirstName","(\"John\",\"Paul\")");
-		assertEvaluatesToWithData(DATA, "namelist.LastName","(\"Lennon\",\"McCartney\")");
-		assertEvaluatesToWithData(DATA, "namelist[1].FirstName","\"John\"");
-		assertEvaluatesToWithData(DATA, "namelist[1].Height","NULL");
-		assertEvaluatesToWithData(DATA, "namelist.Height","(NULL,NULL)");
-		assertEvaluatesToWithData(DATA, "LENGTH johnName.FirstName + LENGTH paulName.FirstName","8");
-		assertEvaluatesToWithData(DATA, "john.FullName.FirstName","\"John\"");
+		String data = createData();
+		assertEvaluatesToWithData(data, "namelist.FirstName","(\"John\",\"Paul\")");
+		assertEvaluatesToWithData(data, "namelist.LastName","(\"Lennon\",\"McCartney\")");
+		assertEvaluatesToWithData(data, "namelist[1].FirstName","\"John\"");
+		assertEvaluatesToWithData(data, "namelist[1].Height","NULL");
+		assertEvaluatesToWithData(data, "namelist.Height","(NULL,NULL)");
+		assertEvaluatesToWithData(data, "LENGTH johnName.FirstName + LENGTH paulName.FirstName","8");
+		assertEvaluatesToWithData(data, "john.FullName.FirstName","\"John\"");
 	}
-	
+
 	@Test
 	public void testClone() throws Exception {
-		String list = new ArdenCodeBuilder(DATA)
+		String data = createData();
+
+		String list = new ArdenCodeBuilder(data)
 				.addData("namelist2 := CLONE (1, 2, namelist);")
 				.addAction("RETURN namelist2[3].FirstName;")
 				.toString();
 		assertReturns(list, "\"John\"");
 		
-		String deepcopy = new ArdenCodeBuilder(DATA)
+		String deepcopy = new ArdenCodeBuilder(data)
 				.addData("john2 := CLONE OF john;")
 				.addAction("john2.FullName.FirstName := \"John2\";")
 				.addAction("RETURN john.FullName.FirstName <> john2.FullName.FirstName;")
@@ -45,7 +50,7 @@ public class ObjectOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("CLONE OF 1990-03-15T15:00:00","1990-03-15T15:00:00");
 		assertEvaluatesTo("CLONE NULL","NULL");
 		
-		String preserveTime = new ArdenCodeBuilder(DATA)
+		String preserveTime = new ArdenCodeBuilder(data)
 				.addData("ringoFirstName := \"Ringo\"; TIME ringoFirstName := 1950-07-07T00:00:00;")
 				.addData("ringoName := NEW Name WITH ringoFirstName, \"Starr\";")
 				.addData("ringoName2 := CLONE ringoName;")
@@ -53,17 +58,19 @@ public class ObjectOperatorsTest extends SpecificationTest {
 				.toString();
 		assertReturns(preserveTime, "1950-07-07T00:00:00");
 	}
-	
+
 	@Test
 	public void testExtract() throws Exception {
-		assertEvaluatesToWithData(DATA, "EXTRACT ATTRIBUTE NAMES john","(\"FullName\",\"Birthdate\")");
-		assertEvaluatesToWithData(DATA, "EXTRACT ATTRIBUTE NAMES 5","NULL");
+		String data = createData();
+		assertEvaluatesToWithData(data, "EXTRACT ATTRIBUTE NAMES john","(\"FullName\",\"Birthdate\")");
+		assertEvaluatesToWithData(data, "EXTRACT ATTRIBUTE NAMES 5","NULL");
 	}
-	
+
 	@Test
 	public void testAttribute() throws Exception {
-		assertEvaluatesToWithData(DATA, "ATTRIBUTE \"LastName\" FROM paulName","\"McCartney\"");
-		assertEvaluatesToWithData(DATA, "ATTRIBUTE \"x\" FROM paulName","NULL");
+		String data = createData();
+		assertEvaluatesToWithData(data, "ATTRIBUTE \"LastName\" FROM paulName","\"McCartney\"");
+		assertEvaluatesToWithData(data, "ATTRIBUTE \"x\" FROM paulName","NULL");
 		assertEvaluatesTo("ATTRIBUTE \"LastName\" FROM NULL","NULL");
 		assertEvaluatesTo("ATTRIBUTE \"LastName\" FROM 5","NULL");
 	}

--- a/test/arden/tests/specification/operators/OccurComparisonOperatorsTest.java
+++ b/test/arden/tests/specification/operators/OccurComparisonOperatorsTest.java
@@ -2,41 +2,43 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
-import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class OccurComparisonOperatorsTest extends SpecificationTest {
 
-	private static final String DATA = new ArdenCodeBuilder()
-			.addData("x := 5; TIME x := 1990-01-01T00:00:00;")
-			.addData("y := 3; TIME y := 1990-01-02T00:00:00;")
-			.addData("z := 2; TIME z := 1990-01-03T00:00:00;")
-			.toString();
+	private String createData() {
+		return createCodeBuilder()
+				.addData("x := 5; TIME x := 1990-01-01T00:00:00;")
+				.addData("y := 3; TIME y := 1990-01-02T00:00:00;")
+				.addData("z := 2; TIME z := 1990-01-03T00:00:00;")
+				.toString();
+	}
 	
 	@Test
 	public void testTimeOfEquivalence() throws Exception {
-		assertEvaluatesToWithData(DATA,
+		assertEvaluatesToWithData(createData(),
 				"(x OCCURRED NOT BEFORE 1990-03-05T11:11:11) = (TIME OF x IS NOT BEFORE 1990-03-05T11:11:11)",
 				"TRUE");
 	}
 
 	@Test
 	public void testWithin() throws Exception {
-		assertEvaluatesToWithData(DATA, "y OCCURRED WITHIN TIME OF x TO TIME OF z", "TRUE");
-		assertEvaluatesToWithData(DATA, "y OCCURRED WITHIN 3 DAYS PRECEDING (1990-03-10T00:00:00,NULL,TIME z)", "(FALSE,NULL,TRUE)");
-		assertEvaluatesToWithData(DATA, "x OCCURRED WITHIN 3 DAYS FOLLOWING (1989-12-31T00:00:00,NULL,TIME z)", "(TRUE,NULL,FALSE)");
-		assertEvaluatesToWithData(DATA, "x OCCURRED WITHIN 3 DAYS SURROUNDING (TIME z,1990-01-02, 1989-12-31)", "(TRUE,TRUE,TRUE)");
-		assertEvaluatesToWithData(DATA,	"z OCCURRED WITHIN SAME DAY AS (FALSE,(TIME z)-1 SECOND,TIME z,1991-01-03)","(NULL,FALSE,TRUE,FALSE)");
+		String data = createData();
+		assertEvaluatesToWithData(data, "y OCCURRED WITHIN TIME OF x TO TIME OF z", "TRUE");
+		assertEvaluatesToWithData(data, "y OCCURRED WITHIN 3 DAYS PRECEDING (1990-03-10T00:00:00,NULL,TIME z)", "(FALSE,NULL,TRUE)");
+		assertEvaluatesToWithData(data, "x OCCURRED WITHIN 3 DAYS FOLLOWING (1989-12-31T00:00:00,NULL,TIME z)", "(TRUE,NULL,FALSE)");
+		assertEvaluatesToWithData(data, "x OCCURRED WITHIN 3 DAYS SURROUNDING (TIME z,1990-01-02, 1989-12-31)", "(TRUE,TRUE,TRUE)");
+		assertEvaluatesToWithData(data,	"z OCCURRED WITHIN SAME DAY AS (FALSE,(TIME z)-1 SECOND,TIME z,1991-01-03)","(NULL,FALSE,TRUE,FALSE)");
 	}
 
 	@Test
 	public void testEqual() throws Exception {
-		assertEvaluatesToWithData(DATA, "x OCCURRED EQUAL TIME OF x", "TRUE");
+		assertEvaluatesToWithData(createData(), "x OCCURRED EQUAL TIME OF x", "TRUE");
 	}
 
 	@Test
 	public void testAt() throws Exception {
-		assertEvaluatesToWithData(DATA, "y OCCURRED AT TIME OF x", "FALSE");
+		assertEvaluatesToWithData(createData(), "y OCCURRED AT TIME OF x", "FALSE");
 	}
 
 }

--- a/test/arden/tests/specification/operators/OccurComparisonOperatorsTest.java
+++ b/test/arden/tests/specification/operators/OccurComparisonOperatorsTest.java
@@ -2,7 +2,9 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
+import arden.tests.specification.testcompiler.ArdenVersion;
 import arden.tests.specification.testcompiler.SpecificationTest;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 
 public class OccurComparisonOperatorsTest extends SpecificationTest {
 
@@ -13,12 +15,10 @@ public class OccurComparisonOperatorsTest extends SpecificationTest {
 				.addData("z := 2; TIME z := 1990-01-03T00:00:00;")
 				.toString();
 	}
-	
+
 	@Test
 	public void testTimeOfEquivalence() throws Exception {
-		assertEvaluatesToWithData(createData(),
-				"(x OCCURRED NOT BEFORE 1990-03-05T11:11:11) = (TIME OF x IS NOT BEFORE 1990-03-05T11:11:11)",
-				"TRUE");
+		assertEvaluatesToWithData(createData(), "(x OCCURRED NOT BEFORE 1990-03-05T11:11:11) = (TIME OF x IS NOT BEFORE 1990-03-05T11:11:11)", "TRUE");
 	}
 
 	@Test
@@ -28,7 +28,7 @@ public class OccurComparisonOperatorsTest extends SpecificationTest {
 		assertEvaluatesToWithData(data, "y OCCURRED WITHIN 3 DAYS PRECEDING (1990-03-10T00:00:00,NULL,TIME z)", "(FALSE,NULL,TRUE)");
 		assertEvaluatesToWithData(data, "x OCCURRED WITHIN 3 DAYS FOLLOWING (1989-12-31T00:00:00,NULL,TIME z)", "(TRUE,NULL,FALSE)");
 		assertEvaluatesToWithData(data, "x OCCURRED WITHIN 3 DAYS SURROUNDING (TIME z,1990-01-02, 1989-12-31)", "(TRUE,TRUE,TRUE)");
-		assertEvaluatesToWithData(data,	"z OCCURRED WITHIN SAME DAY AS (FALSE,(TIME z)-1 SECOND,TIME z,1991-01-03)","(NULL,FALSE,TRUE,FALSE)");
+		assertEvaluatesToWithData(data, "z OCCURRED WITHIN SAME DAY AS (FALSE,(TIME z)-1 SECOND,TIME z,1991-01-03)", "(NULL,FALSE,TRUE,FALSE)");
 	}
 
 	@Test
@@ -37,8 +37,19 @@ public class OccurComparisonOperatorsTest extends SpecificationTest {
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2_1)
 	public void testAt() throws Exception {
 		assertEvaluatesToWithData(createData(), "y OCCURRED AT TIME OF x", "FALSE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testTimeOfDay() throws Exception {
+		String data = createData();
+		assertEvaluatesToWithData(data, "y OCCURRED WITHIN 2 HOURS SURROUNDING 01:00:00", "TRUE");
+		assertEvaluatesToWithData(data, "y OCCURRED WITHIN 5 MINUTES SURROUNDING 01:00:00", "FALSE");
+		assertEvaluatesToWithData(data, "y OCCURRED AT 00:00:00", "TRUE");
+		assertEvaluatesToWithData(data, "y OCCURRED AT 00:00:01", "FALSE");
 	}
 
 }

--- a/test/arden/tests/specification/operators/QueryAggregationOperatorsTest.java
+++ b/test/arden/tests/specification/operators/QueryAggregationOperatorsTest.java
@@ -2,6 +2,8 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
+import arden.tests.specification.testcompiler.ArdenVersion;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class QueryAggregationOperatorsTest extends SpecificationTest {
@@ -19,34 +21,116 @@ public class QueryAggregationOperatorsTest extends SpecificationTest {
 	@Test
 	public void testNearest() throws Exception {
 		String data = createData();
-		assertEvaluatesToWithData(data, "NEAREST (2 days before 1990-03-18T16:00:00) FROM mylist","13");
-		assertEvaluatesToWithData(data, "NEAREST 1990-03-16T16:00:00 FROM a","4");
-		assertEvaluatesToWithData(data, "NEAREST 1990-03-16T16:00:00 FROM (a, 5)","NULL");
-		// element with smallest index when tied 
-		assertEvaluatesToWithData(data, "NEAREST 1990-03-16T16:00:00 FROM (a,mylist)","4");
-		assertEvaluatesTo("NEAREST 1990-03-16T16:00:00 FROM (3,4)","NULL");
-		assertEvaluatesTo("NEAREST 1990-03-16T16:00:00 FROM ()","NULL");
+		assertEvaluatesToWithData(data, "NEAREST (2 days before 1990-03-18T16:00:00) FROM mylist", "13");
+		assertEvaluatesToWithData(data, "NEAREST 1990-03-16T16:00:00 FROM a", "4");
+		assertEvaluatesToWithData(data, "NEAREST 1990-03-16T16:00:00 FROM (a, 5)", "NULL");
+		// element with smallest index when tied
+		assertEvaluatesToWithData(data, "NEAREST 1990-03-16T16:00:00 FROM (a,mylist)", "4");
+		assertEvaluatesTo("NEAREST 1990-03-16T16:00:00 FROM (3,4)", "NULL");
+		assertEvaluatesTo("NEAREST 1990-03-16T16:00:00 FROM ()", "NULL");
+		// primary time preserved
+		assertEvaluatesToWithData(data, "TIME NEAREST (2 days before 1990-03-18T16:00:00) FROM mylist", "1990-03-16T15:00:00");
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testNearestTimeOfDay() throws Exception {
+		String data = createCodeBuilder()
+				.addData("x := 1; TIME x := TODAY ATTIME 08:00:00;")
+				.addData("y := 2; TIME y := TODAY ATTIME 12:00:00;")
+				.addData("z := 3; TIME z := TODAY ATTIME 20:00:00;")
+				.addData("mylist := (x, y, z);")
+				.toString();
+		assertEvaluatesToWithData(data, "NEAREST 08:10:00 FROM mylist", "1");
+		assertEvaluatesToWithData(data, "NEAREST 11:30:00 FROM mylist", "2");
+		assertEvaluatesToWithData(data, "NEAREST 19:00:00 FROM mylist", "3");
+		assertEvaluatesToWithData(data, "NEAREST 20:00:00 FROM mylist", "3");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testIndexNearest() throws Exception {
 		String data = createData();
-		assertEvaluatesToWithData(data, "INDEX NEAREST 1990-03-16T16:00:00 FROM mylist","2");
-		assertEvaluatesTo("INDEX NEAREST 1990-03-16T16:00:00 FROM (3,4)","NULL");
+		assertEvaluatesToWithData(data, "INDEX NEAREST 1990-03-16T16:00:00 FROM mylist", "2");
+		assertEvaluatesTo("INDEX NEAREST 1990-03-16T16:00:00 FROM (3,4)", "NULL");
 		// smallest index when tied
-		assertEvaluatesToWithData(data, "INDEX NEAREST 1990-03-16T16:00:00 FROM (a,mylist)","1");
+		assertEvaluatesToWithData(data, "INDEX NEAREST 1990-03-16T16:00:00 FROM (a,mylist)", "1");
+		// primary time not preserved
+		assertEvaluatesToWithData(data, "TIME (INDEX NEAREST 1990-03-16T16:00:00 FROM mylist)", "NULL");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_8)
+	public void testIndexOf() throws Exception {
+		assertEvaluatesTo("INDEX OF \"x\" FROM (1,2,3,\"x\",\"y\")", "(,4)");
+		assertEvaluatesTo("INDEX OF 2 FROM (1,2,3,\"x\",\"y\")", "(,2)");
+		assertEvaluatesTo("INDEX OF 4 FROM (1,2,3,\"x\",\"y\")", "NULL");
+		assertEvaluatesTo("INDEX OF NULL FROM (1,2,3,\"x\",\"y\")", "NULL");
+		assertEvaluatesTo("INDEX OF 1 FROM NULL", "NULL");
+		assertEvaluatesTo("INDEX OF NULL FROM NULL", "(,1)");
+		assertEvaluatesTo("INDEX OF 2 FROM 2", "(,1)");
+		assertEvaluatesTo("INDEX OF 2 FROM (1,2,1,2,2)", "(2,4,5)");
+		assertEvaluatesTo("INDEX OF NULL FROM (1,NULL,2,NULL)", "(2,4)");
+		// primary time not preserved
+		assertEvaluatesToWithData(createData(), "TIME FIRST (INDEX OF 13 FROM mylist)", "NULL");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_8)
+	public void testAtLeast() throws Exception {
+		assertEvaluatesTo("AT LEAST 1 IsTrue FROM (FALSE, FALSE, TRUE, FALSE)", "TRUE");
+		assertEvaluatesTo("AT LEAST 2 AreTrue FROM (FALSE, FALSE, TRUE, FALSE)", "FALSE");
+		assertEvaluatesTo("AT LEAST 2 FROM (TRUE, FALSE, TRUE, TRUE)", "TRUE");
+		assertEvaluatesTo("AT LEAST 5 FROM (TRUE, FALSE)", "FALSE");
+		assertEvaluatesTo("AT LEAST 1 IsTrue FROM (TRUE, FALSE, \"TRUE\")", "NULL");
+		assertEvaluatesTo("AT LEAST \"1\" FROM (TRUE, FALSE)", "NULL");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testAtLeastTruthValue() throws Exception {
+		// specification has "AT LEAST ... OF" in examples instead of "AT LEAST ... FROM"
+		assertEvaluatesTo("(AT LEAST 2 FROM (TRUE, TRUTH VALUE 0.7, TRUTH VALUE 0.3)) IS WITHIN TRUTH VALUE 0.69 TO TRUTH VALUE 0.71", "TRUE");
+		assertEvaluatesTo("AT LEAST 10 AreTrue FROM (TRUTH VALUE 0.7, TRUTH VALUE 0.1)", "FALSE");
+		assertEvaluatesTo("AT LEAST \"1\" IsTrue FROM (TRUTH VALUE 0.3, FALSE)", "NULL");
+		assertEvaluatesTo("AT LEAST 2 FROM (TRUE, 5, TRUTH VALUE 0.3, TRUE)", "NULL");
+		assertEvaluatesTo("APPLICABILITY OF (AT LEAST 2 FROM (TRUE, 5, TRUTH VALUE 0.3, TRUE))", "TRUE");
+		assertEvaluatesTo("APPLICABILITY OF (AT LEAST 2 FROM (FALSE, TRUTH VALUE 0.3, TRUE))", "TRUE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_8)
+	public void testAtMost() throws Exception {
+		assertEvaluatesTo("AT MOST 1 IsTrue FROM (FALSE, FALSE, TRUE, FALSE)", "TRUE");
+		assertEvaluatesTo("AT MOST 2 AreTrue FROM (FALSE, FALSE, TRUE, FALSE)", "TRUE");
+		assertEvaluatesTo("AT MOST 2 FROM (TRUE, FALSE, TRUE, TRUE)", "FALSE");
+		assertEvaluatesTo("AT MOST 5 FROM (TRUE, FALSE)", "FALSE");
+		assertEvaluatesTo("AT MOST 1 IsTrue FROM (TRUE, FALSE, \"TRUE\")", "NULL");
+		assertEvaluatesTo("AT MOST \"1\" FROM (TRUE, FALSE)", "NULL");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testAtMostTruthValue() throws Exception {
+		// specification has "AT MOST ... OF" as examples instead of "AT MOST ... FROM"
+		assertEvaluatesTo("(AT MOST 2 FROM (TRUE, FALSE, TRUTH VALUE 0.7, TRUTH VALUE 0.3)) IS WITHIN TRUTH VALUE 0.29 TO TRUTH VALUE 0.31", "TRUE");
+		assertEvaluatesTo("AT MOST 10 AreTrue FROM (TRUTH VALUE 0.7, TRUTH VALUE 0.1)", "FALSE");
+		assertEvaluatesTo("AT MOST \"1\" IsTrue FROM (TRUTH VALUE 0.3, FALSE)", "NULL");
+		assertEvaluatesTo("AT MOST 2 FROM (TRUE, 5, TRUTH VALUE 0.3, TRUE)", "NULL");
 	}
 
 	@Test
 	public void testSlope() throws Exception {
 		String data = createData();
-		assertEvaluatesToWithData(data, "SLOPE OF mylist IS WITHIN 0.99 TO 1.01","TRUE");
-		assertEvaluatesToWithData(data, "TIME (SLOPE OF mylist)","NULL");
-		assertEvaluatesTo("SLOPE (3,4)","NULL");
+		assertEvaluatesToWithData(data, "SLOPE OF mylist IS WITHIN 0.99 TO 1.01", "TRUE");
+		assertEvaluatesToWithData(data, "TIME (SLOPE OF mylist)", "NULL");
+		assertEvaluatesTo("SLOPE (3,4)", "NULL");
 		assertEvaluatesTo("SLOPE ()", "NULL");
-		assertEvaluatesToWithData(data, "SLOPE OF a","NULL");
+		assertEvaluatesToWithData(data, "SLOPE OF a", "NULL");
 		// same primary time -> null
-		assertEvaluatesToWithData(data, "SLOPE OF (a, y)","NULL");
+		assertEvaluatesToWithData(data, "SLOPE OF (a, y)", "NULL");
+		// primary time not preserved
+		assertEvaluatesToWithData(data, "TIME OF (SLOPE OF mylist)", "NULL");
 	}
 
 }

--- a/test/arden/tests/specification/operators/QueryAggregationOperatorsTest.java
+++ b/test/arden/tests/specification/operators/QueryAggregationOperatorsTest.java
@@ -2,47 +2,51 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
-import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class QueryAggregationOperatorsTest extends SpecificationTest {
-	
-	private static final String DATA = new ArdenCodeBuilder()
-			.addData("x := 12; TIME x := 1990-03-15T15:00:00;")
-			.addData("y := 13; TIME y := 1990-03-16T15:00:00;")
-			.addData("z := 14; TIME z := 1990-03-17T15:00:00;")
-			.addData("mylist := (x, y, z);")
-			.addData("a := 4; TIME a := 1990-03-16T15:00:00;")
-			.toString();
+
+	private String createData() {
+		return createCodeBuilder()
+				.addData("x := 12; TIME x := 1990-03-15T15:00:00;")
+				.addData("y := 13; TIME y := 1990-03-16T15:00:00;")
+				.addData("z := 14; TIME z := 1990-03-17T15:00:00;")
+				.addData("mylist := (x, y, z);")
+				.addData("a := 4; TIME a := 1990-03-16T15:00:00;")
+				.toString();
+	}
 
 	@Test
 	public void testNearest() throws Exception {
-		assertEvaluatesToWithData(DATA, "NEAREST (2 days before 1990-03-18T16:00:00) FROM mylist","13");
-		assertEvaluatesToWithData(DATA, "NEAREST 1990-03-16T16:00:00 FROM a","4");
-		assertEvaluatesToWithData(DATA, "NEAREST 1990-03-16T16:00:00 FROM (a, 5)","NULL");
+		String data = createData();
+		assertEvaluatesToWithData(data, "NEAREST (2 days before 1990-03-18T16:00:00) FROM mylist","13");
+		assertEvaluatesToWithData(data, "NEAREST 1990-03-16T16:00:00 FROM a","4");
+		assertEvaluatesToWithData(data, "NEAREST 1990-03-16T16:00:00 FROM (a, 5)","NULL");
 		// element with smallest index when tied 
-		assertEvaluatesToWithData(DATA, "NEAREST 1990-03-16T16:00:00 FROM (a,mylist)","4");
+		assertEvaluatesToWithData(data, "NEAREST 1990-03-16T16:00:00 FROM (a,mylist)","4");
 		assertEvaluatesTo("NEAREST 1990-03-16T16:00:00 FROM (3,4)","NULL");
 		assertEvaluatesTo("NEAREST 1990-03-16T16:00:00 FROM ()","NULL");
 	}
 
 	@Test
 	public void testIndexNearest() throws Exception {
-		assertEvaluatesToWithData(DATA, "INDEX NEAREST 1990-03-16T16:00:00 FROM mylist","2");
+		String data = createData();
+		assertEvaluatesToWithData(data, "INDEX NEAREST 1990-03-16T16:00:00 FROM mylist","2");
 		assertEvaluatesTo("INDEX NEAREST 1990-03-16T16:00:00 FROM (3,4)","NULL");
 		// smallest index when tied
-		assertEvaluatesToWithData(DATA, "INDEX NEAREST 1990-03-16T16:00:00 FROM (a,mylist)","1");
+		assertEvaluatesToWithData(data, "INDEX NEAREST 1990-03-16T16:00:00 FROM (a,mylist)","1");
 	}
 
 	@Test
 	public void testSlope() throws Exception {
-		assertEvaluatesToWithData(DATA, "SLOPE OF mylist IS WITHIN 0.99 TO 1.01","TRUE");
-		assertEvaluatesToWithData(DATA, "TIME (SLOPE OF mylist)","NULL");
+		String data = createData();
+		assertEvaluatesToWithData(data, "SLOPE OF mylist IS WITHIN 0.99 TO 1.01","TRUE");
+		assertEvaluatesToWithData(data, "TIME (SLOPE OF mylist)","NULL");
 		assertEvaluatesTo("SLOPE (3,4)","NULL");
 		assertEvaluatesTo("SLOPE ()", "NULL");
-		assertEvaluatesToWithData(DATA, "SLOPE OF a","NULL");
+		assertEvaluatesToWithData(data, "SLOPE OF a","NULL");
 		// same primary time -> null
-		assertEvaluatesToWithData(DATA, "SLOPE OF (a, y)","NULL");
+		assertEvaluatesToWithData(data, "SLOPE OF (a, y)","NULL");
 	}
 
 }

--- a/test/arden/tests/specification/operators/QueryTransformationOperatorsTest.java
+++ b/test/arden/tests/specification/operators/QueryTransformationOperatorsTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class QueryTransformationOperatorsTest extends SpecificationTest {
-	
+
 	@Test
 	public void testInterval() throws Exception {
 		String data = createCodeBuilder()
@@ -15,12 +15,13 @@ public class QueryTransformationOperatorsTest extends SpecificationTest {
 				.addData("mylist := (x, y, z);")
 				.toString();
 
-		assertEvaluatesToWithData(data, "INTERVAL mylist","(86400 seconds,194400 seconds)");
-		assertEvaluatesTo("INTERVAL OF (3,4)","null");
-		assertEvaluatesTo("INTERVAL OF ()","null");
+		assertEvaluatesToWithData(data, "INTERVAL mylist", "(86400 SECONDS,194400 SECONDS)");
+		assertEvaluatesToWithData(data, "INTERVAL x", "()");
+		assertEvaluatesTo("INTERVAL OF (3,4)", "NULL");
+		assertEvaluatesTo("INTERVAL OF ()", "NULL");
 
 		// primary times lost
-		assertEvaluatesToWithData(data, "THE TIME OF THE FIRST INTERVAL OF mylist","NULL");
+		assertEvaluatesToWithData(data, "THE TIME OF THE FIRST INTERVAL OF mylist", "NULL");
 	}
 
 }

--- a/test/arden/tests/specification/operators/QueryTransformationOperatorsTest.java
+++ b/test/arden/tests/specification/operators/QueryTransformationOperatorsTest.java
@@ -2,26 +2,25 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
-import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class QueryTransformationOperatorsTest extends SpecificationTest {
 	
-	private static final String DATA = new ArdenCodeBuilder()
-			.addData("x := 1; TIME x := 1990-03-15T15:00:00;")
-			.addData("y := 2; TIME y := 1990-03-16T15:00:00;")
-			.addData("z := 3; TIME z := 1990-03-18T21:00:00;")
-			.addData("mylist := (x, y, z);")
-			.toString();
-
 	@Test
 	public void testInterval() throws Exception {
-		assertEvaluatesToWithData(DATA, "INTERVAL mylist","(86400 seconds,194400 seconds)");
+		String data = createCodeBuilder()
+				.addData("x := 1; TIME x := 1990-03-15T15:00:00;")
+				.addData("y := 2; TIME y := 1990-03-16T15:00:00;")
+				.addData("z := 3; TIME z := 1990-03-18T21:00:00;")
+				.addData("mylist := (x, y, z);")
+				.toString();
+
+		assertEvaluatesToWithData(data, "INTERVAL mylist","(86400 seconds,194400 seconds)");
 		assertEvaluatesTo("INTERVAL OF (3,4)","null");
 		assertEvaluatesTo("INTERVAL OF ()","null");
-		
+
 		// primary times lost
-		assertEvaluatesToWithData(DATA, "THE TIME OF THE FIRST INTERVAL OF mylist","NULL");
+		assertEvaluatesToWithData(data, "THE TIME OF THE FIRST INTERVAL OF mylist","NULL");
 	}
 
 }

--- a/test/arden/tests/specification/operators/SimpleComparisonOperatorsTest.java
+++ b/test/arden/tests/specification/operators/SimpleComparisonOperatorsTest.java
@@ -2,6 +2,8 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
+import arden.tests.specification.testcompiler.ArdenVersion;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class SimpleComparisonOperatorsTest extends SpecificationTest {
@@ -21,10 +23,35 @@ public class SimpleComparisonOperatorsTest extends SpecificationTest {
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testEqualTimeOfDay() throws Exception {
+		assertEvaluatesTo("1990-12-10T12:20:30 = 12:20:30", "TRUE");
+		assertEvaluatesTo("12:20:30 = 1990-12-10T12:20:30", "TRUE");
+		assertEvaluatesTo("1990-12-10T12:20:30 = 12:20:31", "FALSE");
+		assertEvaluatesTo("08:20:00 + 5 MINUTES = 08:25:00", "TRUE");
+		assertEvaluatesTo("08:20:00 + 4 MINUTES = 08:25:00", "FALSE");
+		assertEvaluatesTo("1990-12-10T12:20:31 = 12:20:30", "FALSE");
+		assertEvaluatesTo("1990-12-10T00:00:00 = 23:59:59", "FALSE");
+	}
+
+	@Test
 	public void testNotEqual() throws Exception {
 		assertEvaluatesTo("1 <> 2", "TRUE");
 		assertEvaluatesTo("(1,2,\"a\") NE (NULL,2,3)", "(NULL,FALSE,TRUE)");
 		assertEvaluatesTo("(3/0) IS NOT EQUAL (3/0)", "NULL");
+
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testNotEqualTimeOfDay() throws Exception {
+		assertEvaluatesTo("1990-12-10T12:20:30 <> 12:20:30", "FALSE");
+		assertEvaluatesTo("12:20:30 <> 1990-12-10T12:20:30", "FALSE");
+		assertEvaluatesTo("1990-12-10T12:20:30 <> 12:20:31", "TRUE");
+		assertEvaluatesTo("08:20:00 + 5 MINUTES <> 08:25:00", "FALSE");
+		assertEvaluatesTo("08:20:00 + 4 MINUTES <> 08:25:00", "TRUE");
+		assertEvaluatesTo("1990-12-10T12:20:31 <> 12:20:30", "TRUE");
+		assertEvaluatesTo("1990-12-10T00:00:00 <> 23:59:59", "TRUE");
 	}
 
 	@Test
@@ -37,6 +64,18 @@ public class SimpleComparisonOperatorsTest extends SpecificationTest {
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testLessTimeOfDay() throws Exception {
+		assertEvaluatesTo("1990-12-10T12:20:30 < 12:20:30", "FALSE");
+		assertEvaluatesTo("12:20:30 < 1990-12-10T12:20:30", "FALSE");
+		assertEvaluatesTo("1990-12-10T12:20:30 < 12:20:31", "TRUE");
+		assertEvaluatesTo("08:20:00 + 5 MINUTES < 08:25:00", "FALSE");
+		assertEvaluatesTo("08:20:00 + 4 MINUTES < 08:25:00", "TRUE");
+		assertEvaluatesTo("1990-12-10T12:20:31 < 12:20:30", "FALSE");
+		assertEvaluatesTo("1990-12-10T00:00:00 < 23:59:59", "TRUE");
+	}
+
+	@Test
 	public void testLessEqual() throws Exception {
 		assertEvaluatesTo("1 <= 2", "TRUE");
 		assertEvaluatesTo("1990-03-02T00:00:00 WAS LESS THAN OR EQUAL 1990-03-10T00:00:00", "TRUE");
@@ -46,12 +85,52 @@ public class SimpleComparisonOperatorsTest extends SpecificationTest {
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testLessEqualTimeOfDay() throws Exception {
+		assertEvaluatesTo("1990-12-10T12:20:30 <= 12:20:30", "TRUE");
+		assertEvaluatesTo("12:20:30 <= 1990-12-10T12:20:30", "TRUE");
+		assertEvaluatesTo("1990-12-10T12:20:30 <= 12:20:31", "TRUE");
+		assertEvaluatesTo("08:20:00 + 5 MINUTES <= 08:25:00", "TRUE");
+		assertEvaluatesTo("08:20:00 + 4 MINUTES <= 08:25:00", "TRUE");
+		assertEvaluatesTo("1990-12-10T12:20:31 <= 12:20:30", "FALSE");
+		assertEvaluatesTo("1990-12-10T00:00:00 <= 23:59:59", "TRUE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testLessEqualFuzzy() throws Exception {
+		String data = createCodeBuilder()
+				.addData("young := FUZZY SET (0 YEARS, TRUTH VALUE 1),(15 YEARS, TRUTH VALUE 1),(20 YEARS, TRUTH VALUE 0);")
+				.addData("middle_aged := FUZZY SET (15 YEARS, TRUTH VALUE 0),(20 YEARS, TRUTH VALUE 1),(60 YEARS, TRUTH VALUE 1), (70 YEARS, truth value 0);")
+				.toString();
+		assertEvaluatesToWithData(data, "25 YEARS <= young", "FALSE");
+		assertEvaluatesToWithData(data, "25 YEARS <= middle_aged", "TRUE");
+		assertEvaluatesToWithData(data, "10 YEARS <= young", "TRUE");
+		assertEvaluatesToWithData(data, "10 YEARS <= middle_aged", "TRUE");
+		assertEvaluatesToWithData(data, "(17.5 YEARS <= young) IS WITHIN TRUTH VALUE 0.49 TO TRUTH VALUE 0.51", "TRUE");
+		assertEvaluatesToWithData(data, "17.5 YEARS <= middle_aged", "TRUE");
+	}
+
+	@Test
 	public void testGreater() throws Exception {
 		assertEvaluatesTo("1 > 2", "FALSE");
 		assertEvaluatesTo("1990-03-02T00:00:00 WAS GREATER THAN 1990-03-10T00:00:00", "FALSE");
+		// false := 1990-03-02T00:00:00 > 13:00:00
 		assertEvaluatesTo("2 days GT 1 year", "FALSE");
 		assertEvaluatesTo("\"aaa\" WERE GREATER THAN \"aab\"", "FALSE");
 		assertEvaluatesTo("\"aaa\" IS NOT LESS THAN OR EQUAL 1", "NULL");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testGreaterTimeOfDay() throws Exception {
+		assertEvaluatesTo("1990-12-10T12:20:30 > 12:20:30", "FALSE");
+		assertEvaluatesTo("12:20:30 > 1990-12-10T12:20:30", "FALSE");
+		assertEvaluatesTo("1990-12-10T12:20:30 > 12:20:31", "FALSE");
+		assertEvaluatesTo("08:20:00 + 5 MINUTES > 08:25:00", "FALSE");
+		assertEvaluatesTo("08:20:00 + 4 MINUTES > 08:25:00", "FALSE");
+		assertEvaluatesTo("1990-12-10T12:20:31 > 12:20:30", "TRUE");
+		assertEvaluatesTo("1990-12-10T00:00:00 > 23:59:59", "FALSE");
 	}
 
 	@Test
@@ -61,6 +140,46 @@ public class SimpleComparisonOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("2 days GE 1 year", "FALSE");
 		assertEvaluatesTo("\"aaa\" WERE GREATER THAN OR EQUAL \"aab\"", "FALSE");
 		assertEvaluatesTo("\"aaa\" IS NOT LESS THAN 1", "NULL");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testGreaterEqualTimeOfDay() throws Exception {
+		assertEvaluatesTo("1990-12-10T12:20:30 >= 12:20:30", "TRUE");
+		assertEvaluatesTo("12:20:30 >= 1990-12-10T12:20:30", "TRUE");
+		assertEvaluatesTo("1990-12-10T12:20:30 >= 12:20:31", "FALSE");
+		assertEvaluatesTo("08:20:00 + 5 MINUTES >= 08:25:00", "TRUE");
+		assertEvaluatesTo("08:20:00 + 4 MINUTES >= 08:25:00", "FALSE");
+		assertEvaluatesTo("1990-12-10T12:20:31 >= 12:20:30", "TRUE");
+		assertEvaluatesTo("1990-12-10T00:00:00 >= 23:59:59", "FALSE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testGreaterEqualFuzzy() throws Exception {
+		String data = createCodeBuilder()
+				.addData("young := FUZZY SET (0 YEARS, truth value 1),(15 YEARS, truth value 1),(20 YEARS, truth value 0);")
+				.addData("middle_aged := FUZZY SET (15 YEARS, truth value 0),(20 YEARS, truth value 1),(60 YEARS, truth value 1), (70 YEARS, truth value 0);")
+				.toString();
+		assertEvaluatesToWithData(data, "25 YEARS >= young", "TRUE");
+		assertEvaluatesToWithData(data, "25 YEARS >= middle_aged", "TRUE");
+		assertEvaluatesToWithData(data, "10 YEARS >= young", "TRUE");
+		assertEvaluatesToWithData(data, "10 YEARS >= middle_aged", "FALSE");
+		assertEvaluatesToWithData(data, "(17.5 YEARS >= young) IS WITHIN TRUTH VALUE 0.49 TO TRUTH VALUE 0.51", "TRUE");
+		assertEvaluatesToWithData(data, "17.5 YEARS >= middle_aged", "TRUE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testTruthValueComparison() throws Exception {
+		// truth value is an ordered type
+		assertEvaluatesTo("TRUTH VALUE 0.3 = TRUTH VALUE 0.3", "TRUE");
+		assertEvaluatesTo("TRUTH VALUE 0.3 < TRUTH VALUE 0.6", "TRUE");
+		assertEvaluatesTo("TRUTH VALUE 0.3 > TRUTH VALUE 0.6", "FALSE");
+		assertEvaluatesTo("FALSE < TRUTH VALUE 0.5", "TRUE");
+		assertEvaluatesTo("TRUE < TRUTH VALUE 0.5", "FALSE");
+		assertEvaluatesTo("FALSE > TRUTH VALUE 0.5", "FALSE");
+		assertEvaluatesTo("TRUE > TRUTH VALUE 0.5", "TRUE");
 	}
 
 }

--- a/test/arden/tests/specification/operators/StringOperatorsTest.java
+++ b/test/arden/tests/specification/operators/StringOperatorsTest.java
@@ -2,14 +2,15 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
-import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class StringOperatorsTest extends SpecificationTest {
 	
-	private static final String DATA = new ArdenCodeBuilder()
-			.addData("x := \"hello world\"; TIME x := 1990-01-01T00:00:00;")
-			.toString();
+	private String createData() {
+		return createCodeBuilder()
+				.addData("x := \"hello world\"; TIME x := 1990-01-01T00:00:00;")
+				.toString();
+	}
 
 	@Test
 	public void testConcatenation() throws Exception {
@@ -20,7 +21,7 @@ public class StringOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("3 days || \" left\"", "\"3 days left\"");
 		assertEvaluatesTo("\"on \" || 1990-03-15T13:45:01", "\"on 1990-03-15T13:45:01\"");
 		assertEvaluatesTo("\"list=\" || (1,2,3)", "\"list=(1,2,3)\"");
-		assertEvaluatesToWithData(DATA, "TIME (x || x)", "NULL");
+		assertEvaluatesToWithData(createData(), "TIME (x || x)", "NULL");
 	}
 
 	@Test
@@ -55,7 +56,7 @@ public class StringOperatorsTest extends SpecificationTest {
 	public void testString() throws Exception {
 		assertEvaluatesTo("STRING (\"a\",\"bc\")", "\"abc\"");
 		assertEvaluatesTo("STRING ()", "\"\"");
-		assertEvaluatesToWithData(DATA, "TIME STRING x", "NULL");
+		assertEvaluatesToWithData(createData(), "TIME STRING x", "NULL");
 		assertEvaluatesTo("STRING ()", "\"\"");
 		assertEvaluatesTo("STRING REVERSE EXTRACT CHARACTERS \"abcde\"", "\"edcba\"");
 	}
@@ -67,7 +68,7 @@ public class StringOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("\"abnormal values\" MATCHES PATTERN \"%value_\"", "TRUE");
 		assertEvaluatesTo("(\"stunned myocardium\", \"myocardial infarction\") MATCHES PATTERN \"%myocardium\"", "(TRUE,FALSE)");
 		assertEvaluatesTo("\"5%\" MATCHES PATTERN \"_\\%\"", "TRUE");
-		assertEvaluatesToWithData(DATA, "TIME (x MATCHES PATTERN \"%hello%\")", "NULL");
+		assertEvaluatesToWithData(createData(), "TIME (x MATCHES PATTERN \"%hello%\")", "NULL");
 	}
 
 	@Test
@@ -77,7 +78,7 @@ public class StringOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("LENGTH ()", "NULL");
 		assertEvaluatesTo("LENGTH OF NULL", "NULL");
 		assertEvaluatesTo("LENGTH OF (\"Negative\", \"Pos\", 2)", "(8,3,NULL)");
-		assertEvaluatesToWithData(DATA, "TIME LENGTH x", "NULL");
+		assertEvaluatesToWithData(createData(), "TIME LENGTH x", "NULL");
 	}
 
 	@Test
@@ -88,7 +89,7 @@ public class StringOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("UPPERCASE ()", "NULL");
 		assertEvaluatesTo("LOWERCASE 12.8", "NULL");
 		assertEvaluatesTo("UPPERCASE (\"5-Hiaa\", \"Pos\", 2)", "(\"5-HIAA\",\"POS\",NULL)");
-		assertEvaluatesToWithData(DATA, "TIME (UPPERCASE x)", "1990-01-01T00:00:00");
+		assertEvaluatesToWithData(createData(), "TIME (UPPERCASE x)", "1990-01-01T00:00:00");
 	}
 
 	@Test
@@ -99,7 +100,7 @@ public class StringOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("TRIM LEFT \" result: \"", "\"result: \"");
 		assertEvaluatesTo("TRIM RIGHT \" result: \"", "\" result:\"");
 		assertEvaluatesTo("TRIM (\" 5 N\", \"2 E \", 2)", "(\"5 N\",\"2 E\",NULL)");
-		assertEvaluatesToWithData(DATA, "TIME (TRIM x)", "1990-01-01T00:00:00");
+		assertEvaluatesToWithData(createData(), "TIME (TRIM x)", "1990-01-01T00:00:00");
 	}
 
 	@Test
@@ -116,7 +117,7 @@ public class StringOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("FIND \"e\" IN STRING \"Example Here\" STARTING AT \"x\"", "NULL");
 		assertEvaluatesTo("FIND \"e\" IN STRING \"Example Here\" STARTING AT 99", "0");
 		assertEvaluatesTo("FIND \"e\" IN STRING \"Example Here\" STARTING AT (10,11)", "(10,12)");
-		assertEvaluatesToWithData(DATA, "TIME (FIND \"e\" IN STRING x)", "NULL");
+		assertEvaluatesToWithData(createData(), "TIME (FIND \"e\" IN STRING x)", "NULL");
 	}
 
 	@Test
@@ -136,7 +137,7 @@ public class StringOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("SUBSTRING 1 CHARACTERS FROM \"abcdefg\"", "\"a\"");
 		assertEvaluatesTo("SUBSTRING -1 CHARACTERS STARTING AT LENGTH OF \"abcdefg\" FROM \"abcdefg\"", "\"g\"");
 		assertEvaluatesTo("SUBSTRING 3 CHARACTERS FROM (\"Positive\",\"Negative\",2)", "(\"Pos\",\"Neg\",NULL)");
-		assertEvaluatesToWithData(DATA, "TIME (SUBSTRING 3 CHARACTERS FROM x)", "1990-01-01T00:00:00");
+		assertEvaluatesToWithData(createData(), "TIME (SUBSTRING 3 CHARACTERS FROM x)", "1990-01-01T00:00:00");
 	}
 
 }

--- a/test/arden/tests/specification/operators/TemporalOperatorsTest.java
+++ b/test/arden/tests/specification/operators/TemporalOperatorsTest.java
@@ -2,20 +2,17 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
+import arden.tests.specification.testcompiler.ArdenVersion;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class TemporalOperatorsTest extends SpecificationTest {
-	
+
 	@Test
 	public void testAfter() throws Exception {
 		assertEvaluatesTo("2 DAYS AFTER 1990-03-13T00:00:00", "1990-03-15T00:00:00");
 	}
-	
-	@Test
-	public void testFrom() throws Exception {
-		assertEvaluatesTo("2 DAYS FROM 2000-09-11T00:08:00", "2000-09-13T00:08:00");
-	}
-	
+
 	@Test
 	public void testBefore() throws Exception {
 		assertEvaluatesTo("2 DAYS BEFORE 1990-03-13T00:00:00", "1990-03-11T00:00:00");
@@ -25,5 +22,138 @@ public class TemporalOperatorsTest extends SpecificationTest {
 	public void testAgo() throws Exception {
 		assertEvaluatesTo("2 DAYS AGO = NOW - 2 days", "TRUE");
 	}
-	
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_1)
+	public void testFrom() throws Exception {
+		assertEvaluatesTo("2 DAYS FROM 2000-09-11T00:08:00", "2000-09-13T00:08:00");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testTimeOfDay() throws Exception {
+		assertEvaluatesTo("TIME OF DAY OF 1990-01-01T12:30:30", "12:30:30");
+		assertEvaluatesTo("TIME OF DAY OF 1990-01-01T12:30:30.123", "12:30:30.123");
+		assertEvaluatesTo("TIME OF DAY OF 5", "NULL");
+
+		String data = createCodeBuilder()
+				.addData("t := 1990-01-01T12:30:30;")
+				.addData("TIME t := 1980-01-01T00:00:00;")
+				.toString();
+		assertEvaluatesToWithData(data, "TIME OF DAY OF t", "12:30:30");
+		assertEvaluatesToWithData(data, "TIME OF (TIME OF DAY OF t)", "NULL");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testDayOfWeek() throws Exception {
+		assertEvaluatesTo("DAY OF WEEK OF 2006-05-26T13:20:00", "5");
+		assertEvaluatesTo("DAY OF WEEK OF (2006-06-03T09:04:00, 2006-06-06T16:40:00)", "(6,2)");
+		assertEvaluatesTo("DAY OF WEEK OF 08:30:00", "NULL");
+		assertEvaluatesTo("DAY OF WEEK OF 2006-05-26T13:20:00 = FRIDAY", "TRUE");
+		assertEvaluatesTo("DAY OF WEEK OF (2006-06-03T09:04:00, 2006-06-06T16:40:00) IS IN (SATURDAY, SUNDAY)", "(TRUE,FALSE)");
+
+		String data = createCodeBuilder()
+				.addData("t := 1990-01-01T12:30:30;")
+				.addData("TIME T := 1970-01-01T00:00:00;")
+				.toString();
+		assertEvaluatesToWithData(data, "DAY OF WEEK OF TIME OF t", "4");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2)
+	public void testExtract() throws Exception {
+		assertEvaluatesTo("EXTRACT YEAR 1990-01-03T14:23:17.3", "1990");
+		assertEvaluatesTo("EXTRACT YEAR (1 YEAR)", "NULL");
+		assertEvaluatesTo("EXTRACT MONTH 1990-01-03T14:23:17.3", "1");
+		assertEvaluatesTo("EXTRACT MONTH 1", "NULL");
+		assertEvaluatesTo("EXTRACT DAY 1990-01-03T14:23:17.3", "3");
+		assertEvaluatesTo("EXTRACT DAY \"this is not a time\"", "NULL");
+		assertEvaluatesTo("EXTRACT HOUR 1990-01-03T14:23:17.3", "14");
+		assertEvaluatesTo("EXTRACT HOUR (1 HOUR)", "NULL");
+		assertEvaluatesTo("EXTRACT MINUTE 1990-01-03T14:23:17.3", "23");
+		assertEvaluatesTo("EXTRACT MINUTE 1990-01-03", "0");
+		// date before 1800-01-01? faulty example in specification?
+		// assertEvaluatesTo("EXTRACT MINUTE 0000-00-00", "NULL");
+		assertEvaluatesTo("EXTRACT SECOND 1990-01-03T14:23:17.3", "17.3");
+		assertEvaluatesTo("EXTRACT SECOND (1 second)", "NULL");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testExtractTimeOfDay() throws Exception {
+		assertEvaluatesTo("EXTRACT YEAR 14:23:17.3", "NULL");
+		assertEvaluatesTo("EXTRACT MONTH 14:23:17.3", "NULL");
+		assertEvaluatesTo("EXTRACT DAY 14:23:17.3", "NULL");
+		assertEvaluatesTo("EXTRACT HOUR 14:23:17.3", "14");
+		assertEvaluatesTo("EXTRACT MINUTE 14:23:17.3", "23");
+		assertEvaluatesTo("EXTRACT SECOND 14:23:17.3", "17.3");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_8)
+	public void testReplaceWith() throws Exception {
+		String data = createCodeBuilder()
+				.addData("d := 1990-01-03T14:23:17.3;")
+				.addData("TIME OF d := 1980-01-01T00:00:00;")
+				.addData("d2 := (1980-12-01T00:00:00,1970-01-01T00:00:00);")
+				.addData("t := 20:00:00;")
+				.addData("TIME OF t := 1980-01-01T00:00:00;")
+				.toString();
+
+		// year
+		assertEvaluatesToWithData(data, "REPLACE YEAR d WITH 2000", "2000-01-03T14:23:17.3");
+		assertEvaluatesToWithData(data, "REPLACE YEAR OF d WITH (2000, 1980)", "(2000-01-03T14:23:17.3,1980-01-03T14:23:17.3)");
+		assertEvaluatesToWithData(data, "REPLACE YEAR d WITH 2000.123", "2000-01-03T14:23:17.3");
+		assertEvaluatesToWithData(data, "REPLACE YEAR OF d WITH 1799", "NULL");
+		assertEvaluatesToWithData(data, "REPLACE YEAR OF d WITH NULL", "NULL");
+		assertEvaluatesToWithData(data, "REPLACE YEAR OF d WITH 5", "NULL");
+		assertEvaluatesToWithData(data, "TIME OF REPLACE YEAR OF d WITH 2000", "1980-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "REPLACE YEAR OF d2 WITH 2000", "(2000-12-01T00:00:00,2000-01-01T00:00:00)");
+		assertEvaluatesToWithData(data, "REPLACE YEAR OF d2 WITH (1990,2000)", "(1990-12-01T00:00:00,2000-01-01T00:00:00)");
+		assertEvaluatesToWithData(data, "REPLACE YEAR OF d2 WITH (1990,2000,2010)", "NULL");
+		assertEvaluatesToWithData(data, "REPLACE YEAR OF t WITH 1990", "NULL");
+
+		// month
+		assertEvaluatesToWithData(data, "REPLACE MONTH OF d WITH 5", "1990-05-03T14:23:17.3");
+		assertEvaluatesToWithData(data, "REPLACE MONTH OF d WITH 12", "1990-12-03T14:23:17.3");
+		assertEvaluatesToWithData(data, "REPLACE MONTH OF d WITH 14", "NULL");
+		assertEvaluatesToWithData(data, "REPLACE MONTH OF d WITH (-2)", "NULL");
+		assertEvaluatesToWithData(data, "REPLACE MONTH OF d WITH \"5\"", "NULL");
+		assertEvaluatesToWithData(data, "REPLACE MONTH OF d WITH 0.7", "NULL");
+		assertEvaluatesToWithData(data, "REPLACE MONTH OF d WITH 2.7", "1990-02-03T14:23:17.3;");
+		assertEvaluatesToWithData(data, "TIME OF REPLACE MONTH OF d WITH 3", "1980-01-01T00:00:00");
+
+		// day
+		assertEvaluatesToWithData(data, "REPLACE DAY OF d WITH 25", "1990-01-25T14:23:17.3");
+		assertEvaluatesToWithData(data, "TIME OF REPLACE DAY OF d WITH 25", "1980-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "REPLACE DAY OF d WITH 50", "NULL");
+		assertEvaluatesToWithData(data, "REPLACE DAY OF d WITH 0.3", "NULL");
+		assertEvaluatesToWithData(data, "REPLACE DAY OF d WITH 0.3", "NULL");
+		assertEvaluatesToWithData(data, "REPLACE DAY OF 2000-02-01T00:00:00 WITH 30", "NULL");
+
+		// hour
+		assertEvaluatesToWithData(data, "REPLACE HOUR OF d WITH 0", "1990-01-03T00:23:17.3");
+		assertEvaluatesToWithData(data, "REPLACE HOUR OF d WITH 23", "1990-01-03T23:23:17.3");
+		assertEvaluatesToWithData(data, "REPLACE HOUR OF d WITH 24", "NULL");
+		assertEvaluatesToWithData(data, "REPLACE HOUR OF d WITH 6.6", "1990-01-03T00:06:17.3");
+		assertEvaluatesToWithData(data, "REPLACE HOUR OF t WITH 12", "12:00:00");
+		assertEvaluatesToWithData(data, "TIME OF REPLACE HOUR OF t WITH 12", "1980-01-01T00:00:00");
+
+		// minute
+		assertEvaluatesToWithData(data, "REPLACE MINUTE OF d WITH 0", "1990-01-03T14:00:17.3");
+		assertEvaluatesToWithData(data, "REPLACE MINUTE OF d WITH 59", "1990-01-03T14:59:17.3");
+		assertEvaluatesToWithData(data, "REPLACE MINUTE OF d WITH 60", "NULL");
+		assertEvaluatesToWithData(data, "REPLACE MINUTE OF t WITH 23", "20:23:00");
+		assertEvaluatesToWithData(data, "REPLACE MINUTE OF t WITH 23.7", "20:23:00");
+		assertEvaluatesToWithData(data, "TIME OF REPLACE MINUTE OF t WITH 12", "1980-01-01T00:00:00");
+
+		// second
+		assertEvaluatesToWithData(data, "REPLACE SECOND OF d WITH 0", "1990-01-03T14:23:00");
+		assertEvaluatesToWithData(data, "REPLACE SECOND OF d WITH 12.35", "1990-01-03T14:23:12.35");
+		assertEvaluatesToWithData(data, "REPLACE SECOND OF t WITH 60", "NULL");
+		assertEvaluatesToWithData(data, "REPLACE SECOND OF t WITH 1", "20:00:01");
+		assertEvaluatesToWithData(data, "REPLACE SECOND OF t WITH 12.7", "20:00:12.7");
+	}
+
 }

--- a/test/arden/tests/specification/operators/TimeFunctionOperatorsTest.java
+++ b/test/arden/tests/specification/operators/TimeFunctionOperatorsTest.java
@@ -3,16 +3,18 @@ package arden.tests.specification.operators;
 import org.junit.Test;
 
 import arden.tests.specification.testcompiler.ArdenCodeBuilder;
+import arden.tests.specification.testcompiler.ArdenVersion;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class TimeFunctionOperatorsTest extends SpecificationTest {
-	
+
 	@Test
 	public void testTimeAssignment() throws Exception {
 		assertValidStatement("x := 1; TIME x := 1990-03-15T15:00:00;");
 		assertValidStatement("x := \"x\"; TIME OF x := 1990-03-15T15:00:00;");
 	}
-	
+
 	@Test
 	public void testTime() throws Exception {
 		String data = createCodeBuilder()
@@ -21,56 +23,72 @@ public class TimeFunctionOperatorsTest extends SpecificationTest {
 				.addData("z := 3; TIME z := 1990-03-18T21:00:00;")
 				.addData("mylist := (x, y, z);")
 				.toString();
-		
-		assertEvaluatesToWithData(data, "TIME mylist[1]","1990-03-15T15:00:00");
-		assertEvaluatesToWithData(data, "TIME OF TIME OF mylist[1]","1990-03-15T15:00:00");
-		assertEvaluatesTo("TIME OF (3,4)","(null,null)");
+		assertEvaluatesToWithData(data, "TIME FIRST mylist", "1990-03-15T15:00:00");
+		assertEvaluatesToWithData(data, "TIME OF TIME OF FIRST mylist", "1990-03-15T15:00:00");
+		assertEvaluatesTo("TIME OF (3,4)", "(NULL,NULL)");
 	}
-	
+
 	@Test
+	@Compatibility(min = ArdenVersion.V2_5)
 	public void testTimeObjects() throws Exception {
 		String data = createCodeBuilder()
 				.addData("obj := OBJECT [attr1, attr2];")
 				.addData("x := 1; TIME x := 2004-01-16T00:00:00;")
 				.addData("y := 2.0; TIME y := 2004-01-17T00:00:00;")
 				.toString();
-		
+
+		String noAttrs = new ArdenCodeBuilder(data)
+				.addData("result := NEW obj;")
+				.addAction("RETURN TIME OF result;")
+				.toString();
+		assertReturns(noAttrs, "NULL");
+
 		String attrTime = new ArdenCodeBuilder(data)
-				.addData("result1 := NEW obj WITH x, x;")
-				.addAction("RETURN TIME OF result1.attr1;")
+				.addData("result := NEW obj WITH x, x;")
+				.addAction("RETURN TIME OF result.attr1;")
 				.toString();
 		assertReturns(attrTime, "2004-01-16T00:00:00");
-		
+
 		String sameAttrTimes = new ArdenCodeBuilder(data)
-				.addData("result2 := NEW obj WITH x, x;")
-				.addAction("RETURN TIME OF result2")
+				.addData("result := NEW obj WITH x, x;")
+				.addAction("RETURN TIME OF result;")
 				.toString();
 		assertReturns(sameAttrTimes, "2004-01-16T00:00:00");
-		
+
 		String differentAttrTimes = new ArdenCodeBuilder(data)
-				.addData("result3 := NEW obj WITH x, y;")
-				.addAction("RETURN TIME OF result3")
+				.addData("result := NEW obj WITH x, y;")
+				.addAction("RETURN TIME OF result;")
 				.toString();
 		assertReturns(differentAttrTimes, "NULL");
-		
+
 		String listAttr = new ArdenCodeBuilder(data)
-				.addData("result4 := NEW obj WITH x, (x,x);")
-				.addAction("RETURN TIME OF result4")
+				.addData("result := NEW obj WITH x, (x,x);")
+				.addAction("RETURN TIME OF result;")
 				.toString();
 		assertReturns(listAttr, "NULL");
-		
+
 		/*
-		 * TODO is "TIME OF result.value := ..." valid?
-		 * It is given as an example in the specification, but the the grammar
-		 * rule <time_becomes> only allows <identifier> not
-		 * <identifier_or_object_ref>
+		 * Is "TIME OF result.value := ..." valid? It is given as an example in
+		 * the specification, but the the grammar rule <time_becomes> only
+		 * allows <identifier> not <identifier_or_object_ref>. Also "value" is a
+		 * reserved word.
 		 */
-		//		String attrTimeAssignment = new ArdenCodeBuilder(data)
-		//				.addData("result5 := NEW obj WITH x, y;")
-		//				.addData("TIME OF result5.attr1 := 2000-01-16T00:00:00;")
-		//				.addAction("RETURN TIME OF result5.attr1;")
-		//				.toString();
-		//		assertReturns(attrTimeAssignment, "2000-01-16T00:00:00");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_6, max = ArdenVersion.V2_6, pedantic = true)
+	public void testAt() throws Exception {
+		assertEvaluatesTo("1980-01-01 AT 15:00:00", "1980-01-01T15:00:00");
+		assertEvaluatesTo("1980-01-01T00:00:30 AT 15:00", "1980-01-01T15:00:00");
+		assertEvaluatesTo("(2010-12-20T12:34:56 + 5 MINUTES) AT 00:00:00", "2010-12-20T00:00:00");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_7)
+	public void testAtTime() throws Exception {
+		assertEvaluatesTo("1980-01-01 ATTIME 15:00:00", "1980-01-01T15:00:00");
+		assertEvaluatesTo("1980-01-01T00:00:30 ATTIME 15:00", "1980-01-01T15:00:00");
+		assertEvaluatesTo("(2010-12-20T12:34:56 + 5 MINUTES) ATTIME 00:00:00", "2010-12-20T00:00:00");
 	}
 
 }

--- a/test/arden/tests/specification/operators/TimeFunctionOperatorsTest.java
+++ b/test/arden/tests/specification/operators/TimeFunctionOperatorsTest.java
@@ -15,7 +15,7 @@ public class TimeFunctionOperatorsTest extends SpecificationTest {
 	
 	@Test
 	public void testTime() throws Exception {
-		String data = new ArdenCodeBuilder()
+		String data = createCodeBuilder()
 				.addData("x := 1; TIME x := 1990-03-15T15:00:00;")
 				.addData("y := 2; TIME y := 1990-03-16T15:00:00;")
 				.addData("z := 3; TIME z := 1990-03-18T21:00:00;")
@@ -29,7 +29,7 @@ public class TimeFunctionOperatorsTest extends SpecificationTest {
 	
 	@Test
 	public void testTimeObjects() throws Exception {
-		String data = new ArdenCodeBuilder()
+		String data = createCodeBuilder()
 				.addData("obj := OBJECT [attr1, attr2];")
 				.addData("x := 1; TIME x := 2004-01-16T00:00:00;")
 				.addData("y := 2.0; TIME y := 2004-01-17T00:00:00;")

--- a/test/arden/tests/specification/operators/TransformationOperatorsTest.java
+++ b/test/arden/tests/specification/operators/TransformationOperatorsTest.java
@@ -2,10 +2,12 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
+import arden.tests.specification.testcompiler.ArdenVersion;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class TransformationOperatorsTest extends SpecificationTest {
-	
+
 	private String createData() {
 		return createCodeBuilder()
 				.addData("w := 4; TIME w := 1995-01-01T00:00:00;")
@@ -16,87 +18,142 @@ public class TransformationOperatorsTest extends SpecificationTest {
 				.addData("mylist := (w,v,z);")
 				.toString();
 	}
-	
+
 	@Test
 	public void testMinimumMaximum() throws Exception {
 		String data = createData();
+		assertEvaluatesTo("MINIMUM 2 FROM (11,14,13,12)", "(11,12)");
+		assertEvaluatesTo("MINIMUM 2 FROM (12,14,13,11)", "(12,11)");
+		assertEvaluatesTo("MINIMUM 2 FROM 3", "(,3)");
+		assertEvaluatesTo("MINIMUM 2 FROM (3, \"asdf\")", "NULL");
+		assertEvaluatesTo("MIN 2 FROM ()", "()");
+		assertEvaluatesTo("MIN 0 FROM (2,3)", "()");
+		assertEvaluatesTo("MIN 3 FROM (3,5,1,2,4,2)", "(1,2,2)");
+		assertEvaluatesTo("MIN 9 FROM (3,2,1)", "(3,2,1)");
+		assertEvaluatesTo("MIN \"x\" FROM (2,3)", "NULL");
+		assertEvaluatesTo("MIN (-3) FROM (2,3)", "NULL");
+		assertEvaluatesToWithData(data, "TIME FIRST MIN 1 FROM (x,y,z)", "1990-01-03T00:00:00");
+		assertEvaluatesTo("MAXIMUM 2 FROM (11,14,13,12)", "(14,13)");
+		assertEvaluatesTo("MAXIMUM 2 FROM (11,13,14,12)", "(13,14)");
+		assertEvaluatesTo("MAXIMUM 2 FROM 3", "(,3)");
+		assertEvaluatesTo("MAXIMUM 2 FROM (3, \"asdf\")", "NULL");
+		assertEvaluatesTo("MAX 2 FROM ()", "()");
+		assertEvaluatesTo("MAX 0 FROM (1,2,3)", "()");
+		assertEvaluatesTo("MAX 3 FROM (1,5,2,4,1,4)", "(5,4,4)");
 
-		assertEvaluatesTo("MINIMUM 2 FROM (11,14,13,12)","(11,12)");
-		assertEvaluatesTo("MINIMUM 2 FROM (12,14,13,11)","(12,11)");
-		assertEvaluatesTo("MINIMUM 2 FROM 3","(,3)");
-		assertEvaluatesTo("MINIMUM 2 FROM (3, \"asdf\")","NULL");
-		assertEvaluatesTo("MIN 2 FROM ()","()");
-		assertEvaluatesTo("MIN 0 FROM (2,3)","()");
-		assertEvaluatesTo("MIN 3 FROM (3,5,1,2,4,2)","(1,2,2)");
-		assertEvaluatesTo("MIN 9 FROM (3,2,1)","(3,2,1)");
-		assertEvaluatesTo("MIN \"x\" FROM (2,3)","NULL");
-		assertEvaluatesTo("MIN (-3) FROM (2,3)","NULL");
-		assertEvaluatesToWithData(data, "TIME FIRST MIN 1 FROM (x,y,z)","1990-01-03T00:00:00");
-		assertEvaluatesTo("MAXIMUM 2 FROM (11,14,13,12)","(14,13)");
-		assertEvaluatesTo("MAXIMUM 2 FROM (11,13,14,12)","(13,14)");
-		assertEvaluatesTo("MAXIMUM 2 FROM 3","(,3)");
-		assertEvaluatesTo("MAXIMUM 2 FROM (3, \"asdf\")","NULL");
-		assertEvaluatesTo("MAX 2 FROM ()","()");
-		assertEvaluatesTo("MAX 0 FROM (1,2,3)","()");
-		assertEvaluatesTo("MAX 3 FROM (1,5,2,4,1,4)","(5,4,4)");
-		
 		// latest of elements with primary time on tie
 		assertEvaluatesToWithData(data, "TIME FIRST MAX 1 FROM (x,v,5)", "2000-01-01T00:00:00");
 		assertEvaluatesToWithData(data, "TIME FIRST MAX 1 FROM (v,x,5)", "2000-01-01T00:00:00");
 		assertEvaluatesToWithData(data, "TIME FIRST MIN 1 FROM (x,v,5)", "2000-01-01T00:00:00");
 		assertEvaluatesToWithData(data, "TIME FIRST MIN 1 FROM (v,x,5)", "2000-01-01T00:00:00");
 	}
-	
+
 	@Test
-	public void testFirstLast() throws Exception {
-		assertEvaluatesTo("FIRST 2 FROM (11,14,13,12)","(11,14)");
-		assertEvaluatesTo("FIRST 2 FROM 3","(,3)");
-		assertEvaluatesTo("FIRST 2 FROM (NULL,1,2,NULL)","(NULL,1)");
-		assertEvaluatesTo("FIRST 2 FROM ()","()");
-		assertEvaluatesTo("FIRST (-2) FROM 3","NULL");
-		assertEvaluatesTo("LAST 2 FROM (11,14,13,12)","(13,12)");
-		assertEvaluatesTo("LAST 2 FROM 3","(,3)");
-		assertEvaluatesTo("LAST 2 FROM (NULL,1,2,NULL)","(2,NULL)");
-		assertEvaluatesTo("LAST 2 FROM ()","()");
+	@Compatibility(min = ArdenVersion.V2_8)
+	public void testMinimumMaximumUsing() throws Exception {
+		assertEvaluatesTo("MIN 2 FROM (0,30,90,180,200,300) USING COSINE OF IT", "(90,180)");
+		assertEvaluatesTo("MIN 2 FROM (0,30,180,90,200,300) USING COSINE OF IT", "(180,90)");
+		assertEvaluatesTo("MAX 2 FROM (0,30,90,180,200,300) USING SINE OF IT", "(0,90)");
+		assertEvaluatesTo("MAX 2 FROM (90,30,0,180,200,300) USING SINE OF IT", "(90,0)");
 	}
-	
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2)
+	public void testFirst() throws Exception {
+		assertEvaluatesTo("FIRST 2 FROM (11,14,13,12)", "(11,14)");
+		assertEvaluatesTo("FIRST 1 FROM (11,14,13,12)", "(,11)");
+		assertEvaluatesTo("FIRST 2 FROM 3", "(,3)");
+		assertEvaluatesTo("FIRST 2 FROM (NULL,1,2,NULL)", "(NULL,1)");
+		assertEvaluatesTo("FIRST 2 FROM ()", "()");
+		assertEvaluatesTo("FIRST 1 FROM ()", "()");
+		assertEvaluatesTo("FIRST (-2) FROM 3", "NULL");
+
+		// primary time preserved
+		assertEvaluatesToWithData(createData(), "TIME FIRST FIRST 1 FROM mylist", "1995-01-01T00:00:00");
+	}
+
+	@Test
+	@Compatibility(max = ArdenVersion.V1, pedantic = true)
+	public void testFirstV1() throws Exception {
+		// "FIRST ... FROM" from version 1 = "EARLIEST ... FROM" from version 2
+		assertEvaluatesToWithData(createData(), "FIRST 2 FROM (w,v,z)", "(4,2)");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2)
+	public void testLast() throws Exception {
+		assertEvaluatesTo("LAST 2 FROM (11,14,13,12)", "(13,12)");
+		assertEvaluatesTo("LAST 2 FROM 3", "(,3)");
+		assertEvaluatesTo("LAST 2 FROM (NULL,1,2,NULL)", "(2,NULL)");
+		assertEvaluatesTo("LAST 2 FROM ()", "()");
+
+		// primary time preserved
+		assertEvaluatesToWithData(createData(), "TIME FIRST LAST 1 FROM mylist", "1990-01-03T00:00:00");
+	}
+
+	@Test
+	@Compatibility(max = ArdenVersion.V1, pedantic = true)
+	public void testLastV1() throws Exception {
+		// "LAST ... FROM" from version 1 = "LATEST ... FROM" from version 2
+		assertEvaluatesToWithData(createData(), "LAST 2 FROM (v,w,z)", "(5,4)");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_8)
+	public void testSublist() throws Exception {
+		assertEvaluatesTo("SUBLIST 3 ELEMENTS FROM (1,2,3,4,5)", "(1,2,3)");
+		assertEvaluatesTo("SUBLIST 10 ELEMENTS FROM (1,2,3,4,5)", "(1,2,3,4,5)");
+		assertEvaluatesTo("SUBLIST 2 ELEMENTS STARTING AT 2 FROM (1,2,3,4,5)", "(2,3)");
+		assertEvaluatesTo("SUBLIST 10 ELEMENTS STARTING AT 2 FROM (1,2,3,4,5)", "(2,3,4,5)");
+		assertEvaluatesTo("SUBLIST 2.5 ELEMENTS FROM (1,2,3,4,5)", "NULL");
+		assertEvaluatesTo("SUBLIST 2 ELEMENTS STARTING AT 2.5 FROM (1,2,3,4,5)", "NULL");
+		assertEvaluatesTo("SUBLIST 2 ELEMENTS STARTING AT 10 FROM (1,2,3,4,5)", "()");
+		assertEvaluatesTo("SUBLIST 1 ELEMENTS STARTING AT 3 FROM (1,2,3,4,5)", "(,3)");
+		assertEvaluatesTo("SUBLIST (-1) ELEMENTS STARTING AT 3 FROM (1,2,3,4,5)", "(,3)");
+		assertEvaluatesTo("SUBLIST (-3) ELEMENTS STARTING AT 3 FROM (1,2,3,4,5)", "(1,2,3)");
+
+		// primary time preserved
+		assertEvaluatesToWithData(createData(), "TIME FIRST (SUBLIST 1 ELEMENTS FROM w)", "1995-01-01T00:00:00");
+	}
+
 	@Test
 	public void testIncreaseDecrease() throws Exception {
-		assertEvaluatesTo("INCREASE (11,15,13,12)","(4,-2,-1)");
-		assertEvaluatesTo("INCREASE 3","()");
-		assertEvaluatesTo("INCREASE ()","NULL");
-		assertEvaluatesTo("INCREASE (1990-03-01,1990-03-02)","(,86400 seconds)");
-		assertEvaluatesTo("INCREASE (1 day, 2 days)","(,86400 seconds)");
-		assertEvaluatesTo("DECREASE (11,15,13,12)","(-4,2,1)");
-		assertEvaluatesTo("DECREASE 3","()");
-		assertEvaluatesTo("DECREASE ()","NULL");
-		assertEvaluatesTo("DECREASE (1990-03-01,1990-03-02)","(,-86400 seconds)");
-		assertEvaluatesTo("DECREASE (1 day, 2 days)","(,-86400 seconds)");
-		
+		assertEvaluatesTo("INCREASE (11,15,13,12)", "(4,-2,-1)");
+		assertEvaluatesTo("INCREASE 3", "()");
+		assertEvaluatesTo("INCREASE ()", "NULL");
+		assertEvaluatesTo("INCREASE (1990-03-01,1990-03-02)", "(,86400 seconds)");
+		assertEvaluatesTo("INCREASE (1 day, 2 days)", "(,86400 seconds)");
+		assertEvaluatesTo("DECREASE (11,15,13,12)", "(-4,2,1)");
+		assertEvaluatesTo("DECREASE 3", "()");
+		assertEvaluatesTo("DECREASE ()", "NULL");
+		assertEvaluatesTo("DECREASE (1990-03-01,1990-03-02)", "(,-86400 seconds)");
+		assertEvaluatesTo("DECREASE (1 day, 2 days)", "(,-86400 seconds)");
+
 		// primary time of second item is kept
 		String data = createData();
 		assertEvaluatesToWithData(data, "TIME FIRST INCREASE (x,z,v)", "1990-01-03T00:00:00");
 		assertEvaluatesToWithData(data, "TIME FIRST INCREASE (x,v,z)", "2000-01-01T00:00:00");
 	}
-	
+
 	@Test
 	public void testPercent() throws Exception {
-		assertEvaluatesTo("PERCENT INCREASE (11,15,13) IS WITHIN (36.36, -13.34) TO (36.37, -13.33)","(TRUE,TRUE)");
-		assertEvaluatesTo("% INCREASE 3","()");
-		assertEvaluatesTo("% INCREASE ()","NULL");
-		assertEvaluatesTo("PERCENT INCREASE (1 day, 2 days)","(,100)");
-		assertEvaluatesTo("PERCENT DECREASE (11,15,13) IS WITHIN (-36.37, 13.33) TO (-36.36, 13.34)","(TRUE,TRUE)");
-		assertEvaluatesTo("% DECREASE 3","()");
-		assertEvaluatesTo("% DECREASE ()","NULL");
-		assertEvaluatesTo("PERCENT DECREASE (1 day, 2 days)","(,-100)");
-		
+		assertEvaluatesTo("PERCENT INCREASE (11,15,13) IS WITHIN (36.36, -13.34) TO (36.37, -13.33)", "(TRUE,TRUE)");
+		assertEvaluatesTo("% INCREASE 3", "()");
+		assertEvaluatesTo("% INCREASE ()", "NULL");
+		assertEvaluatesTo("PERCENT INCREASE (1 day, 2 days)", "(,100)");
+		assertEvaluatesTo("PERCENT DECREASE (11,15,13) IS WITHIN (-36.37, 13.33) TO (-36.36, 13.34)", "(TRUE,TRUE)");
+		assertEvaluatesTo("% DECREASE 3", "()");
+		assertEvaluatesTo("% DECREASE ()", "NULL");
+		assertEvaluatesTo("PERCENT DECREASE (1 day, 2 days)", "(,-100)");
+
 		// primary time of second item is kept
 		String data = createData();
 		assertEvaluatesToWithData(data, "TIME FIRST PERCENT INCREASE (z,v)", "2000-01-01T00:00:00");
 		assertEvaluatesToWithData(data, "TIME FIRST PERCENT DECREASE (v,z)", "1990-01-03T00:00:00");
 	}
-	
+
 	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testEarliestLatest() throws Exception {
 		String data = createData();
 		assertEvaluatesTo("EARLIEST 2 FROM ()", "()");
@@ -109,31 +166,45 @@ public class TransformationOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("LATEST 2 FROM ()", "()");
 		assertEvaluatesToWithData(data, "LATEST 2 FROM (v,w,z)", "(5,4)");
 		assertEvaluatesToWithData(data, "LATEST 2 FROM (w,v,z)", "(4,5)");
+
+		// primary time preserved
+		assertEvaluatesToWithData(data, "TIME FIRST EARLIEST 1 FROM mylist", "1990-01-03T00:00:00");
+		assertEvaluatesToWithData(data, "TIME FIRST LATEST 1 FROM mylist", "2000-01-01T00:00:00");
 	}
-	
+
 	@Test
+	@Compatibility(min = ArdenVersion.V2_8)
+	public void testEarliestLatestUsing() throws Exception {
+		String data = createData();
+		assertEvaluatesToWithData(data, "EARLIEST 2 FROM (w,v,z) USING TIME OF IT", "(4,2)");
+		assertEvaluatesToWithData(data, "LATEST 2 FROM (v,w,z) USING TIME OF IT", "(5,4)");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testIndex() throws Exception {
-		assertEvaluatesTo("INDEX MINIMUM 2 FROM (11,14,13,12)","(1,4)");
-		assertEvaluatesTo("INDEX MINIMUM 3 FROM (3,5,1,2,4,2)","(3,4,6)");
-		assertEvaluatesTo("INDEX MIN 2 FROM (3, \"asdf\")","null");
-		assertEvaluatesTo("INDEX MINIMUM 2 FROM 3","(,1)");
-		assertEvaluatesTo("INDEX MINIMUM 0 FROM (2,3)","()");
-		assertEvaluatesTo("INDEX MAXIMUM 2 FROM (11,14,13,12)","(2,3)");
-		assertEvaluatesTo("INDEX MAXIMUM 3 FROM (3,5,1,2,4,2)","(1,2,5)");
-		assertEvaluatesTo("INDEX MAX 2 FROM (3, \"asdf\")","null");
-		assertEvaluatesTo("INDEX MAXIMUM 2 FROM 3","(,1)");
-		assertEvaluatesTo("INDEX MAXIMUM 0 FROM (2,3)","()");
-		
+		assertEvaluatesTo("INDEX MINIMUM 2 FROM (11,14,13,12)", "(1,4)");
+		assertEvaluatesTo("INDEX MINIMUM 3 FROM (3,5,1,2,4,2)", "(3,4,6)");
+		assertEvaluatesTo("INDEX MIN 2 FROM (3, \"asdf\")", "null");
+		assertEvaluatesTo("INDEX MINIMUM 2 FROM 3", "(,1)");
+		assertEvaluatesTo("INDEX MINIMUM 0 FROM (2,3)", "()");
+		assertEvaluatesTo("INDEX MAXIMUM 2 FROM (11,14,13,12)", "(2,3)");
+		assertEvaluatesTo("INDEX MAXIMUM 3 FROM (3,5,1,2,4,2)", "(1,2,5)");
+		assertEvaluatesTo("INDEX MAX 2 FROM (3, \"asdf\")", "null");
+		assertEvaluatesTo("INDEX MAXIMUM 2 FROM 3", "(,1)");
+		assertEvaluatesTo("INDEX MAXIMUM 0 FROM (2,3)", "()");
+
 		// latest of elements with primary time on tie
 		String data = createData();
 		assertEvaluatesToWithData(data, "FIRST INDEX MAXIMUM 1 FROM (v,x)", "1");
 		assertEvaluatesToWithData(data, "FIRST INDEX MAXIMUM 1 FROM (x,v)", "2");
-		
+
 		// primary time lost
 		assertEvaluatesToWithData(data, "TIME FIRST INDEX MAXIMUM 2 FROM (x,y,z)", "NULL");
 	}
-	
+
 	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testIndexFirstLast() throws Exception {
 		assertInvalidExpression("INDEX FIRST 2 FROM (1,2,3)");
 		assertInvalidExpression("INDEX LAST 2 FROM (1,2,3)");

--- a/test/arden/tests/specification/operators/TransformationOperatorsTest.java
+++ b/test/arden/tests/specification/operators/TransformationOperatorsTest.java
@@ -2,22 +2,25 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
-import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class TransformationOperatorsTest extends SpecificationTest {
 	
-	private static final String DATA = new ArdenCodeBuilder()
-			.addData("w := 4; TIME w := 1995-01-01T00:00:00;")
-			.addData("v := 5; TIME v := 2000-01-01T00:00:00;")
-			.addData("x := 5; TIME x := 1990-01-01T00:00:00;")
-			.addData("y := 3; TIME y := TIME x;")
-			.addData("z := 2; TIME z := 1990-01-03T00:00:00;")
-			.addData("mylist := (w,v,z);")
-			.toString();
+	private String createData() {
+		return createCodeBuilder()
+				.addData("w := 4; TIME w := 1995-01-01T00:00:00;")
+				.addData("v := 5; TIME v := 2000-01-01T00:00:00;")
+				.addData("x := 5; TIME x := 1990-01-01T00:00:00;")
+				.addData("y := 3; TIME y := TIME x;")
+				.addData("z := 2; TIME z := 1990-01-03T00:00:00;")
+				.addData("mylist := (w,v,z);")
+				.toString();
+	}
 	
 	@Test
 	public void testMinimumMaximum() throws Exception {
+		String data = createData();
+
 		assertEvaluatesTo("MINIMUM 2 FROM (11,14,13,12)","(11,12)");
 		assertEvaluatesTo("MINIMUM 2 FROM (12,14,13,11)","(12,11)");
 		assertEvaluatesTo("MINIMUM 2 FROM 3","(,3)");
@@ -28,7 +31,7 @@ public class TransformationOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("MIN 9 FROM (3,2,1)","(3,2,1)");
 		assertEvaluatesTo("MIN \"x\" FROM (2,3)","NULL");
 		assertEvaluatesTo("MIN (-3) FROM (2,3)","NULL");
-		assertEvaluatesToWithData(DATA, "TIME FIRST MIN 1 FROM (x,y,z)","1990-01-03T00:00:00");
+		assertEvaluatesToWithData(data, "TIME FIRST MIN 1 FROM (x,y,z)","1990-01-03T00:00:00");
 		assertEvaluatesTo("MAXIMUM 2 FROM (11,14,13,12)","(14,13)");
 		assertEvaluatesTo("MAXIMUM 2 FROM (11,13,14,12)","(13,14)");
 		assertEvaluatesTo("MAXIMUM 2 FROM 3","(,3)");
@@ -38,10 +41,10 @@ public class TransformationOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("MAX 3 FROM (1,5,2,4,1,4)","(5,4,4)");
 		
 		// latest of elements with primary time on tie
-		assertEvaluatesToWithData(DATA, "TIME FIRST MAX 1 FROM (x,v,5)", "2000-01-01T00:00:00");
-		assertEvaluatesToWithData(DATA, "TIME FIRST MAX 1 FROM (v,x,5)", "2000-01-01T00:00:00");
-		assertEvaluatesToWithData(DATA, "TIME FIRST MIN 1 FROM (x,v,5)", "2000-01-01T00:00:00");
-		assertEvaluatesToWithData(DATA, "TIME FIRST MIN 1 FROM (v,x,5)", "2000-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME FIRST MAX 1 FROM (x,v,5)", "2000-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME FIRST MAX 1 FROM (v,x,5)", "2000-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME FIRST MIN 1 FROM (x,v,5)", "2000-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME FIRST MIN 1 FROM (v,x,5)", "2000-01-01T00:00:00");
 	}
 	
 	@Test
@@ -71,8 +74,9 @@ public class TransformationOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("DECREASE (1 day, 2 days)","(,-86400 seconds)");
 		
 		// primary time of second item is kept
-		assertEvaluatesToWithData(DATA, "TIME FIRST INCREASE (x,z,v)", "1990-01-03T00:00:00");
-		assertEvaluatesToWithData(DATA, "TIME FIRST INCREASE (x,v,z)", "2000-01-01T00:00:00");
+		String data = createData();
+		assertEvaluatesToWithData(data, "TIME FIRST INCREASE (x,z,v)", "1990-01-03T00:00:00");
+		assertEvaluatesToWithData(data, "TIME FIRST INCREASE (x,v,z)", "2000-01-01T00:00:00");
 	}
 	
 	@Test
@@ -87,22 +91,24 @@ public class TransformationOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("PERCENT DECREASE (1 day, 2 days)","(,-100)");
 		
 		// primary time of second item is kept
-		assertEvaluatesToWithData(DATA, "TIME FIRST PERCENT INCREASE (z,v)", "2000-01-01T00:00:00");
-		assertEvaluatesToWithData(DATA, "TIME FIRST PERCENT DECREASE (v,z)", "1990-01-03T00:00:00");
+		String data = createData();
+		assertEvaluatesToWithData(data, "TIME FIRST PERCENT INCREASE (z,v)", "2000-01-01T00:00:00");
+		assertEvaluatesToWithData(data, "TIME FIRST PERCENT DECREASE (v,z)", "1990-01-03T00:00:00");
 	}
 	
 	@Test
 	public void testEarliestLatest() throws Exception {
+		String data = createData();
 		assertEvaluatesTo("EARLIEST 2 FROM ()", "()");
-		assertEvaluatesToWithData(DATA, "EARLIEST 2 FROM (w,v,z)", "(4,2)");
-		assertEvaluatesToWithData(DATA, "EARLIEST (-2) FROM (w,v,z)", "NULL");
-		assertEvaluatesToWithData(DATA, "EARLIEST 99 FROM (w,v,z)", "(4,5,2)");
-		assertEvaluatesToWithData(DATA, "EARLIEST 2 FROM (w,v,z,5)", "NULL");
-		assertEvaluatesToWithData(DATA, "EARLIEST 1 FROM (y,x)", "(,3)");
-		assertEvaluatesToWithData(DATA, "EARLIEST 1 FROM (x,y)", "(,5)");
+		assertEvaluatesToWithData(data, "EARLIEST 2 FROM (w,v,z)", "(4,2)");
+		assertEvaluatesToWithData(data, "EARLIEST (-2) FROM (w,v,z)", "NULL");
+		assertEvaluatesToWithData(data, "EARLIEST 99 FROM (w,v,z)", "(4,5,2)");
+		assertEvaluatesToWithData(data, "EARLIEST 2 FROM (w,v,z,5)", "NULL");
+		assertEvaluatesToWithData(data, "EARLIEST 1 FROM (y,x)", "(,3)");
+		assertEvaluatesToWithData(data, "EARLIEST 1 FROM (x,y)", "(,5)");
 		assertEvaluatesTo("LATEST 2 FROM ()", "()");
-		assertEvaluatesToWithData(DATA, "LATEST 2 FROM (v,w,z)", "(5,4)");
-		assertEvaluatesToWithData(DATA, "LATEST 2 FROM (w,v,z)", "(4,5)");
+		assertEvaluatesToWithData(data, "LATEST 2 FROM (v,w,z)", "(5,4)");
+		assertEvaluatesToWithData(data, "LATEST 2 FROM (w,v,z)", "(4,5)");
 	}
 	
 	@Test
@@ -119,11 +125,12 @@ public class TransformationOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("INDEX MAXIMUM 0 FROM (2,3)","()");
 		
 		// latest of elements with primary time on tie
-		assertEvaluatesToWithData(DATA, "FIRST INDEX MAXIMUM 1 FROM (v,x)", "1");
-		assertEvaluatesToWithData(DATA, "FIRST INDEX MAXIMUM 1 FROM (x,v)", "2");
+		String data = createData();
+		assertEvaluatesToWithData(data, "FIRST INDEX MAXIMUM 1 FROM (v,x)", "1");
+		assertEvaluatesToWithData(data, "FIRST INDEX MAXIMUM 1 FROM (x,v)", "2");
 		
 		// primary time lost
-		assertEvaluatesToWithData(DATA, "TIME FIRST INDEX MAXIMUM 2 FROM (x,y,z)", "NULL");
+		assertEvaluatesToWithData(data, "TIME FIRST INDEX MAXIMUM 2 FROM (x,y,z)", "NULL");
 	}
 	
 	@Test

--- a/test/arden/tests/specification/operators/TypeConversionOperatorsTest.java
+++ b/test/arden/tests/specification/operators/TypeConversionOperatorsTest.java
@@ -1,0 +1,85 @@
+package arden.tests.specification.operators;
+
+import org.junit.Test;
+
+import arden.tests.specification.testcompiler.ArdenVersion;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
+import arden.tests.specification.testcompiler.SpecificationTest;
+
+public class TypeConversionOperatorsTest extends SpecificationTest {
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2)
+	public void testAsNumber() throws Exception {
+		assertEvaluatesTo("\"5\" AS NUMBER", "5");
+		assertEvaluatesTo("\"xyz\" AS NUMBER", "NULL");
+		// TODO truth value as number?
+		assertEvaluatesTo("TRUE AS NUMBER", "1");
+		assertEvaluatesTo("FALSE AS NUMBER", "0");
+		assertEvaluatesTo("6 AS NUMBER", "6");
+		assertEvaluatesTo("(\"7\", 8, \"2.3E+2\", 4.1E+3, \"ABC\", NULL, TRUE, FALSE, 1997-10-31T00:00:00, now, 3 days) AS NUMBER", "(7,8,230,4100,NULL,NULL,1,0,NULL,NULL,NULL)");
+		assertEvaluatesTo("() AS NUMBER", "()");
+
+		// primary time is preserved
+		String data = createCodeBuilder()
+				.addData("x := \"5\"; TIME x := 1997-10-31T00:00:00;")
+				.toString();
+		assertEvaluatesToWithData(data, "TIME (x AS NUMBER)", "1997-10-31T00:00:00");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_8)
+	public void testAsTime() throws Exception {
+		assertEvaluatesTo("\"1999-12-12\" AS TIME", "1999-12-12T00:00:00");
+		assertEvaluatesTo("\"1997-10-31T12:34:56\" AS TIME", "1997-10-31T12:34:56");
+		assertEvaluatesTo("\"1990-01-01T12:00:00.15\" AS TIME", "1990-01-01T12:00:00.15");
+		assertEvaluatesTo("1999-12-12 AS TIME", "1999-12-12T00:00:00");
+		assertEvaluatesTo("\"xyz\" AS TIME", "NULL");
+		assertEvaluatesTo("() AS TIME", "()");
+
+		// primary time is preserved
+		String data = createCodeBuilder()
+				.addData("t := \"2000-10-31T00:00:00\"; TIME t := 1997-10-31T00:00:00;")
+				.toString();
+		assertEvaluatesToWithData(data, "TIME (x AS TIME)", "1997-10-31T00:00:00");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_8)
+	public void testAsString() throws Exception {
+		assertEvaluatesTo("5 AS STRING", "\"5\"");
+		assertEvaluatesTo("NULL AS STRING", "\"null\"");
+		assertEvaluatesTo("TRUE AS STRING", "\"true\"");
+		assertEvaluatesTo("FALSE AS STRING", "\"false\"");
+		assertEvaluatesTo("\"7\" AS STRING", "\"7\"");
+		assertEvaluatesTo("4.1E+3 AS STRING", "\"4100\"");
+		assertEvaluatesTo("3 days AS STRING", "\"3 days\"");
+		assertEvaluatesTo("1997-10-31T00:00:00 AS STRING", "\"1997-10-31T00:00:00\"");
+		assertEvaluatesTo("() AS STRING", "()");
+
+		// primary time is preserved
+		String data = createCodeBuilder()
+				.addData("x := 5; TIME x := 1997-10-31T00:00:00;")
+				.toString();
+		assertEvaluatesToWithData(data, "TIME (x AS STRING)", "1997-10-31T00:00:00");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testAsTruthValue() throws Exception {
+		assertEvaluatesTo("(0.33 AS TRUTH VALUE) IS WITHIN TRUTH VALUE 0.32 TO TRUTH VALUE 0.34", "TRUE");
+		assertEvaluatesTo("\"xyz\" AS TRUTH VALUE", "NULL");
+		assertEvaluatesTo("400 AS TRUTH VALUE", "NULL");
+		assertEvaluatesTo("TRUE AS TRUTH VALUE", "TRUE");
+		assertEvaluatesTo("FALSE AS TRUTH VALUE", "FALSE");
+		assertEvaluatesTo("0 AS TRUTH VALUE", "FALSE");
+		assertEvaluatesTo("1 AS TRUTH VALUE", "TRUE");
+		assertEvaluatesTo("() AS TRUTH VALUE", "()");
+
+		// primary time is preserved
+		String data = createCodeBuilder()
+				.addData("x := 0.8; TIME x := 1997-10-31T00:00:00;")
+				.toString();
+		assertEvaluatesToWithData(data, "TIME (x AS TRUTH VALUE)", "1997-10-31T00:00:00");
+	}
+}

--- a/test/arden/tests/specification/operators/WhereOperatorTest.java
+++ b/test/arden/tests/specification/operators/WhereOperatorTest.java
@@ -14,7 +14,7 @@ public class WhereOperatorTest extends SpecificationTest {
 		assertEvaluatesTo("1 WHERE FALSE", "()");
 		assertEvaluatesTo("(1,2,3) WHERE TRUE", "(1,2,3)");
 		assertEvaluatesTo("1 WHERE (TRUE,FALSE,TRUE)", "(1,1)");
-		
+
 		String data = createCodeBuilder()
 				.addData("x := 5; TIME x := 1990-01-01T00:00:00;")
 				.addData("y := 3; TIME y := 1990-01-02T00:00:00;")
@@ -26,25 +26,23 @@ public class WhereOperatorTest extends SpecificationTest {
 
 	@Test
 	public void testItemCondition() throws Exception {
-		String data = createCodeBuilder()
-				.addData("mylist := (1,2,\"a\");")
-				.toString();
+		String data = createCodeBuilder().addData("mylist := (1,2,\"a\");").toString();
 		assertEvaluatesToWithData(data, "mylist WHERE mylist <= 2", "(1,2)");
-		
+
 		assertEvaluatesTo("(1,2,\"a\") WHERE IT IS NUMBER", "(1,2)");
 		assertEvaluatesTo("(1,2,\"a\") WHERE THEY ARE NUMBER", "(1,2)");
 		assertEvaluatesTo("(1,2,3,4) WHERE (COUNT ((1,2,3,\"x\") WHERE IT IS NUMBER)) <= IT", "(3,4)");
 	}
-	
+
 	@Test
 	public void testInvalidIt() throws Exception {
 		// IT outside of WHERE -> error at compile time or NULL
-		String itOutsideOfWhere = createCodeBuilder().addAction("RETURN IT").toString();
+		String itOutsideOfWhere = createCodeBuilder().addAction("RETURN IT;").toString();
 		try {
 			getCompiler().compile(itOutsideOfWhere);
 			// no error at compile time -> must return NULL
 			assertReturns(itOutsideOfWhere, "NULL");
-		} catch(TestCompilerCompiletimeException e) {
+		} catch (TestCompilerCompiletimeException e) {
 			// error at compile time -> test passed
 		}
 	}

--- a/test/arden/tests/specification/operators/WhereOperatorTest.java
+++ b/test/arden/tests/specification/operators/WhereOperatorTest.java
@@ -2,7 +2,6 @@ package arden.tests.specification.operators;
 
 import org.junit.Test;
 
-import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.SpecificationTest;
 import arden.tests.specification.testcompiler.TestCompilerCompiletimeException;
 
@@ -16,7 +15,7 @@ public class WhereOperatorTest extends SpecificationTest {
 		assertEvaluatesTo("(1,2,3) WHERE TRUE", "(1,2,3)");
 		assertEvaluatesTo("1 WHERE (TRUE,FALSE,TRUE)", "(1,1)");
 		
-		String data = new ArdenCodeBuilder()
+		String data = createCodeBuilder()
 				.addData("x := 5; TIME x := 1990-01-01T00:00:00;")
 				.addData("y := 3; TIME y := 1990-01-02T00:00:00;")
 				.addData("z := 2; TIME z := 1990-01-03T00:00:00;")
@@ -27,7 +26,7 @@ public class WhereOperatorTest extends SpecificationTest {
 
 	@Test
 	public void testItemCondition() throws Exception {
-		String data = new ArdenCodeBuilder()
+		String data = createCodeBuilder()
 				.addData("mylist := (1,2,\"a\");")
 				.toString();
 		assertEvaluatesToWithData(data, "mylist WHERE mylist <= 2", "(1,2)");
@@ -40,7 +39,7 @@ public class WhereOperatorTest extends SpecificationTest {
 	@Test
 	public void testInvalidIt() throws Exception {
 		// IT outside of WHERE -> error at compile time or NULL
-		String itOutsideOfWhere = new ArdenCodeBuilder().addAction("RETURN IT").toString();
+		String itOutsideOfWhere = createCodeBuilder().addAction("RETURN IT").toString();
 		try {
 			getCompiler().compile(itOutsideOfWhere);
 			// no error at compile time -> must return NULL

--- a/test/arden/tests/specification/structureslots/ActionSlotTest.java
+++ b/test/arden/tests/specification/structureslots/ActionSlotTest.java
@@ -3,84 +3,176 @@ package arden.tests.specification.structureslots;
 import org.junit.Test;
 
 import arden.tests.specification.testcompiler.ArdenCodeBuilder;
+import arden.tests.specification.testcompiler.ArdenVersion;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
 import arden.tests.specification.testcompiler.TestCompilerException;
 
 public class ActionSlotTest extends SpecificationTest {
 	// TODO error on illegal statements
-	
+
+	@Test
+	@Compatibility(max = ArdenVersion.V2_1, pedantic = true)
+	public void testAssignmentForbidden() throws Exception {
+		// assignment not allowed before v2.5
+		String actionAssignment = createCodeBuilder().addAction("a := 5;").toString();
+		assertInvalid(actionAssignment);
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_5)
+	public void testAssignment() throws Exception {
+		String actionAssignment = createCodeBuilder()
+				.addAction("a := 5;")
+				.addAction("RETURN a;")
+				.toString();
+		assertReturns(actionAssignment, "5");
+	}
+
 	@Test
 	public void testWriteStatement() throws Exception {
 		String data = createCodeBuilder()
 				.addData("text := \"test message\";")
-				.addData("msg := MESSAGE {"+getMappings().getMessageMapping()+"};")
-				.addData("dest := DESTINATION {"+getMappings().getDestinationMapping()+"};")
+				.addData("msg := MESSAGE {" + getMappings().getMessageMapping() + "};")
+				.addData("dest := DESTINATION {" + getMappings().getDestinationMapping() + "};")
 				.toString();
-		
+
 		String textDefaultDestination = new ArdenCodeBuilder(data).addAction("WRITE text;").toString();
 		assertWrites(textDefaultDestination, "test message");
-		
+
 		String textAtDestination = new ArdenCodeBuilder(data).addAction("WRITE text AT dest;").toString();
 		assertWrites(textAtDestination, "test message");
-		
+
 		String messageDefaultDestination = new ArdenCodeBuilder(data).addAction("WRITE msg;").toString();
 		assertWrites(messageDefaultDestination, "test message");
-		
+
 		String messageAtDestination = new ArdenCodeBuilder(data).addAction("WRITE msg AT dest;").toString();
 		assertWrites(messageAtDestination, "test message");
-				
-		// TODO test if output is grouped with multiple async mlms
+
+		// TODO test if output is grouped with multiple async mlms?
 	}
-	
-	private void assertStatementReturns(String statement, String expected) throws TestCompilerException {
-		String code = createCodeBuilder().addAction(statement).toString();
-		assertReturns(code, expected);
-	}
-	
+
 	@Test
 	public void testReturnStatement() throws Exception {
-		assertStatementReturns("RETURN 5;","5");
-		assertStatementReturns("RETURN (5, 3);","(5,3)");
+		assertStatementReturns("RETURN 5;", "5");
+		assertStatementReturns("RETURN (5, 3);", "(5,3)");
 		assertStatementReturns("RETURN 1; RETURN 2;", "1");
-		
-		String multiReturn = createCodeBuilder().addAction("RETURN 5, (\"a\", \"b\");").toString();
-		assertReturns(multiReturn, "5", "(\"a\",\"b\")");
-		
+
+		// multi return
+		assertStatementReturns("RETURN 5, (\"a\", \"b\");", "5", "(\"a\",\"b\")");
+
 		String empty = createCodeBuilder().toString();
 		assertNoReturn(empty);
 	}
 
+	private void assertStatementReturns(String statement, String... expected) throws TestCompilerException {
+		String code = createCodeBuilder().addAction(statement).toString();
+		assertReturns(code, expected);
+	}
 
-	@Test
-	public void testCallStatement() throws Exception {
+	@Test(timeout = 5000)
+	public void testMlmCallStatement() throws Exception {
+		String startEvent = getMappings().createEventMapping();
 		String othermlm = createCodeBuilder()
-				.replaceSlotContent("mlmname:", "other_mlm")
+				.setName("other_mlm")
 				.addAction("WRITE \"test message\";")
 				.toString();
 		String data = createCodeBuilder()
 				.addMlm(othermlm)
-				.addData("othermlm := MLM 'other_mlm';")
+				.addData("other_mlm := MLM 'other_mlm';")
+				.addData("start_event := EVENT {" + startEvent + "};")
+				.addEvoke("start_event")
 				.toString();
-		
-		String call = new ArdenCodeBuilder(data).addAction("CALL othermlm;").toString();
-		assertValid(call);
-		
-		String delay = new ArdenCodeBuilder(data)
-				.addAction("CALL othermlm DELAY 1 MINUTE;")
-				.addAction("RETURN TRUE")
-				.toString();
-		assertReturns(delay, "TRUE");
-		
-		String args = new ArdenCodeBuilder(data).addAction("CALL othermlm WITH 5;").toString();
-		assertValid(args);
-		
-		String argsDelay = new ArdenCodeBuilder(data).addAction("CALL othermlm WITH 1,2,3 DELAY 10 SECONDS;").toString();
-		assertValid(argsDelay);
-		
-		String invalidReturn = new ArdenCodeBuilder(data).addAction("x := CALL othermlm;").toString();
+
+		String call = new ArdenCodeBuilder(data).addAction("CALL other_mlm;").toString();
+		assertDelayedBy(call, startEvent, 0);
+
+		String delay = new ArdenCodeBuilder(data).addAction("CALL other_mlm DELAY .7 SECONDS;").toString();
+		assertDelayedBy(delay, startEvent, 700);
+
+		String invalidReturn = new ArdenCodeBuilder(data).addAction("x := CALL other_mlm;").toString();
 		assertInvalid(invalidReturn);
-		
-		// TODO test if arguments are ignored on event call
+	}
+
+	@Test(timeout = 5000)
+	@Compatibility(min = ArdenVersion.V2)
+	public void testMlmCallArguments() throws Exception {
+		String startEvent = getMappings().createEventMapping();
+		String othermlm = createCodeBuilder()
+				.setName("other_mlm")
+				.addData("(arg1, arg2, arg3) := ARGUMENT")
+				.addAction("WRITE arg1 || arg2 || arg3;")
+				.toString();
+		String data = createCodeBuilder()
+				.addMlm(othermlm)
+				.addData("other_mlm := MLM 'other_mlm';")
+				.addData("start_event := EVENT {" + startEvent + "};")
+				.addEvoke("start_event")
+				.toString();
+
+		String args = new ArdenCodeBuilder(data).addAction("CALL other_mlm WITH 5;").toString();
+		assertWritesAfterEvent(args, startEvent, "5NULLNULL");
+
+		String argsDelay = new ArdenCodeBuilder(data)
+				.addAction("CALL other_mlm WITH 1,2,3 DELAY 0.6 SECONDS;")
+				.toString();
+		assertWritesAfterEvent(argsDelay, startEvent, "123");
+		assertDelayedBy(argsDelay, startEvent, 600);
+	}
+
+	@Test(timeout = 5000)
+	public void testEventCallStatement() throws Exception {
+		String startEvent = getMappings().createEventMapping();
+		String callEvent = getMappings().createEventMapping();
+		String othermlm = createCodeBuilder()
+				.setName("other_mlm")
+				.addData("call_event := EVENT {" + callEvent + "};")
+				.addEvoke("call_event")
+				.addAction("WRITE \"success\";")
+				.toString();
+		String data = createCodeBuilder()
+				.addMlm(othermlm)
+				.addData("start_event := EVENT {" + startEvent + "};")
+				.addData("call_event := EVENT {" + callEvent + "};")
+				.addEvoke("start_event")
+				.toString();
+	
+		String eventCall = new ArdenCodeBuilder(data).addAction("CALL call_event;").toString();
+		assertDelayedBy(eventCall, startEvent, 0);
+	
+		String delay = new ArdenCodeBuilder(data).addAction("CALL call_event DELAY .7 SECONDS;").toString();
+		assertDelayedBy(delay, startEvent, 700);
+	
+		String invalidReturn = new ArdenCodeBuilder(data).addAction("x := CALL call_event;").toString();
+		assertInvalid(invalidReturn);
+	}
+
+	@Test(timeout = 5000)
+	@Compatibility(min = ArdenVersion.V2)
+	public void testEventCallArguments() throws Exception {
+		String startEvent = getMappings().createEventMapping();
+		String callEvent = getMappings().createEventMapping();
+		String othermlm = createCodeBuilder()
+				.setName("other_mlm")
+				.addData("call_event := EVENT {" + callEvent + "};")
+				.addData("arg := ARGUMENT;")
+				.addEvoke("call_event")
+				.addAction("WRITE arg;")
+				.toString();
+		String data = createCodeBuilder()
+				.addMlm(othermlm)
+				.addData("start_event := EVENT {" + startEvent + "};")
+				.addData("call_event := EVENT {" + callEvent + "};")
+				.addEvoke("start_event")
+				.toString();
+
+		String args = new ArdenCodeBuilder(data).addAction("CALL call_event WITH 5;").toString();
+		assertWritesAfterEvent(args, startEvent, "NULL");
+
+		String argsDelay = new ArdenCodeBuilder(data)
+				.addAction("CALL call_event WITH 1,2,3 DELAY 0.6 SECONDS;")
+				.toString();
+		assertDelayedBy(argsDelay, startEvent, 600);
 	}
 
 }

--- a/test/arden/tests/specification/structureslots/ActionSlotTest.java
+++ b/test/arden/tests/specification/structureslots/ActionSlotTest.java
@@ -11,7 +11,7 @@ public class ActionSlotTest extends SpecificationTest {
 	
 	@Test
 	public void testWriteStatement() throws Exception {
-		String data = new ArdenCodeBuilder()
+		String data = createCodeBuilder()
 				.addData("text := \"test message\";")
 				.addData("msg := MESSAGE {"+getMappings().getMessageMapping()+"};")
 				.addData("dest := DESTINATION {"+getMappings().getDestinationMapping()+"};")
@@ -33,7 +33,7 @@ public class ActionSlotTest extends SpecificationTest {
 	}
 	
 	private void assertStatementReturns(String statement, String expected) throws TestCompilerException {
-		String code = new ArdenCodeBuilder().addAction(statement).toString();
+		String code = createCodeBuilder().addAction(statement).toString();
 		assertReturns(code, expected);
 	}
 	
@@ -43,21 +43,21 @@ public class ActionSlotTest extends SpecificationTest {
 		assertStatementReturns("RETURN (5, 3);","(5,3)");
 		assertStatementReturns("RETURN 1; RETURN 2;", "1");
 		
-		String multiReturn = new ArdenCodeBuilder().addAction("RETURN 5, (\"a\", \"b\");").toString();
+		String multiReturn = createCodeBuilder().addAction("RETURN 5, (\"a\", \"b\");").toString();
 		assertReturns(multiReturn, "5", "(\"a\",\"b\")");
 		
-		String empty = new ArdenCodeBuilder().toString();
+		String empty = createCodeBuilder().toString();
 		assertNoReturn(empty);
 	}
 
 
 	@Test
 	public void testCallStatement() throws Exception {
-		String othermlm = new ArdenCodeBuilder()
+		String othermlm = createCodeBuilder()
 				.replaceSlotContent("mlmname:", "other_mlm")
 				.addAction("WRITE \"test message\";")
 				.toString();
-		String data = new ArdenCodeBuilder()
+		String data = createCodeBuilder()
 				.addMlm(othermlm)
 				.addData("othermlm := MLM 'other_mlm';")
 				.toString();

--- a/test/arden/tests/specification/structureslots/DataSlotTest.java
+++ b/test/arden/tests/specification/structureslots/DataSlotTest.java
@@ -13,14 +13,14 @@ public class DataSlotTest extends SpecificationTest {
 		String readMapping = getMappings().getReadMapping();
 		String readMultiMapping = getMappings().getReadMultipleMapping();
 		
-		String sortedByTime1 = new ArdenCodeBuilder()
+		String sortedByTime1 = createCodeBuilder()
 				.addData("first_ := READ FIRST {"+readMapping+"};")
 				.addData("earliest_  := READ EARLIEST {"+readMapping+"};")
 				.addAction("RETURN first_ = earliest_;")
 				.toString();
 		assertReturns(sortedByTime1, "TRUE");
 		
-		String sortedByTime2 = new ArdenCodeBuilder()
+		String sortedByTime2 = createCodeBuilder()
 				.addData("last_ := READ LAST {"+readMapping+"};")
 				.addData("latest_  := READ LATEST {"+readMapping+"};")
 				.addAction("RETURN last_ = latest_;")
@@ -36,13 +36,13 @@ public class DataSlotTest extends SpecificationTest {
 		// no aggregation
 		assertEvaluatesTo("READ {"+readMapping+"}", "(5,3,2,4,1)");
 		
-		String multipleResults = new ArdenCodeBuilder()
+		String multipleResults = createCodeBuilder()
 				.addData("(id, val):= READ LAST 2 FROM {"+readMultiMapping+"};")
 				.addAction("RETURN (id, val);")
 				.toString();
 		assertReturns(multipleResults, "(4,1,\"d\",\"a\")");
 		
-		String readAs = new ArdenCodeBuilder()
+		String readAs = createCodeBuilder()
 				.addData("DbResult := OBJECT [Id, Val];")
 				.addData("entries := READ AS DbResult {"+readMultiMapping+"};")
 				.addAction("RETURN entries.val;")
@@ -58,7 +58,7 @@ public class DataSlotTest extends SpecificationTest {
 	@Test
 	public void testEventStatement() throws Exception {
 		// usable as boolean
-		String other_mlm = new ArdenCodeBuilder()
+		String other_mlm = createCodeBuilder()
 				.replaceSlotContent("mlmname:", "other_mlm")
 				.addData("test_event := EVENT {"+getMappings().getEventMapping()+"};")
 				.addEvoke("test_event;")
@@ -67,7 +67,7 @@ public class DataSlotTest extends SpecificationTest {
 				.addAction("RETURN 2;")
 				.toString();
 		
-		String eventAsBoolean = new ArdenCodeBuilder()
+		String eventAsBoolean = createCodeBuilder()
 			.addMlm(other_mlm)
 			.addData("test_event := EVENT {"+getMappings().getEventMapping()+"};")
 			.clearSlotContent("logic:")
@@ -82,27 +82,27 @@ public class DataSlotTest extends SpecificationTest {
 	public void testMlmStatement() throws Exception {
 		// mlm search algorithm
 		// 1. institution (mlm_self if missing) 2. mlmname 3. validation (only with institution missing) 4. version
-		String mlm1_instself = new ArdenCodeBuilder()
+		String mlm1_instself = createCodeBuilder()
 				.replaceSlotContent("mlmname:", "mlm1")
 				.addExpression("\"mlm1_instself\"")
 				.toString();
-		String mlm1_instother = new ArdenCodeBuilder()
+		String mlm1_instother = createCodeBuilder()
 				.replaceSlotContent("mlmname:", "mlm1")
 				.replaceSlotContent("institution:", "other_institute")
 				.addExpression("\"mlm1_instother\"")
 				.toString();
-		String mlm2_testing = new ArdenCodeBuilder()
+		String mlm2_testing = createCodeBuilder()
 				.replaceSlotContent("mlmname:", "mlm2")
 				.replaceSlotContent("validation:", "testing")
 				.addExpression("\"mlm2_testing\"")
 				.toString();
-		String mlm2_production = new ArdenCodeBuilder()
+		String mlm2_production = createCodeBuilder()
 				.replaceSlotContent("mlmname:", "mlm2")
 				.replaceSlotContent("validation:", "production")
 				.addExpression("\"mlm2_production\"")				
 				.toString();
 		
-		String data = new ArdenCodeBuilder()
+		String data = createCodeBuilder()
 				.addMlm(mlm1_instother)
 				.addMlm(mlm1_instself)
 				.addMlm(mlm2_testing)
@@ -123,7 +123,7 @@ public class DataSlotTest extends SpecificationTest {
 		assertReturns(validation, "\"mlm2_production\"");
 		
 		// mlm self
-		String mlmSelf = new ArdenCodeBuilder()
+		String mlmSelf = createCodeBuilder()
 				.addData("this := MLM MLM_SELF;")
 				.addData("arg := ARGUMENT;")
 				.clearSlotContent("logic:")
@@ -140,12 +140,12 @@ public class DataSlotTest extends SpecificationTest {
 
 	@Test
 	public void testArgumentStatement() throws Exception {
-		String othermlm = new ArdenCodeBuilder()
+		String othermlm = createCodeBuilder()
 				.replaceSlotContent("mlmname:", "other_mlm")
 				.addData("(x,y) := ARGUMENT;")
 				.addAction("RETURN (x,y);")
 				.toString();
-		String mlmSelf = new ArdenCodeBuilder()
+		String mlmSelf = createCodeBuilder()
 				.addMlm(othermlm)
 				.addData("othermlm := MLM 'other_mlm';")
 				.clearSlotContent("logic:")
@@ -158,19 +158,19 @@ public class DataSlotTest extends SpecificationTest {
 
 	@Test
 	public void testMessageStatement() throws Exception {
-		String message = new ArdenCodeBuilder()
+		String message = createCodeBuilder()
 				.addData("m := MESSAGE {"+getMappings().getMessageMapping()+"};")
 				.toString();
 		assertValid(message);
 		
 		// TODO too implementation specific? 		
-		//		String messageAs = new ArdenCodeBuilder()
+		//		String messageAs = createCodeBuilder()
 		//				.addData("Email := OBJECT [subject, text];")
 		//				.addData("mail := MESSAGE AS Email {"+getMappings().getMessageMapping()+"};")
 		//				.toString();
 		//		assertValid(messageAs);
 		//		
-		//		String messageAsDefault = new ArdenCodeBuilder()
+		//		String messageAsDefault = createCodeBuilder()
 		//				.addData("Email := OBJECT [subject, text];")
 		//				.addData("mail := MESSAGE AS Email;")
 		//				.toString();
@@ -179,19 +179,19 @@ public class DataSlotTest extends SpecificationTest {
 
 	@Test
 	public void testDestinationStatement() throws Exception {
-		String destination = new ArdenCodeBuilder()
+		String destination = createCodeBuilder()
 				.addData("d := DESTINATION {"+getMappings().getDestinationMapping()+"};")
 				.toString();
 		assertValid(destination);
 		
 		// TODO too implementation specific?		
-		//		String destinationAs = new ArdenCodeBuilder()
+		//		String destinationAs = createCodeBuilder()
 		//				.addData("File := OBJECT [name];")
 		//				.addData("d := DESTINATION AS File {"+getMappings().getDestinationMapping()+"};")
 		//				.toString();
 		//		assertValid(destinationAs);
 		//		
-		//		String destinationAsDefault = new ArdenCodeBuilder()
+		//		String destinationAsDefault = createCodeBuilder()
 		//				.addData("File := OBJECT [name];")
 		//				.addData("d := DESTINATION AS File;")
 		//				.toString();
@@ -200,7 +200,7 @@ public class DataSlotTest extends SpecificationTest {
 
 	@Test
 	public void testObjectStatement() throws Exception {
-		String object = new ArdenCodeBuilder()
+		String object = createCodeBuilder()
 				.addData("Patient := OBJECT [Name, DateOfBirth, Id];")
 				.addData("p := NEW patient;")
 				.toString();
@@ -209,16 +209,16 @@ public class DataSlotTest extends SpecificationTest {
 
 	@Test
 	public void testIncludeStatement() throws Exception {
-		String mlm1 = new ArdenCodeBuilder()
+		String mlm1 = createCodeBuilder()
 				.replaceSlotContent("mlmname:", "mlm1")
 				.addData("Patient := OBJECT [Name, DateOfBirth, Id];")
 				.toString();
-		String mlm2 = new ArdenCodeBuilder()
+		String mlm2 = createCodeBuilder()
 				.replaceSlotContent("mlmname:", "mlm2")
 				.addData("Patient := OBJECT [Id, Name, DateOfBirth, Gender, Phone];")
 				.toString();
 		
-		String include = new ArdenCodeBuilder()
+		String include = createCodeBuilder()
 				.addMlm(mlm1)
 				.addData("othermlm := MLM 'mlm1';")
 				.addData("INCLUDE othermlm;")
@@ -228,7 +228,7 @@ public class DataSlotTest extends SpecificationTest {
 				.toString();
 		assertReturns(include, "5");
 		
-		String localPrecedence = new ArdenCodeBuilder()
+		String localPrecedence = createCodeBuilder()
 				.addMlm(mlm1)
 				.addData("Patient := OBJECT [Id, Name, Phone];")
 				.addData("othermlm := MLM 'mlm1';")
@@ -239,7 +239,7 @@ public class DataSlotTest extends SpecificationTest {
 				.toString();
 		assertReturns(localPrecedence, "12345");
 		
-		String latestPrecedence = new ArdenCodeBuilder()
+		String latestPrecedence = createCodeBuilder()
 				.addMlm(mlm1)
 				.addMlm(mlm2)
 				.addData("mlm1 := MLM 'mlm1';")

--- a/test/arden/tests/specification/structureslots/EvokeSlotTest.java
+++ b/test/arden/tests/specification/structureslots/EvokeSlotTest.java
@@ -3,24 +3,26 @@ package arden.tests.specification.structureslots;
 import org.junit.Test;
 
 import arden.tests.specification.testcompiler.ArdenCodeBuilder;
+import arden.tests.specification.testcompiler.ArdenVersion;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
+import arden.tests.specification.testcompiler.TestCompilerException;
 
 public class EvokeSlotTest extends SpecificationTest {
-	private final String event_data = createCodeBuilder()
-			.addData("test_event := EVENT {" + getMappings().getEventMapping() + "};")
-			.toString();
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testTimeOfEvent() throws Exception {
-		
-		String othermlm = new ArdenCodeBuilder(event_data)
+		String event = getMappings().createEventMapping();
+		String othermlm = createCodeBuilder()
 				.replaceSlotContent("mlmname:", "other_mlm")
+				.addData("test_event := EVENT {" + event + "};")
 				.addEvoke("test_event;")
 				.addAction("RETURN (TIME OF test_event = eventtime);")
 				.toString();
-		String eventtime = new ArdenCodeBuilder(event_data)
+		String eventtime = createEmptyLogicSlotCodeBuilder()
 				.addMlm(othermlm)
-				.clearSlotContent("logic:")
+				.addData("test_event := EVENT {" + event + "};")
 				.addLogic("result := CALL test_event;")
 				.addLogic("CONCLUDE TRUE;")
 				.addAction("RETURN result;")
@@ -28,69 +30,212 @@ public class EvokeSlotTest extends SpecificationTest {
 		assertReturns(eventtime, "TRUE");
 	}
 
-	@Test
-	public void testSimpleTriggerStatement() throws Exception {
+	@Test(timeout = 5000)
+	public void testSimpleTrigger() throws Exception {
+		assertDelayedBy("test_event", 0);
+		assertDelayedBy("TIME OF test_event", 0);
+
+		String eventMapping = getMappings().createEventMapping();
 		String any = createCodeBuilder()
-				.addData("test_event1 := EVENT {" + getMappings().getEventMapping() + "};")
-				.addData("test_event2 := EVENT {" + getMappings().getEventMapping() + "};")
-				.addData("test_event3 := EVENT {" + getMappings().getEventMapping() + "};")
-				.addEvoke("test_event1 OR ANY OF(test_event2, test_event3);")
+				.addData("test_event1 := EVENT {" + getMappings().createEventMapping() + "};")
+				.addData("test_event2 := EVENT {" + eventMapping + "};")
+				.addData("test_event3 := EVENT {" + getMappings().createEventMapping() + "};")
+				.addEvoke("test_event1 OR ANY OF(test_event2, test_event3)")
+				.addAction("WRITE \"success\";")
 				.toString();
-		assertValid(any);
-		
+		assertDelayedBy(any, eventMapping, 0);
+
 		String invalidEvent = createCodeBuilder()
 				.addData("a := 5;")
 				.addEvoke("a;")
 				.toString();
 		assertInvalid(invalidEvent);
-		
-		String othermlm = createCodeBuilder()
-				.replaceSlotContent("mlmname:", "other_mlm")
-				.addEvoke("CALL;")
-				.toString();
-		String call = createCodeBuilder()
-				.addMlm(othermlm)
-				.addData("othermlm := MLM 'other_mlm';")
-				.addAction("CALL othermlm;")
-				.toString();
-		assertValid(call);
-		
-		// TODO test logic
+	}
+
+	@Test(timeout = 5000)
+	public void testDelayedEventTrigger() throws Exception {
+		// duration
+		assertDelayedBy(".5 SECONDS AFTER TIME OF test_event", 500);
+		assertDelayedBy(".5 SECONDS AFTER .5 SECOND AFTER TIME OF test_event", 1000);
+		assertInvalidEvokeStatement("10 SECONDS BEFORE TIME OF test_event");
+	}
+
+	@Test(timeout = 5000)
+	@Compatibility(min = ArdenVersion.V2_7)
+	public void testDelayedEventTriggerRelativeConstant() throws Exception {
+		// time constant (in the past, so execute immediately)
+		assertDelayedBy("1800-01-01 AFTER TIME OF test_event", 0);
+
+		// day of week attime time of day
+		assertValidEvokeStatement("MONDAY ATTIME 12:00 AFTER TIME OF test_event");
+		assertValidEvokeStatement("TUESDAY ATTIME 12:00:00 AFTER TIME OF test_event");
+		assertValidEvokeStatement("WEDNESDAY ATTIME 12:00:30Z OR FRIDAY AT 20:00 AFTER TIME OF test_event");
+
+		// reserved words (in the past, so executed immediately)
+		assertDelayedBy("TODAY ATTIME 00:00 AFTER TIME OF test_event", 0);
+		assertDelayedBy("TODAY ATTIME 00:00:00 AFTER TIME OF test_event", 0);
+		assertValidEvokeStatement("TOMORROW ATTIME 12:00 AFTER TIME OF test_event");
+	}
+
+	@Test(timeout = 5000)
+	@Compatibility(min = ArdenVersion.V2_6, max = ArdenVersion.V2_6, pedantic = true)
+	public void testDelayedEventTriggerRelativeConstantV2_6() throws Exception {
+		// time constant
+		assertDelayedBy("1800-01-01 AFTER TIME OF test_event", 0);
+
+		// day of week at time of day
+		assertValidEvokeStatement("MONDAY AT 12:00 AFTER TIME OF test_event");
+		assertValidEvokeStatement("TUESDAY AT 12:00:00 AFTER TIME OF test_event");
+		assertValidEvokeStatement("WEDNESDAY AT 12:00:30Z OR FRIDAY AT 20:00 AFTER TIME OF test_event");
+
+		// reserved word
+		assertDelayedBy("TODAY AT 00:00 AFTER TIME OF test_event", 0);
+		assertDelayedBy("TODAY AT 00:00:00 AFTER TIME OF test_event", 0);
+		assertValidEvokeStatement("TOMORROW AT 12:00 AFTER TIME OF test_event");
 	}
 
 	@Test
-	public void testDelayedTriggerStatement() throws Exception {
-		String after = new ArdenCodeBuilder(event_data).addEvoke("10 SECONDS AFTER TIME OF test_event;").toString();
-		assertValid(after);
-		
-		String before = new ArdenCodeBuilder(event_data).addEvoke("10 SECONDS BEFORE TIME OF test_event;").toString();
-		assertInvalid(before);
-		
-		String time = new ArdenCodeBuilder(event_data).addEvoke("2016-01-01T12:00:00; 2016-01-02T12:00:00;").toString();
-		assertValid(time);
-		
-		String date = new ArdenCodeBuilder(event_data).addEvoke("2016-01-01;").toString();
-		assertValid(date);
-		
-		String eventTime = new ArdenCodeBuilder(event_data).addEvoke("TIME OF test_event;").toString();
-		assertValid(eventTime);
-		
-		String duration = new ArdenCodeBuilder(event_data).addEvoke("5 SECONDS;").toString();
-		assertInvalid(duration);
+	public void testConstantTimeTrigger() throws Exception {
+		String datetime = createCodeBuilder()
+				.addEvoke("2016-01-01T12:00:00;")
+				.addEvoke("2016-01-02T12:00:00;")
+				.toString();
+		assertValid(datetime);
+
+		assertDelayedBy("1800-02-05", 0);
+		assertDelayedBy("1 WEEK AFTER 1800-01-01", 0);
 	}
 
-	@Test
-	public void testPeriodicTriggerStatement() throws Exception {
-		String simple = new ArdenCodeBuilder(event_data).addEvoke("EVERY 15 SECONDS FOR 1 HOUR STARTING TIME test_event;").toString();
-		assertValid(simple);
-		
-		String complex  = new ArdenCodeBuilder(event_data).addEvoke("EVERY 2 HOURS FOR 1 DAY STARTING 5 HOURS AFTER THE TIME OF test_event;").toString();
-		assertValid(complex);
-		
-		String condition = new ArdenCodeBuilder(event_data)
+	@Test(timeout = 5000)
+	@Compatibility(min = ArdenVersion.V2_7)
+	public void testConstantTimeTriggerTimeExpression() throws Exception {
+		assertDelayedBy("1 SECOND", 1000);
+		assertDelayedBy("TODAY ATTIME 00:00:00", 0);
+		assertValidEvokeStatement("TOMORROW ATTIME 02:30");
+		assertValidEvokeStatement("MONDAY ATTIME 02:30");
+	}
+
+	@Test(timeout = 5000)
+	@Compatibility(min = ArdenVersion.V2_6, max = ArdenVersion.V2_6, pedantic = true)
+	public void testConstantTimeTriggerTimeExpressionV2_6() throws Exception {
+		assertDelayedBy("1 SECOND", 1000);
+		assertDelayedBy("TODAY AT 00:00:00", 0);
+		assertValidEvokeStatement("TOMORROW AT 02:30");
+		assertValidEvokeStatement("MONDAY AT 02:30");
+	}
+
+	@Test(timeout = 10000)
+	public void testPeriodicEventTrigger() throws Exception {
+		String eventMapping = getMappings().createEventMapping();
+		String data = createCodeBuilder()
+				.addData("test_event := EVENT {" + eventMapping + "};")
+				.addAction("WRITE \"success\";")
+				.toString();
+
+		String simple = new ArdenCodeBuilder(data)
+				.addEvoke("EVERY 1 SECOND FOR 2 SECONDS STARTING TIME OF test_event")
+				.toString();
+		assertDelayedBy(simple, eventMapping, 0, 1000, 2000);
+
+		String complex = new ArdenCodeBuilder(data)
+				.addEvoke("EVERY 1 SECONDS FOR 2 SECONDS STARTING .7 SECONDS AFTER THE TIME OF test_event")
+				.toString();
+		assertDelayedBy(complex, eventMapping, 700, 1700, 2700);
+
+		String condition = new ArdenCodeBuilder(data)
 				.addData("a := 0;")
-				.addEvoke("EVERY 1 WEEK FOR 6 MONTHS STARTING 1990-01-01T12:00:00 UNTIL a > 5;").toString();
+				.addEvoke("EVERY 1 WEEK FOR 6 MONTHS STARTING 1990-01-01T12:00:00 UNTIL a > 5")
+				.toString();
 		assertValid(condition);
+	}
+
+	@Test(timeout = 10000)
+	@Compatibility(min = ArdenVersion.V2_7)
+	public void testPeriodicEventTriggerRelativeConstant() throws Exception {
+		assertValidEvokeStatement("EVERY 1 YEAR FOR 99 YEARS STARTING 2010-06-03T12:33:00Z AFTER TIME OF test_event");
+		assertValidEvokeStatement("EVERY 1 HOUR FOR 2 WEEKS STARTING TODAY ATTIME 12:33:54Z AFTER TIME OF test_event");
+	}
+
+	@Test(timeout = 10000)
+	@Compatibility(min = ArdenVersion.V2_6, max = ArdenVersion.V2_6, pedantic = true)
+	public void testPeriodicEventTriggerRelativeConstantV2_6() throws Exception {
+		assertValidEvokeStatement("EVERY 1 YEAR FOR 99 YEARS STARTING 2010-06-03T12:33:00Z AFTER TIME OF test_event");
+		assertValidEvokeStatement("EVERY 1 HOUR FOR 2 WEEKS STARTING TODAY AT 12:33:54Z AFTER TIME OF test_event");
+	}
+
+	@Test
+	public void testConstantPeriodicTimeTrigger() throws Exception {
+		assertValidEvokeStatement("EVERY 1 DAY FOR 14 DAYS STARTING 1992-01-01T00:00:00");
+		assertValidEvokeStatement("EVERY 1 WEEK FOR 1 MONTH STARTING 3 DAYS AFTER 1992-01-01T00:00:00 UNTIL TRUE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_7)
+	public void testConstantPeriodicTimeTriggerRelativeConstant() throws Exception {
+		assertValidEvokeStatement("EVERY 2 HOURS FOR 1 DAY STARTING TODAY ATTIME 12:00");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_6, max = ArdenVersion.V2_6, pedantic = true)
+	public void testConstantPeriodicTimeTriggerRelativeConstantV2_6() throws Exception {
+		assertValidEvokeStatement("EVERY 2 HOURS FOR 1 DAY STARTING TODAY AT 12:00");
+	}
+
+	@Test
+	@Compatibility(max = ArdenVersion.V2, pedantic = true)
+	public void testWhereTriggerStatement() throws Exception {
+		assertValidEvokeStatement("test_event WHERE TRUE");
+
+		String complex = createCodeBuilder()
+				.addData("penicillin_storage := EVENT {" + getMappings().createEventMapping() + "};")
+				.addData("cephalosporin_storage := EVENT {" + getMappings().createEventMapping() + "};")
+				.addData("penicillin_dose := 600;")
+				.addData("cephalosporin_dose := 400;")
+				.addEvoke("(penicillin_storage WHERE penicillin_dose > 500) OR (cephalosporin_storage WHERE cephalosporin_dose > 500)")
+				.addAction("WRITE \"success\";")
+				.toString();
+		assertValid(complex);
+	}
+
+	@Test
+	@Compatibility(max = ArdenVersion.V1)
+	public void testCallStatement() throws Exception {
+		assertValidEvokeStatement("CALL");
+	}
+
+	@Test(timeout = 5000)
+	@Compatibility(min = ArdenVersion.V2)
+	public void testCombinedDelay() throws Exception {
+		String startEvent = getMappings().createEventMapping();
+		String callEvent = getMappings().createEventMapping();
+		String othermlm = createCodeBuilder().replaceSlotContent("mlmname:", "other_mlm")
+				.addEvoke(".5 SECONDS AFTER TIME OF call_event") // 2. delay
+				.addAction("WRITE \"success\";").toString();
+		String combinedDelay = createCodeBuilder().addMlm(othermlm)
+				.addData("start_event := EVENT {" + startEvent + "};")
+				.addData("call_event := EVENT {" + callEvent + "};").addEvoke("start_event")
+				.addAction("CALL call_event DELAY 0.5 SECONDS;") // 1. delay
+				.toString();
+		assertDelayedBy(combinedDelay, startEvent, 1000);
+	}
+
+	private void assertDelayedBy(String evokeStatement, int delay) throws TestCompilerException {
+		String eventMapping = getMappings().createEventMapping();
+		String code = createCodeBuilder().addData("test_event := EVENT {" + eventMapping + "};")
+				.addEvoke(evokeStatement).addAction("WRITE \"success\";").toString();
+		assertDelayedBy(code, eventMapping, delay);
+	}
+
+	private void assertInvalidEvokeStatement(String evokeStatement) throws TestCompilerException {
+		String code = createCodeBuilder().addData("test_event := EVENT {" + getMappings().createEventMapping() + "};")
+				.addEvoke(evokeStatement).addAction("WRITE \"success\";").toString();
+		assertInvalid(code);
+	}
+
+	private void assertValidEvokeStatement(String evokeStatement) throws TestCompilerException {
+		String code = createCodeBuilder().addData("test_event := EVENT {" + getMappings().createEventMapping() + "};")
+				.addEvoke(evokeStatement).addAction("WRITE \"success\";").toString();
+		assertValid(code);
 	}
 
 }

--- a/test/arden/tests/specification/structureslots/EvokeSlotTest.java
+++ b/test/arden/tests/specification/structureslots/EvokeSlotTest.java
@@ -6,7 +6,7 @@ import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class EvokeSlotTest extends SpecificationTest {
-	private final String event_data = new ArdenCodeBuilder()
+	private final String event_data = createCodeBuilder()
 			.addData("test_event := EVENT {" + getMappings().getEventMapping() + "};")
 			.toString();
 
@@ -30,7 +30,7 @@ public class EvokeSlotTest extends SpecificationTest {
 
 	@Test
 	public void testSimpleTriggerStatement() throws Exception {
-		String any = new ArdenCodeBuilder()
+		String any = createCodeBuilder()
 				.addData("test_event1 := EVENT {" + getMappings().getEventMapping() + "};")
 				.addData("test_event2 := EVENT {" + getMappings().getEventMapping() + "};")
 				.addData("test_event3 := EVENT {" + getMappings().getEventMapping() + "};")
@@ -38,17 +38,17 @@ public class EvokeSlotTest extends SpecificationTest {
 				.toString();
 		assertValid(any);
 		
-		String invalidEvent = new ArdenCodeBuilder()
+		String invalidEvent = createCodeBuilder()
 				.addData("a := 5;")
 				.addEvoke("a;")
 				.toString();
 		assertInvalid(invalidEvent);
 		
-		String othermlm = new ArdenCodeBuilder()
+		String othermlm = createCodeBuilder()
 				.replaceSlotContent("mlmname:", "other_mlm")
 				.addEvoke("CALL;")
 				.toString();
-		String call = new ArdenCodeBuilder()
+		String call = createCodeBuilder()
 				.addMlm(othermlm)
 				.addData("othermlm := MLM 'other_mlm';")
 				.addAction("CALL othermlm;")

--- a/test/arden/tests/specification/structureslots/LogicSlotTest.java
+++ b/test/arden/tests/specification/structureslots/LogicSlotTest.java
@@ -3,32 +3,22 @@ package arden.tests.specification.structureslots;
 import org.junit.Test;
 
 import arden.tests.specification.testcompiler.ArdenCodeBuilder;
+import arden.tests.specification.testcompiler.ArdenVersion;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
+import arden.tests.specification.testcompiler.TestCompilerException;
 
 public class LogicSlotTest extends SpecificationTest {
 	// TODO error on illegal statements
-	
-	private ArdenCodeBuilder createEmptyLogicSlotCodeBuilder() {
-		return createCodeBuilder().clearSlotContent("logic:");
-	}
 
 	@Test
 	public void testAssignmentStatement() throws Exception {
-		String data = createEmptyLogicSlotCodeBuilder()
-				.addData("Pixel := OBJECT [x, y];")
-				.addData("p := new Pixel;")
-				.toString();
-		
-		String let = createEmptyLogicSlotCodeBuilder()
-				.addLogic("LET v BE 5;")
-				.toString();
+		String let = createEmptyLogicSlotCodeBuilder().addLogic("LET v BE 5;").toString();
 		assertValid(let);
-		
-		String assignNull = createEmptyLogicSlotCodeBuilder()
-				.addLogic("x := NULL;")
-				.toString();
-		assertValid(assignNull);	
-		
+
+		String assignNull = createEmptyLogicSlotCodeBuilder().addLogic("x := NULL;").toString();
+		assertValid(assignNull);
+
 		String notReference = createEmptyLogicSlotCodeBuilder()
 				.addLogic("a := 5;")
 				.addLogic("b := a + 3;")
@@ -37,7 +27,15 @@ public class LogicSlotTest extends SpecificationTest {
 				.addAction("RETURN b;")
 				.toString();
 		assertReturns(notReference, "8");
-		
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_5)
+	public void testObjectAttributeAssignment() throws Exception {
+		String data = createEmptyLogicSlotCodeBuilder()
+				.addData("Pixel := OBJECT [x, y];")
+				.addData("p := new Pixel;")
+				.toString();
 		String attrs = new ArdenCodeBuilder(data)
 				.addLogic("p.x := 0;")
 				.addLogic("p.y := 10;")
@@ -45,14 +43,14 @@ public class LogicSlotTest extends SpecificationTest {
 				.addAction("RETURN p.x;")
 				.toString();
 		assertReturns(attrs, "0");
-		
+
 		String invalidAttr = new ArdenCodeBuilder(data)
 				.addLogic("p.w := 10;")
 				.addLogic("CONCLUDE TRUE;")
 				.addAction("RETURN p.w;")
 				.toString();
 		assertReturns(invalidAttr, "NULL");
-		
+
 		String reference = new ArdenCodeBuilder(data)
 				.addLogic("p.x := 10;")
 				.addLogic("p2 := p;")
@@ -62,33 +60,91 @@ public class LogicSlotTest extends SpecificationTest {
 				.toString();
 		assertReturns(reference, "5");
 	}
-	
+
 	@Test
-	public void testReassignment() throws Exception {
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testEnhancedAssignmentStatement() throws Exception {
+		String index = createEmptyLogicSlotCodeBuilder()
+				.addData("values := 2, 4, 8;")
+				.addLogic("values[3] := 6;")
+				.addLogic("CONCLUDE TRUE;")
+				.addAction("RETURN values;")
+				.toString();
+		assertReturns(index, "(2,4,6)");
+
+		String data = createEmptyLogicSlotCodeBuilder()
+				.addData("Patient := OBJECT [name, date_of_birth, id];")
+				.addData("john := NEW Patient WITH \"John\";")
+				.addData("jane := NEW Patient WITH \"Jane\";")
+				.addData("alice := NEW Patient WITH \"Alice\";")
+				.addData("Room := OBJECT [room_number, patients];")
+				.addData("room_40 := NEW Room WITH 40, (john, jane, alice);")
+				.toString();
+
+		String simple = new ArdenCodeBuilder(data)
+				.addLogic("room_40.patients[2].id := 123;")
+				.addLogic("CONCLUDE TRUE;")
+				.addAction("RETURN jane.id")
+				.toString();
+		assertReturns(simple, "123");
+
+		String replaceItem = new ArdenCodeBuilder(data)
+				.addLogic("room_40.patients[3] := NEW Patient WITH \"Bob\";")
+				.addLogic("bob := room_40.patients[3];")
+				.addLogic("CONCLUDE TRUE;")
+				.addAction("RETURN bob.name")
+				.toString();
+		assertReturns(replaceItem, "\"Bob\"");
+
+		String massAssignment = new ArdenCodeBuilder(data)
+				.addLogic("room_40.patients.date_of_birth := 1970-01-01T01:02:03;")
+				.addLogic("CONCLUDE TRUE;")
+				.addAction("RETURN alice.date_of_birth")
+				.toString();
+		assertReturns(massAssignment, "1970-01-01T01:02:03");
+	}
+
+	@Test(expected = TestCompilerException.class)
+	public void testEventReassignment() throws Exception {
+		String event = createEmptyLogicSlotCodeBuilder()
+				.addData("e := EVENT {" + getMappings().createEventMapping() + "};")
+				.addLogic("e := 5;")
+				.toString();
+		getCompiler().compileAndRun(event);
+	}
+
+	@Test(expected = TestCompilerException.class)
+	public void testMlmReassignment() throws Exception {
+		String mlm = createEmptyLogicSlotCodeBuilder()
+				.addData("mymlm := MLM MLM_SELF;")
+				.addLogic("mymlm := 3;")
+				.toString();
+		getCompiler().compileAndRun(mlm);
+	}
+
+	@Test(expected = TestCompilerException.class)
+	@Compatibility(min = ArdenVersion.V2)
+	public void testInterfaceReassignment() throws Exception {
+		String interface_ = createEmptyLogicSlotCodeBuilder()
+				.addData("i := INTERFACE {" + getMappings().getInterfaceMapping() + "};")
+				.addLogic("i := 5;")
+				.toString();
+		getCompiler().compileAndRun(interface_);
+	}
+
+	@Test(expected = TestCompilerException.class)
+	@Compatibility(min = ArdenVersion.V2_5)
+	public void testObjectReassignment() throws Exception {
 		String object = createEmptyLogicSlotCodeBuilder()
 				.addData("Patient := OBJECT [Name, DateOfBirth, Id];")
 				.addLogic("Patient := 5;")
 				.toString();
-		assertInvalid(object);
-		
-		String event = createEmptyLogicSlotCodeBuilder()
-				.addData("e := EVENT {something happens};")
-				.addLogic("e := 5;")
-				.toString();
-		assertInvalid(event);
-		
-		String mlm = createEmptyLogicSlotCodeBuilder()
-				.addData("mymlm := MLM 'testmlm';")
-				.addLogic("mymlm := 3;")
-				.toString();
-		assertInvalid(mlm);
-		
-		String interface_ = createEmptyLogicSlotCodeBuilder()
-				.addData("curl := INTERFACE {curl};")
-				.addLogic("curl := NULL;")
-				.toString();
-		assertInvalid(interface_);
-		
+		getCompiler().compileAndRun(object);
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2)
+	public void testBranchingAssignment() throws Exception {
 		String otherMlm = createCodeBuilder()
 				.replaceSlotContent("mlmname:", "other_mlm")
 				.addAction("RETURN 1")
@@ -96,7 +152,7 @@ public class LogicSlotTest extends SpecificationTest {
 		String chooseMlmOrInterface = createEmptyLogicSlotCodeBuilder()
 				.addMlm(otherMlm)
 				.addData("IF FALSE THEN x := MLM 'other_mlm';")
-				.addData("ELSE x := INTERFACE {"+getMappings().getInterfaceMapping()+"};")
+				.addData("ELSE x := INTERFACE {" + getMappings().getInterfaceMapping() + "};")
 				.addData("ENDIF;")
 				.addLogic("result := CALL x WITH 3, 4;")
 				.addLogic("CONCLUDE TRUE;")
@@ -114,16 +170,16 @@ public class LogicSlotTest extends SpecificationTest {
 				.addAction("RETURN a;")
 				.toString();
 		assertReturns(if_, "0");
-		
+
 		String else_ = createEmptyLogicSlotCodeBuilder()
-				.addAction("IF ,TRUE THEN a := 0;")
-				.addAction("ELSE a := 1;")
-				.addAction("ENDIF;")
+				.addLogic("IF ,TRUE THEN a := 0;")
+				.addLogic("ELSE a := 1;")
+				.addLogic("ENDIF;")
 				.addLogic("CONCLUDE TRUE;")
 				.addAction("RETURN a;")
 				.toString();
 		assertReturns(else_, "1");
-		
+
 		String elseif1 = createEmptyLogicSlotCodeBuilder()
 				.addLogic("IF 5 THEN a := 0;")
 				.addLogic("ELSEIF TRUE THEN a := 1;")
@@ -132,7 +188,7 @@ public class LogicSlotTest extends SpecificationTest {
 				.addAction("RETURN a;")
 				.toString();
 		assertReturns(elseif1, "1");
-		
+
 		String elseif2 = createEmptyLogicSlotCodeBuilder()
 				.addLogic("IF NULL THEN a := 0;")
 				.addLogic("ELSEIF FALSE THEN a := 1;")
@@ -144,7 +200,116 @@ public class LogicSlotTest extends SpecificationTest {
 				.toString();
 		assertReturns(elseif2, "3");
 	}
-	
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testIfThenAggregate() throws Exception {
+		String simpleAggregate = createEmptyLogicSlotCodeBuilder()
+				.addData("a := 0;")
+				.addLogic("IF TRUTH VALUE 0.3 THEN a := 2;")
+				.addLogic("ELSE a := 5;")
+				.addLogic("ENDIF AGGREGATE;")
+				.addLogic("CONCLUDE TRUE;")
+				.addAction("RETURN a IS WITHIN 4.099 TO 4.101;")
+				.toString();
+		assertReturns(simpleAggregate, "TRUE");
+
+		String nestedAggregate = createEmptyLogicSlotCodeBuilder()
+				.addData("a := 0;")
+				.addLogic("IF TRUTH VALUE 0.2 THEN a := a + 1;")
+				  .addLogic("IF TRUTH VALUE 0.3 THEN a := a + 1;")
+				  .addLogic("ELSE a := a + 3;")
+				  .addLogic("ENDIF;")
+				.addLogic("ELSE a := a + 3;")
+				.addLogic("ENDIF AGGREGATE;")
+				.addLogic("CONCLUDE TRUE;")
+				.addAction("RETURN a IS WITHIN 3.079 TO 3.081;")
+				.toString();
+		assertReturns(nestedAggregate, "TRUE");
+
+		String primaryTimePreserved = createEmptyLogicSlotCodeBuilder()
+				.addData("a := 0;")
+				.addData("TIME a := 1970-01-01T00:00:00;")
+				.addLogic("IF TRUTH VALUE 0.3 THEN a := 2;")
+				.addLogic("ELSE a := 5;")
+				.addLogic("ENDIF AGGREGATE;")
+				.addLogic("CONCLUDE TRUE;")
+				.addAction("RETURN TIME a;")
+				.toString();
+		assertReturns(primaryTimePreserved, "1970-01-01T00:00:00");
+
+		String primaryTimeLost = createEmptyLogicSlotCodeBuilder()
+				.addData("a := 0;")
+				.addData("TIME a := 1970-01-01T00:00:00;")
+				.addLogic("IF TRUTH VALUE 0.3 THEN a := 2;")
+				  .addLogic("TIME a := 1990-01-01T00:00:00;")
+				.addLogic("ELSE a := 5;")
+				.addLogic("ENDIF AGGREGATE;")
+				.addLogic("CONCLUDE TRUE;")
+				.addAction("RETURN TIME a;")
+				.toString();
+		assertReturns(primaryTimeLost, "NULL");
+
+		String applicabilityPreserved = createEmptyLogicSlotCodeBuilder()
+				.addData("a := 0;")
+				.addData("APPLICABILITY a := TRUTH VALUE 0.3;")
+				.addLogic("IF TRUTH VALUE 0.3 THEN a := 2;")
+				.addLogic("ELSE a := 5;")
+				.addLogic("ENDIF AGGREGATE;")
+				.addLogic("CONCLUDE TRUE;")
+				.addAction("RETURN (APPLICABILITY a) IS WITHIN TRUTH VALUE 0.29 TO TRUTH VALUE 0.31;")
+				.toString();
+		assertReturns(applicabilityPreserved, "NULL");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_8)
+	public void testSwitchCase() throws Exception {
+		String switchCase = createEmptyLogicSlotCodeBuilder()
+				.addData("x := 5;")
+				.addLogic("SWITCH x")
+				  .addLogic("CASE 4 result := FALSE;")
+				  .addLogic("CASE 5 result := TRUE;")
+				  .addLogic("CASE 6 result := FALSE;")
+				  .addLogic("ENDSWITCH;")
+				.addLogic("CONCLUDE TRUE;")
+				.addAction("RETURN result;")
+				.toString();
+		assertReturns(switchCase, "TRUE");
+
+		String defaultCase = createEmptyLogicSlotCodeBuilder()
+				.addData("x := 1;")
+				.addLogic("SWITCH x")
+				  .addLogic("CASE 4 result := FALSE;")
+				  .addLogic("CASE 5 result := FALSE;")
+				  .addLogic("CASE 6 result := FALSE;")
+				  .addLogic("DEFAULT result := TRUE;")
+				.addLogic("ENDSWITCH;")
+				.addLogic("CONCLUDE TRUE;")
+				.addAction("RETURN result;")
+				.toString();
+		assertReturns(defaultCase, "TRUE");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testSwitchCaseAggregate() throws Exception {
+		String aggregate = createEmptyLogicSlotCodeBuilder()
+				.addData("age := 16 YEARS;")
+				.addData("young := FUZZY SET (0 YEARS, TRUTH VALUE 1), (15 YEARS, TRUTH VALUE 1), (20 YEARS, TRUTH VALUE 0);")
+				.addData("middle_aged := FUZZY SET (15 YEARS, TRUTH VALUE 0), (20 YEARS, TRUTH VALUE 1), (60 YEARS, TRUTH VALUE 1), (70 YEARS, TRUTH VALUE 0);")
+				.addData("dose := 0;")
+				.addLogic("SWITCH AGE")
+				  .addLogic("CASE young dose := 10;")
+				  .addLogic("CASE middle_aged dose := 20;")
+				  .addLogic("DEFAULT dose := 15;")
+				.addLogic("ENDSWITCH AGGREGATE;")
+				.addLogic("CONCLUDE TRUE;")
+				.addAction("RETURN dose IS WITHIN 11.99 TO 12.01;")
+				.toString();
+		assertReturns(aggregate, "TRUE");
+	}
+
 	@Test
 	public void testConcludeStatement() throws Exception {
 		String conclude = createEmptyLogicSlotCodeBuilder()
@@ -152,7 +317,7 @@ public class LogicSlotTest extends SpecificationTest {
 				.addAction("RETURN TRUE;")
 				.toString();
 		assertReturns(conclude, "TRUE");
-		
+
 		String concludeVariable = createEmptyLogicSlotCodeBuilder()
 				.addLogic("a := 5;")
 				.addLogic("CONCLUDE TRUE;")
@@ -161,31 +326,30 @@ public class LogicSlotTest extends SpecificationTest {
 				.addAction("RETURN a;")
 				.toString();
 		assertReturns(concludeVariable, "5");
-		
+
 		String noAction1 = createEmptyLogicSlotCodeBuilder()
 				.addLogic("CONCLUDE FALSE;")
 				.addAction("RETURN TRUE;")
 				.toString();
 		assertNoReturn(noAction1);
-				
+
 		String noAction2 = createEmptyLogicSlotCodeBuilder()
-				.clearSlotContent("logic:")
 				.addAction("RETURN TRUE;")
 				.toString();
 		assertNoReturn(noAction2);
-				
+
 		String noAction3 = createEmptyLogicSlotCodeBuilder()
 				.addLogic("CONCLUDE NULL;")
 				.addAction("RETURN TRUE;")
 				.toString();
 		assertNoReturn(noAction3);
-				
+
 		String noAction4 = createEmptyLogicSlotCodeBuilder()
 				.addLogic("CONCLUDE ,TRUE;")
 				.addAction("RETURN TRUE;")
 				.toString();
 		assertNoReturn(noAction4);
-		
+
 		String noAction5 = createEmptyLogicSlotCodeBuilder()
 				.addLogic("CONCLUDE FALSE;")
 				.addLogic("CONCLUDE TRUE;")
@@ -195,97 +359,128 @@ public class LogicSlotTest extends SpecificationTest {
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testConcludeApplicability() throws Exception {
+		String applicability = createEmptyLogicSlotCodeBuilder()
+				.addData("x := 1;")
+				.addLogic("CONCLUDE TRUTH VALUE 0.3;")
+				.addAction("RETURN (APPLICABILITY OF x) IS WITHIN TRUTH VALUE 0.29 TO TRUTH VALUE 0.31;")
+				.toString();
+		assertReturns(applicability, "TRUE");
+
+		String concludeWord = createEmptyLogicSlotCodeBuilder()
+				.addLogic("CONCLUDE TRUTH VALUE 0.3;")
+				.addAction("applicability_of_action_slot := CONCLUDE;")
+				.addAction("RETURN applicability_of_action_slot IS WITHIN TRUTH VALUE 0.29 TO TRUTH VALUE 0.31;")
+				.toString();
+		assertReturns(concludeWord, "TRUE");
+	}
+
+	@Test
 	public void testMlmCallStatement() throws Exception {
 		// other mlm which is called
 		String otherMlm = createCodeBuilder()
-				.replaceSlotContent("mlmname:", "other_mlm")
+				.setName("other_mlm")
 				.addData("(a, b) := ARGUMENT;")
 				.addAction("IF a IS PRESENT THEN RETURN a, b; ENDIF;")
 				.toString();
 		String data = createEmptyLogicSlotCodeBuilder()
 				.addMlm(otherMlm)
-				.addData("othermlm := MLM 'other_mlm';")
+				.addData("other_mlm := MLM 'other_mlm';")
 				.toString();
-		
+
 		String noReturn = new ArdenCodeBuilder(data)
-				.addLogic("a := CALL othermlm;")
+				.addLogic("a := CALL other_mlm;")
 				.addLogic("CONCLUDE TRUE;")
 				.addAction("RETURN a;")
 				.toString();
 		assertReturns(noReturn, "NULL");
-		
+
 		String param = new ArdenCodeBuilder(data)
-				.addLogic("a := CALL othermlm WITH 3;")
+				.addLogic("a := CALL other_mlm WITH 3;")
 				.addLogic("CONCLUDE TRUE;")
 				.addAction("RETURN a;")
 				.toString();
 		assertReturns(param, "3");
-		
+
 		String nullParam = new ArdenCodeBuilder(data)
-				.addLogic("a := CALL othermlm WITH NULL;")
+				.addLogic("a := CALL other_mlm WITH NULL;")
 				.addLogic("CONCLUDE TRUE;")
 				.addAction("RETURN a;")
 				.toString();
 		assertReturns(nullParam, "NULL");
-		
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2)
+	public void testMlmCallMultipleArguments() throws Exception {
+		// other mlm which is called
+		String otherMlm = createCodeBuilder()
+				.setName("other_mlm")
+				.addData("(a, b) := ARGUMENT;")
+				.addAction("IF a IS PRESENT THEN RETURN a, b; ENDIF;")
+				.toString();
+		String data = createEmptyLogicSlotCodeBuilder()
+				.addMlm(otherMlm)
+				.addData("other_mlm := MLM 'other_mlm';")
+				.toString();
+
 		String multiParams = new ArdenCodeBuilder(data)
-				.addLogic("(a,b,c) := CALL othermlm WITH 1,2,3;")
+				.addLogic("(a,b,c) := CALL other_mlm WITH 1,2,3;")
 				.addLogic("CONCLUDE TRUE;")
 				.addAction("RETURN (a,b,c);")
 				.toString();
 		assertReturns(multiParams, "(1,2,NULL)");
-		
+
 		String listParam = new ArdenCodeBuilder(data)
-				.addLogic("(a, b) := CALL othermlm WITH (1,2,3), 2;")
+				.addLogic("(a, b) := CALL other_mlm WITH (1,2,3), 2;")
 				.addLogic("CONCLUDE TRUE;")
 				.addAction("RETURN a*b;")
 				.toString();
 		assertReturns(listParam, "(2,4,6)");
 	}
-	
+
 	@Test
+	@Compatibility(min = ArdenVersion.V2) // multi args
 	public void testEventCallStatement() throws Exception {
-		String eventAssignment = "test_event := EVENT {" + getMappings().getEventMapping() + "};";
-		
+		String eventAssignment = "test_event := EVENT {" + getMappings().createEventMapping() + "};";
+
 		String mlm1 = createCodeBuilder()
-				.replaceSlotContent("mlmname:", "mlm1")
+				.setName("mlm1")
 				.addData(eventAssignment)
 				.addData("(a, b) := ARGUMENT;")
 				.addEvoke("test_event;")
 				.addAction("RETURN a+b;")
 				.toString();
-		
 		String mlm2 = createCodeBuilder()
-				.replaceSlotContent("mlmname:", "mlm2")
+				.setName("mlm2")
 				.addData(eventAssignment)
 				.addData("(a, b) := ARGUMENT;")
 				.addEvoke("test_event;")
 				.addAction("RETURN a*b;")
 				.toString();
-		
 		String mlm3 = createCodeBuilder()
-				.replaceSlotContent("mlmname:", "mlm3")
+				.setName("mlm3")
 				.addData(eventAssignment)
 				.addEvoke("test_event;")
 				.addAction("RETURN NULL;")
 				.toString();
-		
 		String eventCall = createEmptyLogicSlotCodeBuilder()
 				.addMlm(mlm1)
 				.addMlm(mlm2)
 				.addMlm(mlm3)
 				.addData(eventAssignment)
-				.addLogic("result_collection := CALL test_event WITH 3,4;")
+				.addLogic("result_collection := CALL test_event WITH 3,4;") 
 				.addLogic("mlm1_success := 7 IS IN result_collection;")
 				.addLogic("mlm2_success := 12 IS IN result_collection;")
 				.addLogic("mlm3_success := NULL IS NOT IN result_collection;")
 				.addLogic("CONCLUDE TRUE;")
-				.addAction("RETURN mlm1_success AND mlm2_success AND mlm3_success;")
-				.toString();
+				.addAction("RETURN mlm1_success AND mlm2_success AND mlm3_success;").toString();
 		assertReturns(eventCall, "TRUE");
 	}
-	
+
 	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testInterfaceCallStatement() throws Exception {
 		String interfaceCall = createEmptyLogicSlotCodeBuilder()
 				.addData("test_interface := INTERFACE {" + getMappings().getInterfaceMapping() + "};")
@@ -297,12 +492,13 @@ public class LogicSlotTest extends SpecificationTest {
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testWhileLoop() throws Exception {
 		String whileLoop = createEmptyLogicSlotCodeBuilder()
 				.addData("i := 0;")
 				.addData("c := 100;")
 				.addLogic("WHILE c > 0 DO c := c-7;")
-				.addLogic("i := i+1;")
+				  .addLogic("i := i+1;")
 				.addLogic("ENDDO;")
 				.addLogic("CONCLUDE TRUE;")
 				.addAction("RETURN (c, i);")
@@ -310,17 +506,51 @@ public class LogicSlotTest extends SpecificationTest {
 		assertReturns(whileLoop, "(-5,15)");
 	}
 
+	@Test(timeout = 1000)
+	@Compatibility(min = ArdenVersion.V2_8)
+	public void testBreakLoop() throws Exception {
+		String breakloop = createEmptyLogicSlotCodeBuilder()
+				.addData("i := 0;")
+				.addLogic("WHILE TRUE DO i := i+1;")
+				  .addLogic("IF i >= 5 THEN BREAKLOOP;")
+				  .addLogic("ENDIF;")
+				.addLogic("ENDDO;")
+				.addLogic("CONCLUDE TRUE;")
+				.addAction("RETURN i;")
+				.toString();
+		assertReturns(breakloop, "5");
+
+		String nested = createEmptyLogicSlotCodeBuilder()
+				.addData("i := 0;")
+				.addLogic("WHILE TRUE DO;")
+				  .addLogic("WHILE TRUE DO i := i+1;")
+				    .addLogic("IF i >= 5 THEN BREAKLOOP;")
+				    .addLogic("ENDIF;")
+				  .addLogic("ENDDO;")
+				  .addLogic("i := 123;")
+				  .addLogic("BREAKLOOP;")
+				.addLogic("ENDDO;")
+				.addLogic("CONCLUDE TRUE;")
+				.addAction("RETURN i;")
+				.toString();
+		assertReturns(nested, "123");
+
+		// only allowed inside of loop
+		assertInvalidStatement("BREAKLOOP;");
+	}
+
 	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testForLoop() throws Exception {
 		String forLoop1 = createEmptyLogicSlotCodeBuilder()
 				.addData("fac := 1;")
 				.addLogic("FOR i IN 1 SEQTO 5 DO fac := fac*i;")
 				.addLogic("ENDDO;")
 				.addLogic("CONCLUDE TRUE;")
-				.addAction(" RETURN fac;")
+				.addAction("RETURN fac;")
 				.toString();
 		assertReturns(forLoop1, "120");
-		
+
 		String forLoop2 = createEmptyLogicSlotCodeBuilder()
 				.addLogic("FOR i IN () DO CONCLUDE FALSE;")
 				.addLogic("ENDDO;")
@@ -328,7 +558,7 @@ public class LogicSlotTest extends SpecificationTest {
 				.addAction("RETURN 1;")
 				.toString();
 		assertReturns(forLoop2, "1");
-		
+
 		String forLoop3 = createEmptyLogicSlotCodeBuilder()
 				.addLogic("FOR i IN NULL DO CONCLUDE FALSE;")
 				.addLogic("ENDDO;")
@@ -336,7 +566,7 @@ public class LogicSlotTest extends SpecificationTest {
 				.addAction("RETURN 1;")
 				.toString();
 		assertReturns(forLoop3, "1");
-		
+
 		String reassign = createEmptyLogicSlotCodeBuilder()
 				.addLogic("FOR i IN (1,2,3) DO i := 1;")
 				.addLogic("ENDDO;")
@@ -347,27 +577,60 @@ public class LogicSlotTest extends SpecificationTest {
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2_5)
 	public void testNewStatement() throws Exception {
 		String data = createEmptyLogicSlotCodeBuilder()
 				.addData("Patient := OBJECT [Name, DateOfBirth, Id];")
 				.toString();
-		
-		String new_ = new ArdenCodeBuilder(data).addLogic("blankPatient := NEW Patient;").toString();
+
+		String new_ = new ArdenCodeBuilder(data)
+				.addLogic("blankPatient := NEW Patient;")
+				.toString();
 		assertValid(new_);
-		
+
 		String newWith = new ArdenCodeBuilder(data)
 				.addLogic("john := NEW Patient WITH \"John Doe\", \"1970-01-01T00:00:00\", \"1\", \"X\";")
 				.addLogic("CONCLUDE TRUE;")
 				.addAction("RETURN john.Name;")
 				.toString();
 		assertReturns(newWith, "\"John Doe\"");
-		
+
 		String uninitializedAttr = new ArdenCodeBuilder(data)
 				.addLogic("john := NEW Patient WITH \"John Doe\", \"1970-01-01T00:00:00\";")
 				.addLogic("CONCLUDE TRUE;")
 				.addAction("RETURN john.Id;")
 				.toString();
 		assertReturns(uninitializedAttr, "NULL");
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_7)
+	public void testNewStatementWithInitializer() throws Exception {
+		String data = createEmptyLogicSlotCodeBuilder()
+				.addData("Patient := OBJECT [Name, DateOfBirth, Id];")
+				.toString();
+
+		String initialized = new ArdenCodeBuilder(data)
+				.addLogic("john := NEW Patient WITH [Id:=123, Name:=\"John Doe\"];")
+				.addLogic("CONCLUDE TRUE;")
+				.addAction("RETURN john.Name;")
+				.toString();
+		assertReturns(initialized, "\"John Doe\"");
+
+		String uninitializedAttr = new ArdenCodeBuilder(data)
+				.addLogic("noname := NEW Patient WITH [Id:=123];")
+				.addLogic("CONCLUDE TRUE;")
+				.addAction("RETURN noname.Name;")
+				.toString();
+		assertReturns(uninitializedAttr, "NULL");
+
+		String twoWiths = new ArdenCodeBuilder(data)
+				.addLogic("john := NEW Patient WITH \"John Doe\" WITH [Id:=123];")
+				.addLogic("CONCLUDE TRUE;")
+				.addAction("RETURN john.DateOfBirth;")
+				.toString();
+		assertReturns(twoWiths, "NULL");
+
 	}
 
 }

--- a/test/arden/tests/specification/structureslots/LogicSlotTest.java
+++ b/test/arden/tests/specification/structureslots/LogicSlotTest.java
@@ -8,22 +8,28 @@ import arden.tests.specification.testcompiler.SpecificationTest;
 public class LogicSlotTest extends SpecificationTest {
 	// TODO error on illegal statements
 	
-	private static final String EMPTY_LOGIC_SLOT = new ArdenCodeBuilder().clearSlotContent("logic:").toString();
+	private ArdenCodeBuilder createEmptyLogicSlotCodeBuilder() {
+		return createCodeBuilder().clearSlotContent("logic:");
+	}
 
 	@Test
 	public void testAssignmentStatement() throws Exception {
-		String data = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String data = createEmptyLogicSlotCodeBuilder()
 				.addData("Pixel := OBJECT [x, y];")
 				.addData("p := new Pixel;")
 				.toString();
 		
-		String let = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT).addLogic("LET v BE 5;").toString();
+		String let = createEmptyLogicSlotCodeBuilder()
+				.addLogic("LET v BE 5;")
+				.toString();
 		assertValid(let);
 		
-		String assignNull = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT).addLogic("x := NULL;").toString();
+		String assignNull = createEmptyLogicSlotCodeBuilder()
+				.addLogic("x := NULL;")
+				.toString();
 		assertValid(assignNull);	
 		
-		String notReference = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String notReference = createEmptyLogicSlotCodeBuilder()
 				.addLogic("a := 5;")
 				.addLogic("b := a + 3;")
 				.addLogic("a := 0;")
@@ -59,35 +65,35 @@ public class LogicSlotTest extends SpecificationTest {
 	
 	@Test
 	public void testReassignment() throws Exception {
-		String object = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String object = createEmptyLogicSlotCodeBuilder()
 				.addData("Patient := OBJECT [Name, DateOfBirth, Id];")
 				.addLogic("Patient := 5;")
 				.toString();
 		assertInvalid(object);
 		
-		String event = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String event = createEmptyLogicSlotCodeBuilder()
 				.addData("e := EVENT {something happens};")
 				.addLogic("e := 5;")
 				.toString();
 		assertInvalid(event);
 		
-		String mlm = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String mlm = createEmptyLogicSlotCodeBuilder()
 				.addData("mymlm := MLM 'testmlm';")
 				.addLogic("mymlm := 3;")
 				.toString();
 		assertInvalid(mlm);
 		
-		String interface_ = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String interface_ = createEmptyLogicSlotCodeBuilder()
 				.addData("curl := INTERFACE {curl};")
 				.addLogic("curl := NULL;")
 				.toString();
 		assertInvalid(interface_);
 		
-		String otherMlm = new ArdenCodeBuilder()
+		String otherMlm = createCodeBuilder()
 				.replaceSlotContent("mlmname:", "other_mlm")
 				.addAction("RETURN 1")
 				.toString();
-		String chooseMlmOrInterface = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String chooseMlmOrInterface = createEmptyLogicSlotCodeBuilder()
 				.addMlm(otherMlm)
 				.addData("IF FALSE THEN x := MLM 'other_mlm';")
 				.addData("ELSE x := INTERFACE {"+getMappings().getInterfaceMapping()+"};")
@@ -101,7 +107,7 @@ public class LogicSlotTest extends SpecificationTest {
 
 	@Test
 	public void testIfThenStatement() throws Exception {
-		String if_ = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String if_ = createEmptyLogicSlotCodeBuilder()
 				.addLogic("IF 5 = 5 THEN a := 0;")
 				.addLogic("ENDIF;")
 				.addLogic("CONCLUDE TRUE;")
@@ -109,7 +115,7 @@ public class LogicSlotTest extends SpecificationTest {
 				.toString();
 		assertReturns(if_, "0");
 		
-		String else_ = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String else_ = createEmptyLogicSlotCodeBuilder()
 				.addAction("IF ,TRUE THEN a := 0;")
 				.addAction("ELSE a := 1;")
 				.addAction("ENDIF;")
@@ -118,7 +124,7 @@ public class LogicSlotTest extends SpecificationTest {
 				.toString();
 		assertReturns(else_, "1");
 		
-		String elseif1 = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String elseif1 = createEmptyLogicSlotCodeBuilder()
 				.addLogic("IF 5 THEN a := 0;")
 				.addLogic("ELSEIF TRUE THEN a := 1;")
 				.addLogic("ENDIF;")
@@ -127,7 +133,7 @@ public class LogicSlotTest extends SpecificationTest {
 				.toString();
 		assertReturns(elseif1, "1");
 		
-		String elseif2 = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String elseif2 = createEmptyLogicSlotCodeBuilder()
 				.addLogic("IF NULL THEN a := 0;")
 				.addLogic("ELSEIF FALSE THEN a := 1;")
 				.addLogic("ELSEIF TRUE THEN a := 3;")
@@ -141,13 +147,13 @@ public class LogicSlotTest extends SpecificationTest {
 	
 	@Test
 	public void testConcludeStatement() throws Exception {
-		String conclude = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String conclude = createEmptyLogicSlotCodeBuilder()
 				.addLogic("CONCLUDE TRUE;")
 				.addAction("RETURN TRUE;")
 				.toString();
 		assertReturns(conclude, "TRUE");
 		
-		String concludeVariable = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String concludeVariable = createEmptyLogicSlotCodeBuilder()
 				.addLogic("a := 5;")
 				.addLogic("CONCLUDE TRUE;")
 				.addLogic("a := 3;")
@@ -156,31 +162,31 @@ public class LogicSlotTest extends SpecificationTest {
 				.toString();
 		assertReturns(concludeVariable, "5");
 		
-		String noAction1 = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String noAction1 = createEmptyLogicSlotCodeBuilder()
 				.addLogic("CONCLUDE FALSE;")
 				.addAction("RETURN TRUE;")
 				.toString();
 		assertNoReturn(noAction1);
 				
-		String noAction2 = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String noAction2 = createEmptyLogicSlotCodeBuilder()
 				.clearSlotContent("logic:")
 				.addAction("RETURN TRUE;")
 				.toString();
 		assertNoReturn(noAction2);
 				
-		String noAction3 = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String noAction3 = createEmptyLogicSlotCodeBuilder()
 				.addLogic("CONCLUDE NULL;")
 				.addAction("RETURN TRUE;")
 				.toString();
 		assertNoReturn(noAction3);
 				
-		String noAction4 = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String noAction4 = createEmptyLogicSlotCodeBuilder()
 				.addLogic("CONCLUDE ,TRUE;")
 				.addAction("RETURN TRUE;")
 				.toString();
 		assertNoReturn(noAction4);
 		
-		String noAction5 = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String noAction5 = createEmptyLogicSlotCodeBuilder()
 				.addLogic("CONCLUDE FALSE;")
 				.addLogic("CONCLUDE TRUE;")
 				.addAction("RETURN TRUE;")
@@ -191,12 +197,12 @@ public class LogicSlotTest extends SpecificationTest {
 	@Test
 	public void testMlmCallStatement() throws Exception {
 		// other mlm which is called
-		String otherMlm = new ArdenCodeBuilder()
+		String otherMlm = createCodeBuilder()
 				.replaceSlotContent("mlmname:", "other_mlm")
 				.addData("(a, b) := ARGUMENT;")
 				.addAction("IF a IS PRESENT THEN RETURN a, b; ENDIF;")
 				.toString();
-		String data = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String data = createEmptyLogicSlotCodeBuilder()
 				.addMlm(otherMlm)
 				.addData("othermlm := MLM 'other_mlm';")
 				.toString();
@@ -241,7 +247,7 @@ public class LogicSlotTest extends SpecificationTest {
 	public void testEventCallStatement() throws Exception {
 		String eventAssignment = "test_event := EVENT {" + getMappings().getEventMapping() + "};";
 		
-		String mlm1 = new ArdenCodeBuilder()
+		String mlm1 = createCodeBuilder()
 				.replaceSlotContent("mlmname:", "mlm1")
 				.addData(eventAssignment)
 				.addData("(a, b) := ARGUMENT;")
@@ -249,7 +255,7 @@ public class LogicSlotTest extends SpecificationTest {
 				.addAction("RETURN a+b;")
 				.toString();
 		
-		String mlm2 = new ArdenCodeBuilder()
+		String mlm2 = createCodeBuilder()
 				.replaceSlotContent("mlmname:", "mlm2")
 				.addData(eventAssignment)
 				.addData("(a, b) := ARGUMENT;")
@@ -257,14 +263,14 @@ public class LogicSlotTest extends SpecificationTest {
 				.addAction("RETURN a*b;")
 				.toString();
 		
-		String mlm3 = new ArdenCodeBuilder()
+		String mlm3 = createCodeBuilder()
 				.replaceSlotContent("mlmname:", "mlm3")
 				.addData(eventAssignment)
 				.addEvoke("test_event;")
 				.addAction("RETURN NULL;")
 				.toString();
 		
-		String eventCall = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String eventCall = createEmptyLogicSlotCodeBuilder()
 				.addMlm(mlm1)
 				.addMlm(mlm2)
 				.addMlm(mlm3)
@@ -281,7 +287,7 @@ public class LogicSlotTest extends SpecificationTest {
 	
 	@Test
 	public void testInterfaceCallStatement() throws Exception {
-		String interfaceCall = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String interfaceCall = createEmptyLogicSlotCodeBuilder()
 				.addData("test_interface := INTERFACE {" + getMappings().getInterfaceMapping() + "};")
 				.addLogic("(x, y, z) := CALL test_interface WITH 3, 4;")
 				.addLogic("CONCLUDE TRUE;")
@@ -292,7 +298,7 @@ public class LogicSlotTest extends SpecificationTest {
 
 	@Test
 	public void testWhileLoop() throws Exception {
-		String whileLoop = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String whileLoop = createEmptyLogicSlotCodeBuilder()
 				.addData("i := 0;")
 				.addData("c := 100;")
 				.addLogic("WHILE c > 0 DO c := c-7;")
@@ -306,7 +312,7 @@ public class LogicSlotTest extends SpecificationTest {
 
 	@Test
 	public void testForLoop() throws Exception {
-		String forLoop1 = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String forLoop1 = createEmptyLogicSlotCodeBuilder()
 				.addData("fac := 1;")
 				.addLogic("FOR i IN 1 SEQTO 5 DO fac := fac*i;")
 				.addLogic("ENDDO;")
@@ -315,7 +321,7 @@ public class LogicSlotTest extends SpecificationTest {
 				.toString();
 		assertReturns(forLoop1, "120");
 		
-		String forLoop2 = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String forLoop2 = createEmptyLogicSlotCodeBuilder()
 				.addLogic("FOR i IN () DO CONCLUDE FALSE;")
 				.addLogic("ENDDO;")
 				.addLogic("CONCLUDE TRUE")
@@ -323,7 +329,7 @@ public class LogicSlotTest extends SpecificationTest {
 				.toString();
 		assertReturns(forLoop2, "1");
 		
-		String forLoop3 = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String forLoop3 = createEmptyLogicSlotCodeBuilder()
 				.addLogic("FOR i IN NULL DO CONCLUDE FALSE;")
 				.addLogic("ENDDO;")
 				.addLogic("CONCLUDE TRUE")
@@ -331,7 +337,7 @@ public class LogicSlotTest extends SpecificationTest {
 				.toString();
 		assertReturns(forLoop3, "1");
 		
-		String reassign = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String reassign = createEmptyLogicSlotCodeBuilder()
 				.addLogic("FOR i IN (1,2,3) DO i := 1;")
 				.addLogic("ENDDO;")
 				.addLogic("CONCLUDE TRUE;")
@@ -342,7 +348,7 @@ public class LogicSlotTest extends SpecificationTest {
 
 	@Test
 	public void testNewStatement() throws Exception {
-		String data = new ArdenCodeBuilder(EMPTY_LOGIC_SLOT)
+		String data = createEmptyLogicSlotCodeBuilder()
 				.addData("Patient := OBJECT [Name, DateOfBirth, Id];")
 				.toString();
 		

--- a/test/arden/tests/specification/structureslots/OrganizationTest.java
+++ b/test/arden/tests/specification/structureslots/OrganizationTest.java
@@ -2,7 +2,6 @@ package arden.tests.specification.structureslots;
 
 import org.junit.Test;
 
-import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.SpecificationTest;
 
 public class OrganizationTest extends SpecificationTest {
@@ -27,13 +26,13 @@ public class OrganizationTest extends SpecificationTest {
 	@Test
 	public void testVariables() throws Exception {
 		// null if no value assigned
-		String useBeforeAssign = new ArdenCodeBuilder()
+		String useBeforeAssign = createCodeBuilder()
 				.addData("x := x;")
 				.addAction("RETURN x;")
 				.toString();
 		assertReturns(useBeforeAssign, "NULL");
 
-		String uninitialized = new ArdenCodeBuilder()
+		String uninitialized = createCodeBuilder()
 				.addData("IF FALSE THEN x := 0;")
 				.addData("ENDIF;")
 				.addAction("RETURN x;")
@@ -44,21 +43,21 @@ public class OrganizationTest extends SpecificationTest {
 	@Test
 	public void testScope() throws Exception {
 		// entire mlm
-		String slotScope = new ArdenCodeBuilder()
+		String slotScope = createCodeBuilder()
 				.addData("x := 5;")
 				.addAction("RETURN x")
 				.toString();
 		assertReturns(slotScope, "5");
 		
 		// not other mlms
-		String otherMlm = new ArdenCodeBuilder()
+		String otherMlm = createCodeBuilder()
 				.replaceSlotContent("mlmname:", "other_mlm")
 				.addData("a := 1;")
 				.addData("c := 2;")
 				.addAction("a := 3;")
 				.addAction("RETURN a;")
 				.toString();
-		String scope = new ArdenCodeBuilder()
+		String scope = createCodeBuilder()
 				.addMlm(otherMlm)
 				.addData("a := 4;")
 				.addAction("b := 5;")

--- a/test/arden/tests/specification/structureslots/OrganizationTest.java
+++ b/test/arden/tests/specification/structureslots/OrganizationTest.java
@@ -2,16 +2,18 @@ package arden.tests.specification.structureslots;
 
 import org.junit.Test;
 
+import arden.tests.specification.testcompiler.ArdenVersion;
 import arden.tests.specification.testcompiler.SpecificationTest;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 
 public class OrganizationTest extends SpecificationTest {
-	
+
 	@Test
 	public void testStatements() throws Exception {
 		// optional semicolon for last statement in slot
 		assertValidStatement("x := 5; y := 6");
 		assertValidStatement("x := 5; y := 6;");
-		
+
 		// ;;; invalid
 		assertInvalidStatement("x := 5; y := 6;;; //");
 		assertValidStatement("x := 5; y := 6;/**/;; //");
@@ -39,8 +41,9 @@ public class OrganizationTest extends SpecificationTest {
 				.toString();
 		assertReturns(uninitialized, "NULL");
 	}
-	
+
 	@Test
+	@Compatibility(min = ArdenVersion.V2) // mlmname
 	public void testScope() throws Exception {
 		// entire mlm
 		String slotScope = createCodeBuilder()
@@ -48,20 +51,22 @@ public class OrganizationTest extends SpecificationTest {
 				.addAction("RETURN x")
 				.toString();
 		assertReturns(slotScope, "5");
-		
+
 		// not other mlms
-		String otherMlm = createCodeBuilder()
+		String otherMlm = createEmptyLogicSlotCodeBuilder()
 				.replaceSlotContent("mlmname:", "other_mlm")
 				.addData("a := 1;")
 				.addData("c := 2;")
-				.addAction("a := 3;")
+				.addLogic("a := 3;")
+				.addLogic("CONCLUDE TRUE")
 				.addAction("RETURN a;")
 				.toString();
-		String scope = createCodeBuilder()
+		String scope = createEmptyLogicSlotCodeBuilder()
 				.addMlm(otherMlm)
 				.addData("a := 4;")
-				.addAction("b := 5;")
-				.addAction("c := c;")
+				.addLogic("b := 5;")
+				.addLogic("c := c;")
+				.addLogic("CONCLUDE TRUE")
 				.addAction("RETURN (a,b,c);")
 				.toString();
 		assertReturns(scope, "(4,5,NULL)");

--- a/test/arden/tests/specification/structureslots/TokensTest.java
+++ b/test/arden/tests/specification/structureslots/TokensTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
-import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.SpecificationTest;
 import arden.tests.specification.testcompiler.TestCompilerCompiletimeException;
 import arden.tests.specification.testcompiler.TestCompilerException;
@@ -13,7 +12,7 @@ public class TokensTest extends SpecificationTest {
 	
 	public void assertInvalidIdentifier(String reservedWord) {
 		try {
-			String invalidIdentifier = new ArdenCodeBuilder().addAction("let" + reservedWord + " be 5;").toString();
+			String invalidIdentifier = createCodeBuilder().addAction("let" + reservedWord + " be 5;").toString();
 			getCompiler().compile(invalidIdentifier);
 			fail("Expected an " + TestCompilerException.class.getSimpleName() + " to be thrown for reserved word: \"" + reservedWord+ "\"");
 		} catch(TestCompilerCompiletimeException e) {
@@ -74,7 +73,7 @@ public class TokensTest extends SpecificationTest {
 		// invalid length
 		assertInvalidStatement("Lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_Quisque_libero_felis_bibendum_at_ullamcorper_ac_dictum_eget_eros := 5;");
 		
-		String case_ = new ArdenCodeBuilder()
+		String case_ = createCodeBuilder()
 				.addData("AbCd := 5;")
 				.addAction("abcd := ABCD + 5;")
 				.addAction(" RETURN abCD;")
@@ -144,14 +143,14 @@ public class TokensTest extends SpecificationTest {
 	
 	@Test
 	public void testTermConstant() throws Exception {
-		String term = new ArdenCodeBuilder().addData("x := MLM 'other_mlm';").toString();
+		String term = createCodeBuilder().addData("x := MLM 'other_mlm';").toString();
 		assertValid(term);
 	}
 
 	@Test
 	public void testMappingClauses() throws Exception {
 		// READ only in data slot
-		String mapping = new ArdenCodeBuilder().addData("x := READ {Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque libero felis, bibendum at ullamcorper ac, dictum eget eros.};").toString();
+		String mapping = createCodeBuilder().addData("x := READ {Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque libero felis, bibendum at ullamcorper ac, dictum eget eros.};").toString();
 		assertValid(mapping);
 	}
 

--- a/test/arden/tests/specification/structureslots/TokensTest.java
+++ b/test/arden/tests/specification/structureslots/TokensTest.java
@@ -4,67 +4,132 @@ import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
+import arden.tests.specification.testcompiler.ArdenVersion;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.SpecificationTest;
 import arden.tests.specification.testcompiler.TestCompilerCompiletimeException;
 import arden.tests.specification.testcompiler.TestCompilerException;
 
 public class TokensTest extends SpecificationTest {
-	
-	public void assertInvalidIdentifier(String reservedWord) {
+
+	protected void assertReservedWord(String reservedWord) {
 		try {
-			String invalidIdentifier = createCodeBuilder().addAction("let" + reservedWord + " be 5;").toString();
+			/*
+			 * The BNF allows the reserved word "NOW" to be used in the
+			 * statement "NOW := ...;", but not "LET NOW BE ...;" (see
+			 * <identifier_becomes>).
+			 */
+			String invalidIdentifier = createCodeBuilder()
+					.addAction("LET " + reservedWord + " BE 5;")
+					.toString();
 			getCompiler().compile(invalidIdentifier);
-			fail("Expected an " + TestCompilerException.class.getSimpleName() + " to be thrown for reserved word: \"" + reservedWord+ "\"");
-		} catch(TestCompilerCompiletimeException e) {
+			fail("Expected an " + TestCompilerException.class.getSimpleName() + " to be thrown for reserved word: \""
+					+ reservedWord + "\"");
+		} catch (TestCompilerCompiletimeException e) {
 			// test passed
 		}
 	}
 
 	@Test
+	@Compatibility(min = ArdenVersion.V2)
 	public void testReservedWords() throws Exception {
-		
-		// reserved word (keywords)
-		String[] reservedWords = { "Abs", "action", "after", "ago", "alert", "all", "and", "any", "arccos", "arcsin",
-				"arctan", "arden", "are", "argument", "as", "at", "attribute", "author", "average", "avg", "be",
-				"before", "Boolean", "call", "ceiling", "characters", "citations", "conclude", "cos", "cosine", "count",
-				"clone", "currenttime", "data", "data_driven", "data-driven", "date", "day", "days", "decrease",
-				"delay", "destination", "do", "duration", "earliest", "else", "elseif", "enddo", "endif", "end", "eq",
-				"equal", "event", "eventtime", "every", "evoke", "exist", "exists", "exp", "expired", "explanation",
-				"extract", "false", "filename", "find", "first", "floor", "following", "for", "formatted", "from", "ge",
-				"greater", "gt", "hour", "hours", "if", "in", "include", "increase", "index", "institution", "int",
-				"interface", "interval", "is", "it", "keywords", "knowledge", "last", "latest", "le", "left", "length",
-				"less", "let", "library", "links", "list", "log", "log10", "logic", "lowercase", "lt", "maintenance",
-				"matches", "max", "maximum", "median", "merge", "message", "min", "minimum", "minute", "minutes", "mlm",
-				"mlmname", "mlm_self", "month", "months", "names", "ne", "nearest", "new", "no", "not", "now", "null",
-				"number", "object", "occur", "occurred", "occurs", "of", "or", "past", "pattern", "percent",
-				"preceding", "present", "priority", "production", "purpose", "read", "refute", "research", "return",
-				"reverse", "right", "round", "same", "second", "seconds", "seqto", "sin", "sine", "slope", "sort",
-				"specialist", "sqrt", "starting", "stddev", "string", "substring", "sum", "support", "surrounding",
-				"tan", "tangent", "testing", "than", "the", "then", "they", "time", "title", "to", "triggertime",
-				"trim", "true", "truncate", "type", "unique", "until", "uppercase", "urgency", "validation", "variance",
-				"version", "was", "week", "weeks", "were", "where", "while", "with", "within", "write", "year",
-				"years" };
-		
+		String[] reservedWords = { "abs", "destination", "increase", "month", "action", "do", "index", "months",
+				"after", "duration", "institution", "ne", "ago", "earliest", "int", "nearest", "alert", "else",
+				"interface", "no", "all", "elseif", "interval", "not", "and", "enddo", "is", "now", "any", "endif",
+				"it", "null", "arccos", "end", "keywords", "number", "arcsin", "eq", "knowledge", "occur", "arctan",
+				"equal", "last", "occurred", "arden", "event", "latest", "occurs", "are", "eventtime", "le", "of",
+				"argument", "every", "less", "or", "as", "evoke", "let", "past", "at", "exist", "library", "pattern",
+				"author", "exists", "links", "percent", "average", "exp", "list", "preceding", "avg", "expired", "log",
+				"present", "be", "explanation", "log10", "priority", "before", "extract", "logic", "production",
+				"Boolean", "false", "lt", "purpose", "call", "filename", "maintenance", "read", "ceiling", "first",
+				"matches", "refute", "characters", "floor", "max", "research", "citations", "following", "maximum",
+				"return", "conclude", "for", "median", "reverse", "cos", "formatted", "merge", "round", "cosine",
+				"from", "message", "same", "count", "ge", "min", "second", "data", "greater", "minimum", "seconds",
+				"date", "gt", "minute", "seqto", "day", "hour", "minutes", "sin", "days", "hours", "mlm", "sine",
+				"decrease", "if", "mlmname", "slope", "delay", "in", "mlm_self", "sort", "specialist", "testing",
+				"truncate", "weeks", "sqrt", "than", "type", "were", "starting", "the", "unique", "where", "stddev",
+				"then", "until", "while", "string", "they", "urgency", "with", "sum", "time", "validation", "within",
+				"support", "title", "variance", "write", "surrounding", "to", "version", "year", "tan", "triggertime",
+				"was", "year", "tangent", "true", "week" };
 		for (String reservedWord : reservedWords) {
-			assertInvalidIdentifier(reservedWord);
+			assertReservedWord(reservedWord);
 		}
-		
-		// words reserved for future use
-		String[] reservedFutureWords = {
-				"union", "intersect", "excluding", "citation", "select"
-		};
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_1)
+	public void testReservedWordsV2_1() throws Exception {
+		String[] reservedWords = { "left", "length", "find", "currenttime", "lowercase", "data_driven", "data-driven",
+				"right", "substring", "trim", "uppercase", "years" };
+		for (String reservedWord : reservedWords) {
+			assertReservedWord(reservedWord);
+		}
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_5)
+	public void testReservedWordsV2_5() throws Exception {
+		String[] reservedWords = { "Abs", /* typo: "arcos", */
+				"include", "attribute", "names", "new", "object", "clone" };
+		for (String reservedWord : reservedWords) {
+			assertReservedWord(reservedWord);
+		}
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testReservedWordsV2_6() throws Exception {
+		String[] reservedWords = { "localized", "friday", "default", "monday", "by", "language", "saturday", "thursday",
+				"wednesday", "today", "tomorrow", "resources", "sunday", "tuesday" };
+		for (String reservedWord : reservedWords) {
+			assertReservedWord(reservedWord);
+		}
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_7)
+	public void testReservedWordsV2_7() throws Exception {
+		assertReservedWord("attime"); // missing from specification
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_8)
+	public void testReservedWordsV2_8() throws Exception {
+		String[] reservedWords = { "add", "least", "aretrue", "elements", "breakloop", "case", "istrue", "most",
+				"sublist", "remove", "replace", "switch", "using" };
+		for (String reservedWord : reservedWords) {
+			assertReservedWord(reservedWord);
+		}
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_9)
+	public void testReservedWordsV2_9() throws Exception {
+		String[] reservedWords = { "aggregate", "crisp", "applicability", "defuzzified", "linguistic", "fuzzified",
+				"fuzzy", "endswitch", "truth", "value", "variable", "set" };
+		for (String reservedWord : reservedWords) {
+			assertReservedWord(reservedWord);
+		}
+	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2)
+	public void testFutureReservedWords() throws Exception {
+		String[] reservedFutureWords = { "union", "intersect", "excluding", "citation", "select" };
 		for (String reservedWord : reservedFutureWords) {
-			assertInvalidIdentifier(reservedWord);
+			assertReservedWord(reservedWord);
 		}
-		
-		// the
+	}
+
+	@Test
+	public void testThe() throws Exception {
 		assertValidStatement("THE LET THE x BE THE THE 5 THE;");
 	}
 
 	@Test
 	public void testIdentifiers() throws Exception {
 		assertValidStatement("Asdf123_X_5 := 5;");
-		
+
 		// invalid identifier
 		assertInvalidStatement("a-b := 5;");
 		assertInvalidStatement("1var := 5;");
@@ -72,10 +137,11 @@ public class TokensTest extends SpecificationTest {
 
 		// invalid length
 		assertInvalidStatement("Lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_Quisque_libero_felis_bibendum_at_ullamcorper_ac_dictum_eget_eros := 5;");
-		
+		assertValidStatement("Lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_Quisque_libero_felis_bibe := 5;");
+
 		String case_ = createCodeBuilder()
 				.addData("AbCd := 5;")
-				.addAction("abcd := ABCD + 5;")
+				.addData("abcd := ABCD + 5;")
 				.addAction(" RETURN abCD;")
 				.toString();
 		assertReturns(case_, "10");
@@ -84,12 +150,12 @@ public class TokensTest extends SpecificationTest {
 	@Test
 	public void testNumberConstants() throws Exception {
 		assertValidStatement("x := 500;");
-		
+
 		// decimal point
 		assertValidStatement("x := 0.5;");
 		assertValidStatement("x := 5.;");
 		assertValidStatement("x := .5;");
-		
+
 		// exponent
 		assertValidStatement("x := 12e10;");
 		assertValidStatement("x := 10e13;");
@@ -98,49 +164,41 @@ public class TokensTest extends SpecificationTest {
 
 	@Test
 	public void testTimeConstants() throws Exception {
-		// date
 		assertValidStatement("t := 1990-01-01;");
-		
-		// datetime
 		assertValidStatement("t := 1990-01-01T12:00:00;");
-		
-		// fractional seconds
+
+		// fractionals seconds + timezones
 		assertValidStatement("t := 1990-01-01T12:00:00.15;");
-		
-		// timezones
 		assertValidStatement("t := 1990-01-01T12:00:00.15Z;");
 		assertValidStatement("t := 1990-01-01T12:00:00.15-05:00;");
-		
-		// fractionals seconds + timezones
 		assertValidStatement("t := 1990-01-01T12:00:00.12345+01:00;");
-		
+
 		// case insensitive
 		assertValidStatement("t := 1990-01-01t12:00:00;");
 		assertValidStatement("t := 1990-01-01T12:00:00.15z;");
-		
-		// construction
-		assertValidStatement("t := 1990-01-01 + 5 years + (6-3)months + 123 days;");
-		assertEvaluatesTo("1800-01-01 + (1993-1800)years + (5-1)months + (17-1)days", "1993-05-17T00:00:00");
 	}
 
 	@Test
 	public void testStringConstants() throws Exception {
+		String lb = System.lineSeparator();
+
 		// no length limit
-		assertValidStatement("x := \"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque libero felis, bibendum at ullamcorper ac, dictum eget eros.\";"); 
-		
+		assertValidStatement(
+				"x := \"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque libero felis, bibendum at ullamcorper ac, dictum eget eros.\";");
+
 		// interalQuotationMarks
 		assertValidStatement("x := \"Lorem \"\"ipsum\"\" dolor sit amet\";");
-		
+
 		// single line break
-		assertEvaluatesTo("\"Lorem     \n    ipsum\"", "\"Lorem ipsum\"");
-		
+		assertEvaluatesTo("\"Lorem     " + lb + "    ipsum\"", "\"Lorem ipsum\"");
+
 		// multi line break
-		assertEvaluatesTo("\"Lorem     \n\n\n\n    ipsum\"", "\"Lorem\nipsum\"");
-		
+		assertEvaluatesTo("\"Lorem     " + lb + lb + lb + lb + "    ipsum\"", "\"Lorem" + lb + "ipsum\"");
+
 		// empty string
 		assertEvaluatesTo("\"\"", "\"\"");
 	}
-	
+
 	@Test
 	public void testTermConstant() throws Exception {
 		String term = createCodeBuilder().addData("x := MLM 'other_mlm';").toString();
@@ -149,16 +207,23 @@ public class TokensTest extends SpecificationTest {
 
 	@Test
 	public void testMappingClauses() throws Exception {
-		// READ only in data slot
-		String mapping = createCodeBuilder().addData("x := READ {Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque libero felis, bibendum at ullamcorper ac, dictum eget eros.};").toString();
+		String mapping = createCodeBuilder()
+				.addData("x := READ {Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque libero felis, bibendum at ullamcorper ac, dictum eget eros.};")
+				.toString();
 		assertValid(mapping);
 	}
 
 	@Test
-	public void testComments() throws Exception {
+	@Compatibility(min = ArdenVersion.V2)
+	public void testSingleLineComments() throws Exception {
+		assertValidStatement("// Lorem // */ ipsum " + System.lineSeparator());
 		assertValidStatement("/* Lorem /* ipsum // */");
-		assertValidStatement("// Lorem // */ ipsum \n");
+	}
+
+	@Test
+	public void testMultiLineComments() throws Exception {
 		assertValidStatement("a/**/:=/*xyz*/5;");
+		assertValidStatement("a/*.../*...*/:=5;");
 	}
 
 	@Test
@@ -166,4 +231,29 @@ public class TokensTest extends SpecificationTest {
 		assertValidStatement("x := 3+4;");
 		assertValidStatement("x := 3 + 4;");
 	}
+
+	@Test
+	@Compatibility(min = ArdenVersion.V2_6)
+	public void testTimeOfDayConstants() throws Exception {
+		assertValidStatement("t := 18:30");
+		assertValidStatement("t := 18:30:30");
+
+		// midnight
+		assertValidStatement("t := 00:00:00.000");
+		assertInvalidStatement("t := 24:00");
+		assertInvalidStatement("t := 23:60");
+
+		// fractionals seconds + timezones
+		assertValidStatement("t := 12:34:56;");
+		assertValidStatement("t := 12:34:30.56;");
+		assertValidStatement("t := 12:34Z;");
+		assertValidStatement("t := 12:34:56Z;");
+		assertValidStatement("t := 12:34-05:00;");
+		assertValidStatement("t := 12:34:56-05:00;");
+		assertValidStatement("t := 12:34:56.12345+01:00;");
+
+		// case insensitive
+		assertValidStatement("t := 22:22z;");
+	}
+
 }

--- a/test/arden/tests/specification/testcompiler/ArdenCodeBuilder.java
+++ b/test/arden/tests/specification/testcompiler/ArdenCodeBuilder.java
@@ -66,23 +66,23 @@ public class ArdenCodeBuilder {
 	 * Initialize the code builder with a template or the output from another
 	 * code builder.
 	 * 
-	 * @param template complete code for an MLM
+	 * @param template
+	 *            complete code for an MLM
 	 */
 	public ArdenCodeBuilder(String template) {
 		resultBuilder = new StringBuilder(template);
 	}
-	
-	
+
 	private void checkSlotIndex(int index, String slotname) {
 		if (index == -1) {
 			throw new IllegalArgumentException("The \"" + slotname + "\" slot could not be found in the template");
 		}
 	}
-	
+
 	public ArdenCodeBuilder removeSlot(String slotname) {
 		int slotIndex = resultBuilder.indexOf(slotname.toLowerCase());
 		checkSlotIndex(slotIndex, slotname);
-		
+
 		int endIndex = resultBuilder.indexOf(";;", slotIndex);
 		checkSlotIndex(endIndex, slotname);
 		endIndex += ";;".length();
@@ -90,63 +90,68 @@ public class ArdenCodeBuilder {
 		resultBuilder.delete(slotIndex, endIndex);
 		return this;
 	}
-	
+
 	public ArdenCodeBuilder renameSlot(String slotname, String newname) {
 		int slotIndex = resultBuilder.indexOf(slotname.toLowerCase());
 		checkSlotIndex(slotIndex, slotname);
-		
+
 		int endIndex = slotIndex + slotname.length();
-		
+
 		resultBuilder.replace(slotIndex, endIndex, newname);
 		return this;
 	}
-	
+
 	/**
 	 * @param slotname
 	 *            e.g. <code>"title:"</code>
 	 * @param slotcontent
 	 *            e.g. <code>"My Test MLM"</code>
+	 * @param append
+	 *            append to slot or replace content
+	 * @param ignoreCase
+	 *            ignore slot name case
 	 */
-	private ArdenCodeBuilder insertSlotContent(String slotname, String content, boolean append) {
-		int slotIndex = resultBuilder.indexOf(slotname.toLowerCase());
+	private ArdenCodeBuilder insertSlotContent(String slotname, String content, boolean append, boolean ignoreCase) {
+		slotname = ignoreCase ? slotname.toLowerCase() : slotname;
+		int slotIndex = resultBuilder.indexOf(slotname);
 		checkSlotIndex(slotIndex, slotname);
 		int startOfContent = slotIndex + slotname.length();
-		
+
 		int endOfContent = resultBuilder.indexOf(";;", startOfContent);
 		checkSlotIndex(endOfContent, slotname);
 
 		String paddedContent = " " + content + " "; // to prevent illegal ";;;"
-		if(append) {
+		if (append) {
 			resultBuilder.insert(endOfContent, paddedContent).toString();
 		} else {
 			resultBuilder.replace(startOfContent, endOfContent, paddedContent).toString();
 		}
-		
+
 		return this;
 	}
-	
+
 	public ArdenCodeBuilder replaceSlotContent(String slotname, String content) {
-		return insertSlotContent(slotname, content, false);
+		return insertSlotContent(slotname, content, false, true);
 	}
-	
+
 	public ArdenCodeBuilder appendSlotContent(String slotname, String content) {
-		return insertSlotContent(slotname, content, true);
+		return insertSlotContent(slotname, content, true, true);
 	}
-	
+
 	public ArdenCodeBuilder clearSlotContent(String slotname) {
-		return insertSlotContent(slotname, "", false);
+		return insertSlotContent(slotname, "", false, true);
 	}
-	
+
 	public ArdenCodeBuilder addData(String dataCode) {
 		return appendSlotContent("data:", dataCode);
 	}
-	
-	public ArdenCodeBuilder addLogic(String actionCode) {
-		return appendSlotContent("logic:", actionCode);
+
+	public ArdenCodeBuilder addLogic(String logicCode) {
+		return appendSlotContent("logic:", logicCode);
 	}
-	
-	public ArdenCodeBuilder addEvoke(String actionCode) {
-		return appendSlotContent("evoke:", actionCode);
+
+	public ArdenCodeBuilder addEvoke(String evokeCode) {
+		return appendSlotContent("evoke:", evokeCode);
 	}
 
 	public ArdenCodeBuilder addAction(String actionCode) {
@@ -156,7 +161,7 @@ public class ArdenCodeBuilder {
 	public ArdenCodeBuilder addExpression(String expression) {
 		return addData("return_expression__ := " + expression + ";").addAction("RETURN return_expression__;");
 	}
-	
+
 	public ArdenCodeBuilder addMlm(String mlmCode) {
 		resultBuilder.append('\n');
 		resultBuilder.append(mlmCode);
@@ -170,9 +175,51 @@ public class ArdenCodeBuilder {
 		return replaceSlotContent("arden:", version.toString());
 	}
 
+	public ArdenCodeBuilder setName(String name) {
+		if (resultBuilder.indexOf("mlmname:") != -1) {
+			replaceSlotContent("mlmname:", name);
+		} else {
+			replaceSlotContent("filename:", name + ".mlm");
+		}
+		return this;
+	}
+
+	public ArdenCodeBuilder removeResourceSlots() {
+		int resourceIndex = resultBuilder.indexOf("resources:");
+		if (resourceIndex == -1) {
+			throw new IllegalArgumentException("The resources category could not be found in the template");
+		}
+		int startIndex = resourceIndex + "resources:".length();
+		int endIndex = resultBuilder.indexOf("end:");
+		resultBuilder.replace(startIndex, endIndex, " " + System.lineSeparator());
+		return this;
+	}
+
+	public ArdenCodeBuilder appendDefaultSlot(String languageCode) {
+		String resourceSlot = "default: " + languageCode + ";;" + System.lineSeparator();
+		int endIndex = resultBuilder.indexOf("end:");
+		resultBuilder.insert(endIndex, resourceSlot);
+		return this;
+	}
+
+	public ArdenCodeBuilder appendLanguageSlot(String languageCode) {
+		String resourceSlot = "language: " + languageCode + ";; " + System.lineSeparator();
+		int endIndex = resultBuilder.indexOf("end:");
+		resultBuilder.insert(endIndex, resourceSlot);
+		return this;
+	}
+
+	public ArdenCodeBuilder addTextConstant(String languageCode, String key, String value) {
+		// Note: Will only work if one space is between "language:" and the code
+		String slotName = "language: " + languageCode;
+		String textConstant = "'" + key + "': \"" + value + "\";";
+		insertSlotContent(slotName, textConstant, true, false);
+		return this;
+	}
+
 	@Override
 	public String toString() {
 		return resultBuilder.toString();
 	}
-	
+
 }

--- a/test/arden/tests/specification/testcompiler/ArdenCodeBuilder.java
+++ b/test/arden/tests/specification/testcompiler/ArdenCodeBuilder.java
@@ -6,10 +6,12 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 
 /**
- * Builder for generating arden code from a template.
+ * Builder for generating Arden code from a template.
  */
 public class ArdenCodeBuilder {
-	private static String template = readTemplate("Template.mlm");
+	private static final String DEFAULT_TEMPLATE = readTemplate("Template.mlm");
+	private static final String V1_TEMPLATE = readTemplate("Template_V1.mlm");
+	private static final String RESOURCES_TEMPLATE = readTemplate("Template_Resources.mlm");
 	private StringBuilder resultBuilder;
 
 	private static String readTemplate(String filename) {
@@ -35,10 +37,37 @@ public class ArdenCodeBuilder {
 		return stringBuilder.toString();
 	}
 
-	public ArdenCodeBuilder() {
-		resultBuilder = new StringBuilder(template);
+	/**
+	 * Initialize the code builder with a template for the given version and set
+	 * the "arden:" slot accordingly. <br>
+	 * For version 1 the "filename:" slot is used instead of the "mlmname:" slot
+	 * and the "arden:" slot is removed. <br>
+	 * For versions greater or equal to version 2.9 the resources category is
+	 * used in the builder's template, as it is no longer optional.
+	 * 
+	 * @param version
+	 *            The Arden Syntax version for which the template must be
+	 *            compatible.
+	 */
+	ArdenCodeBuilder(ArdenVersion version) {
+		if (version == ArdenVersion.V1) {
+			resultBuilder = new StringBuilder(V1_TEMPLATE);
+		} else if (version.ordinal() >= ArdenVersion.V2_6.ordinal()) {
+			resultBuilder = new StringBuilder(RESOURCES_TEMPLATE);
+			setArdenVersion(version);
+		} else {
+			resultBuilder = new StringBuilder(DEFAULT_TEMPLATE);
+			setArdenVersion(version);
+		}
+
 	}
-	
+
+	/**
+	 * Initialize the code builder with a template or the output from another
+	 * code builder.
+	 * 
+	 * @param template complete code for an MLM
+	 */
 	public ArdenCodeBuilder(String template) {
 		resultBuilder = new StringBuilder(template);
 	}
@@ -133,7 +162,14 @@ public class ArdenCodeBuilder {
 		resultBuilder.append(mlmCode);
 		return this;
 	}
-	
+
+	public ArdenCodeBuilder setArdenVersion(ArdenVersion version) {
+		if (version == ArdenVersion.V1) {
+			return removeSlot("arden:");
+		}
+		return replaceSlotContent("arden:", version.toString());
+	}
+
 	@Override
 	public String toString() {
 		return resultBuilder.toString();

--- a/test/arden/tests/specification/testcompiler/ArdenVersion.java
+++ b/test/arden/tests/specification/testcompiler/ArdenVersion.java
@@ -5,7 +5,12 @@ public enum ArdenVersion implements Comparable<ArdenVersion> {
 	V1(1, 0), // ASTM E1460-1992
 	V2(2, 0),
 	V2_1(2, 1),
-	V2_5(2, 5);
+	V2_5(2, 5),
+	V2_6(2, 6),
+	V2_7(2, 7),
+	V2_8(2, 8),
+	V2_9(2, 9),
+	V2_10(2, 10);
 
 	public final int major;
 	public final int minor;

--- a/test/arden/tests/specification/testcompiler/ArdenVersion.java
+++ b/test/arden/tests/specification/testcompiler/ArdenVersion.java
@@ -32,9 +32,11 @@ public enum ArdenVersion implements Comparable<ArdenVersion> {
 		StringBuilder versionBuilder = new StringBuilder("Version ");
 		versionBuilder.append(major);
 		if (minor != 0) {
+			versionBuilder.append('.');
 			versionBuilder.append(minor);
 		}
 		if (rev != 0) {
+			versionBuilder.append('.');
 			versionBuilder.append(rev);
 		}
 		return versionBuilder.toString();

--- a/test/arden/tests/specification/testcompiler/CompatibilityRule.java
+++ b/test/arden/tests/specification/testcompiler/CompatibilityRule.java
@@ -13,13 +13,12 @@ import org.junit.runners.model.Statement;
 
 /**
  * JUnit rule to check all tests for the <code>@Compatibility</code> annotation
- * and skip backward compatibility tests for compilers which do not support the
- * given version. <br>
+ * and skip tests for compilers which do not support the given version. <br>
  * Usage:
  * 
  * <pre>
  * &#064;Rule
- * public CompatibilityRule rule = new CompatibilityRule();
+ * public CompatibilityRule rule = new CompatibilityRule(settings);
  * 
  * &#064;Test
  * &#064;Compatibility(ArdenVersion.V1)
@@ -29,10 +28,10 @@ import org.junit.runners.model.Statement;
  */
 public class CompatibilityRule implements MethodRule {
 
-	private TestCompiler compiler;
+	private TestCompilerSettings settings;
 
-	public CompatibilityRule(TestCompiler compiler) {
-		this.compiler = compiler;
+	public CompatibilityRule(TestCompilerSettings settings) {
+		this.settings = settings;
 	}
 
 	@Override
@@ -42,9 +41,9 @@ public class CompatibilityRule implements MethodRule {
 		Compatibility annotation = method.getAnnotation(Compatibility.class);
 		if (annotation != null) {
 			ArdenVersion version = annotation.value();
-			if (!compiler.isVersionSupported(version)) {
-				String message = "Compiler doesn't support backward compatibility tests for version: "
-						+ version.toString();
+			if (settings.targetVersion.ordinal() < version.ordinal()
+					|| settings.lowestVersion.ordinal() > version.ordinal()) {
+				String message = "Compiler doesn't support tests for version: " + version.toString();
 				result = new IgnoreStatement(message);
 			}
 		}

--- a/test/arden/tests/specification/testcompiler/CompatibilityRule.java
+++ b/test/arden/tests/specification/testcompiler/CompatibilityRule.java
@@ -6,6 +6,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.reflect.Method;
 
 import org.junit.rules.MethodRule;
 import org.junit.runners.model.FrameworkMethod;
@@ -29,6 +30,11 @@ import org.junit.runners.model.Statement;
 public class CompatibilityRule implements MethodRule {
 
 	private TestCompilerSettings settings;
+	private ArdenVersion currentTestMaxVersion;
+	private ArdenVersion currentTestMinVersion;
+
+	private static final ArdenVersion MIN_VERSION = getAnnotationDefaultValue("min");
+	private static final ArdenVersion MAX_VERSION = getAnnotationDefaultValue("max");
 
 	public CompatibilityRule(TestCompilerSettings settings) {
 		this.settings = settings;
@@ -40,15 +46,45 @@ public class CompatibilityRule implements MethodRule {
 
 		Compatibility annotation = method.getAnnotation(Compatibility.class);
 		if (annotation != null) {
-			ArdenVersion version = annotation.value();
-			if (settings.targetVersion.ordinal() < version.ordinal()
-					|| settings.lowestVersion.ordinal() > version.ordinal()) {
-				String message = "Compiler doesn't support tests for version: " + version.toString();
+			currentTestMinVersion = annotation.min();
+			currentTestMaxVersion = annotation.max();
+			if (settings.lowestVersion.ordinal() > currentTestMaxVersion.ordinal()) {
+				String message = "Compiler is not backwards compatible to version: " + currentTestMaxVersion.toString();
+				result = new IgnoreStatement(message);
+			} else if (settings.targetVersion.ordinal() < currentTestMinVersion.ordinal()) {
+				String message = "Compiler doesn't support newer version: " + currentTestMinVersion.toString();
 				result = new IgnoreStatement(message);
 			}
+		} else {
+			currentTestMinVersion = MIN_VERSION;
+			currentTestMaxVersion = MAX_VERSION;
 		}
 
 		return result;
+	}
+
+	/**
+	 * @return See {@link Compatibility#min()}
+	 */
+	public ArdenVersion getCurrentTestMinVersion() {
+		return currentTestMinVersion;
+	}
+
+	/**
+	 * @return See {@link Compatibility#max()}
+	 */
+	public ArdenVersion getCurrentTestMaxVersion() {
+		return currentTestMaxVersion;
+	}
+
+	private static ArdenVersion getAnnotationDefaultValue(String methodName) throws ExceptionInInitializerError {
+		// easiest way to reuse the annotations default values
+		try {
+			Method method = Compatibility.class.getMethod(methodName, (Class[]) null);
+			return (ArdenVersion) method.getDefaultValue();
+		} catch (NoSuchMethodException | SecurityException e) {
+			throw new ExceptionInInitializerError(e);
+		}
 	}
 
 	/**
@@ -57,7 +93,17 @@ public class CompatibilityRule implements MethodRule {
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.METHOD })
 	public @interface Compatibility {
-		ArdenVersion value();
+		/**
+		 * The Arden Syntax version, when the tested feature was introduced to
+		 * the language.
+		 */
+		ArdenVersion min() default ArdenVersion.V1;
+
+		/**
+		 * The last Arden Syntax version, before the tested feature was
+		 * deprecated or removed.
+		 */
+		ArdenVersion max() default ArdenVersion.V2_10;
 	}
 
 	private static class IgnoreStatement extends Statement {

--- a/test/arden/tests/specification/testcompiler/SpecificationTest.java
+++ b/test/arden/tests/specification/testcompiler/SpecificationTest.java
@@ -189,5 +189,47 @@ public abstract class SpecificationTest {
 			// test passed
 		}
 	}
-	
+
+	protected void assertValidSlot(String slotname, String slotcontent) throws TestCompilerCompiletimeException {
+		String code = createCodeBuilder().replaceSlotContent(slotname, slotcontent).toString();
+		assertValid(code);
+	}
+
+	protected void assertInvalidSlot(String slotname, String slotcontent) {
+		String code = createCodeBuilder().replaceSlotContent(slotname, slotcontent).toString();
+		assertInvalid(code);
+	}
+
+	protected void assertSlotIsRequired(String slotname) {
+		String missingSlot = createCodeBuilder().removeSlot(slotname).toString();
+		assertInvalid(missingSlot);
+	}
+
+	protected void assertSlotIsOptional(String slotname) throws TestCompilerCompiletimeException {
+		String missingSlot = createCodeBuilder().removeSlot(slotname).toString();
+		assertValid(missingSlot);
+	}
+
+	protected void assertWritesAfterEvent(String code, String event, String... messages) throws TestCompilerException {
+		if (!getSettings().isRuntimeSupported || !getSettings().runDelayTests) {
+			assertValid(code);
+			return;
+		}
+		TestCompilerDelayedMessage[] delayedMessages = getCompiler().compileAndRunForEvent(code, event, messages.length);
+		for (int i = 0; i < messages.length; i++) {
+			assertEquals(messages[i].toLowerCase(), delayedMessages[i].message.toLowerCase());
+		}
+	}
+
+	protected void assertDelayedBy(String code, String event, long... delayMillis) throws TestCompilerException {
+		if (!getSettings().isRuntimeSupported || !getSettings().runDelayTests) {
+			assertValid(code);
+			return;
+		}
+		TestCompilerDelayedMessage[] messages = getCompiler().compileAndRunForEvent(code, event, delayMillis.length);
+		for (int i = 0; i < delayMillis.length; i++) {
+			assertEquals(delayMillis[i], messages[i].delayMillis, TestCompilerDelayedMessage.PRECISION_MILLIS);
+		}
+	}
+
 }

--- a/test/arden/tests/specification/testcompiler/SpecificationTest.java
+++ b/test/arden/tests/specification/testcompiler/SpecificationTest.java
@@ -11,21 +11,22 @@ import org.junit.Rule;
 import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 
 /**
- * Base test class which all tests extend. Adds useful asserts, annotations and shared access
- * to the compiler.
+ * Base test class which all tests extend. Adds useful asserts, annotations and
+ * access to the compiler.
  */
 public abstract class SpecificationTest {
-	
+
 	/** Initialise your compiler here. It will be used by all tests. */
 	private final TestCompiler compiler = new arden.tests.specification.testcompiler.impl.TestCompilerImpl();
 	private final TestCompilerSettings settings = compiler.getSettings();
-	
-	// Decorator which intercepts calls to the compiler to skip unsupported tests
+
+	// decorator which intercepts calls to the compiler to skip unsupported tests
 	private TestCompiler runtimeCheckedCompiler = new TestCompiler() {
 		@Override
 		public TestCompilerSettings getSettings() {
 			return compiler.getSettings();
 		};
+
 		@Override
 		public TestCompilerMappings getMappings() {
 			TestCompilerMappings mappings = compiler.getMappings();
@@ -33,16 +34,19 @@ public abstract class SpecificationTest {
 			assumeNotNull("Compiler doesn't support tests with mappings", mappings);
 			return mappings;
 		};
+
 		@Override
 		public TestCompilerResult compileAndRun(String code) throws TestCompilerException {
 			// only run tests if runtime is supported
 			assumeTrue("Compiler doesn't support runtime tests", getSettings().isRuntimeSupported);
 			return compiler.compileAndRun(code);
 		}
+
 		@Override
 		public void compile(String code) throws TestCompilerCompiletimeException {
 			compiler.compile(code);
 		}
+
 		@Override
 		public TestCompilerDelayedMessage[] compileAndRunForEvent(String code, String eventMapping,
 				int messagesToCollect) throws TestCompilerException {
@@ -51,15 +55,15 @@ public abstract class SpecificationTest {
 			return compiler.compileAndRunForEvent(code, eventMapping, messagesToCollect);
 		}
 	};
-	
+
 	protected TestCompilerSettings getSettings() {
 		return settings;
 	}
-	
+
 	protected TestCompiler getCompiler() {
 		return runtimeCheckedCompiler;
 	}
-	
+
 	protected TestCompilerMappings getMappings() {
 		return runtimeCheckedCompiler.getMappings();
 	}
@@ -89,11 +93,10 @@ public abstract class SpecificationTest {
 		return createCodeBuilder().clearSlotContent("logic:");
 	}
 
-	// Used for compatibility tests with the <code>@Compatibility</code> annotation.
+	// Used for compatibility tests with the @Compatibility annotation.
 	@Rule
 	public CompatibilityRule compatibilityRule = new CompatibilityRule(getSettings());
-	
-	
+
 	/**
 	 * Tests if the result of the evaluated expressions is equal to the expected
 	 * string (case insensitive).
@@ -101,10 +104,10 @@ public abstract class SpecificationTest {
 	protected void assertEvaluatesTo(String expression, String expected) throws TestCompilerException {
 		assertEvaluatesToWithData(null, expression, expected);
 	}
-	
+
 	protected void assertEvaluatesToWithData(String dataCode, String expression, String expected) throws TestCompilerException {
 		ArdenCodeBuilder builder;
-		if(dataCode != null) {
+		if (dataCode != null) {
 			builder = new ArdenCodeBuilder(dataCode);
 		} else {
 			builder = createCodeBuilder();
@@ -112,17 +115,17 @@ public abstract class SpecificationTest {
 		String code = builder.addExpression(expression).toString();
 		assertReturns(code, expected);
 	}
-	
+
 	protected void assertReturns(String code, String... expected) throws TestCompilerException {
-		if(!getSettings().isRuntimeSupported) {
+		if (!getSettings().isRuntimeSupported) {
 			assertValid(code);
 			return;
 		}
-		
+
 		TestCompilerResult result = getCompiler().compileAndRun(code);
-		if(expected.length == 0) {
+		if (expected.length == 0) {
 			// no return values
-			if(result.returnValues.isEmpty()) {
+			if (result.returnValues.isEmpty()) {
 				// test passed
 			} else {
 				// a single "NULL" is also okay
@@ -146,11 +149,11 @@ public abstract class SpecificationTest {
 			assertArrayEquals(expected_lowercase, returnValues_lowercase);
 		}
 	}
-	
+
 	protected void assertNoReturn(String code) throws TestCompilerException {
 		assertReturns(code); // no expected values
 	}
-	
+
 	protected void assertWrites(String code, String expected) throws TestCompilerException {
 		if (!getSettings().isRuntimeSupported) {
 			assertValid(code);
@@ -161,31 +164,31 @@ public abstract class SpecificationTest {
 		String message = result.messages.get(0);
 		assertEquals(expected.toLowerCase(), message.toLowerCase());
 	}
-	
+
 	protected void assertValidStatement(String statement) throws TestCompilerException {
 		String code = createCodeBuilder().addData(statement).toString();
 		assertValid(code);
 	}
-	
+
 	protected void assertInvalidStatement(String statement) throws TestCompilerException {
 		String code = createCodeBuilder().addData(statement).toString();
 		assertInvalid(code);
 	}
-	
+
 	protected void assertInvalidExpression(String expression) throws TestCompilerException {
 		String code = createCodeBuilder().addExpression(expression).toString();
 		assertInvalid(code);
 	}
-	
+
 	protected void assertValid(String code) throws TestCompilerCompiletimeException {
 		getCompiler().compile(code);
 	}
-	
+
 	protected void assertInvalid(String code) {
 		try {
 			getCompiler().compile(code);
 			fail("Expected a " + TestCompilerCompiletimeException.class.getSimpleName() + " to be thrown.");
-		} catch(TestCompilerCompiletimeException e) {
+		} catch (TestCompilerCompiletimeException e) {
 			// test passed
 		}
 	}

--- a/test/arden/tests/specification/testcompiler/SpecificationTest.java
+++ b/test/arden/tests/specification/testcompiler/SpecificationTest.java
@@ -159,7 +159,7 @@ public abstract class SpecificationTest {
 
 		TestCompilerResult result = getCompiler().compileAndRun(code);
 		String message = result.messages.get(0);
-		assertEquals(expected, message);
+		assertEquals(expected.toLowerCase(), message.toLowerCase());
 	}
 	
 	protected void assertValidStatement(String statement) throws TestCompilerException {

--- a/test/arden/tests/specification/testcompiler/SpecificationTest.java
+++ b/test/arden/tests/specification/testcompiler/SpecificationTest.java
@@ -8,15 +8,7 @@ import static org.junit.Assume.assumeTrue;
 
 import org.junit.Rule;
 
-import arden.tests.specification.testcompiler.ArdenCodeBuilder;
-import arden.tests.specification.testcompiler.CompatibilityRule;
 import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
-import arden.tests.specification.testcompiler.TestCompiler;
-import arden.tests.specification.testcompiler.TestCompilerCompiletimeException;
-import arden.tests.specification.testcompiler.TestCompilerException;
-import arden.tests.specification.testcompiler.TestCompilerMappings;
-import arden.tests.specification.testcompiler.TestCompilerResult;
-import arden.tests.specification.testcompiler.TestCompilerResult.TestCompilerOutputText;
 
 /**
  * Base test class which all tests extend. Adds useful asserts, annotations and shared access
@@ -153,14 +145,14 @@ public abstract class SpecificationTest {
 	}
 	
 	protected void assertWrites(String code, String expected) throws TestCompilerException {
-		if(!getSettings().isRuntimeSupported) {
+		if (!getSettings().isRuntimeSupported) {
 			assertValid(code);
 			return;
 		}
-		
+
 		TestCompilerResult result = getCompiler().compileAndRun(code);
-		TestCompilerOutputText outputText = result.outputTexts.get(0);
-		assertEquals(expected, outputText.text);
+		String message = result.messages.get(0);
+		assertEquals(expected, message);
 	}
 	
 	protected void assertValidStatement(String statement) throws TestCompilerException {

--- a/test/arden/tests/specification/testcompiler/SpecificationTest.java
+++ b/test/arden/tests/specification/testcompiler/SpecificationTest.java
@@ -10,6 +10,7 @@ import org.junit.Rule;
 
 import arden.tests.specification.testcompiler.ArdenCodeBuilder;
 import arden.tests.specification.testcompiler.CompatibilityRule;
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
 import arden.tests.specification.testcompiler.TestCompiler;
 import arden.tests.specification.testcompiler.TestCompilerCompiletimeException;
 import arden.tests.specification.testcompiler.TestCompilerException;
@@ -63,10 +64,35 @@ public abstract class SpecificationTest {
 	protected TestCompilerMappings getMappings() {
 		return runtimeCheckedCompiler.getMappings();
 	}
-	
-	// Used for backward compatibility tests with the <code>@Compatibility</code> annotation.
+
+	/**
+	 * Initializes a code builder with a
+	 * {@link ArdenCodeBuilder#ArdenCodeBuilder(ArdenVersion) template}
+	 * compatible to the highest possible version. <br>
+	 * The highest possible version is either the compiler's
+	 * {@link TestCompilerSettings#targetVersion target version} or the tests
+	 * {@link Compatibility#max() max compatible version}, whichever is lower.
+	 * 
+	 * @return the {@link ArdenCodeBuilder}
+	 */
+	protected ArdenCodeBuilder createCodeBuilder() {
+		ArdenVersion maxPossibleVersion;
+		if (settings.targetVersion.ordinal() <= compatibilityRule.getCurrentTestMaxVersion().ordinal()) {
+			maxPossibleVersion = settings.targetVersion;
+		} else {
+			maxPossibleVersion = compatibilityRule.getCurrentTestMaxVersion();
+		}
+
+		return new ArdenCodeBuilder(maxPossibleVersion);
+	}
+
+	protected ArdenCodeBuilder createEmptyLogicSlotCodeBuilder() {
+		return createCodeBuilder().clearSlotContent("logic:");
+	}
+
+	// Used for compatibility tests with the <code>@Compatibility</code> annotation.
 	@Rule
-	public CompatibilityRule comaptibilityRule = new CompatibilityRule(getSettings());
+	public CompatibilityRule compatibilityRule = new CompatibilityRule(getSettings());
 	
 	
 	/**
@@ -82,7 +108,7 @@ public abstract class SpecificationTest {
 		if(dataCode != null) {
 			builder = new ArdenCodeBuilder(dataCode);
 		} else {
-			builder = new ArdenCodeBuilder();
+			builder = createCodeBuilder();
 		}
 		String code = builder.addExpression(expression).toString();
 		assertReturns(code, expected);
@@ -138,17 +164,17 @@ public abstract class SpecificationTest {
 	}
 	
 	protected void assertValidStatement(String statement) throws TestCompilerException {
-		String code = new ArdenCodeBuilder().addAction(statement).toString();
+		String code = createCodeBuilder().addAction(statement).toString();
 		assertValid(code);
 	}
 	
 	protected void assertInvalidStatement(String statement) throws TestCompilerException {
-		String code = new ArdenCodeBuilder().addAction(statement).toString();
+		String code = createCodeBuilder().addAction(statement).toString();
 		assertInvalid(code);
 	}
 	
 	protected void assertInvalidExpression(String expression) throws TestCompilerException {
-		String code = new ArdenCodeBuilder().addExpression(expression).toString();
+		String code = createCodeBuilder().addExpression(expression).toString();
 		assertInvalid(code);
 	}
 	

--- a/test/arden/tests/specification/testcompiler/SpecificationTest.java
+++ b/test/arden/tests/specification/testcompiler/SpecificationTest.java
@@ -25,34 +25,36 @@ public abstract class SpecificationTest {
 	
 	/** Initialise your compiler here. It will be used by all tests. */
 	private final TestCompiler compiler = new arden.tests.specification.testcompiler.impl.TestCompilerImpl();
+	private final TestCompilerSettings settings = compiler.getSettings();
 	
 	// Decorator which intercepts calls to the compiler to skip unsupported tests
 	private TestCompiler runtimeCheckedCompiler = new TestCompiler() {
-		public TestCompilerResult compileAndRun(String code) throws TestCompilerException {
-			// only run tests if runtime is supported
-			assumeTrue("Compiler doesn't support runtime tests", isRuntimeSupported());
-			return compiler.compileAndRun(code);
-		}
 		@Override
-		public boolean isRuntimeSupported() {
-			return compiler.isRuntimeSupported();
-		}
-		@Override
-		public boolean isVersionSupported(ArdenVersion version) {
-			return compiler.isVersionSupported(version);
-		}
-		@Override
-		public void compile(String code) throws TestCompilerCompiletimeException {
-			compiler.compile(code);
-		}
+		public TestCompilerSettings getSettings() {
+			return compiler.getSettings();
+		};
 		@Override
 		public TestCompilerMappings getMappings() {
 			TestCompilerMappings mappings = compiler.getMappings();
 			// only run test if mappings are provided
 			assumeNotNull("Compiler doesn't support tests with mappings", mappings);
-			return compiler.getMappings();
+			return mappings;
 		};
+		@Override
+		public TestCompilerResult compileAndRun(String code) throws TestCompilerException {
+			// only run tests if runtime is supported
+			assumeTrue("Compiler doesn't support runtime tests", getSettings().isRuntimeSupported);
+			return compiler.compileAndRun(code);
+		}
+		@Override
+		public void compile(String code) throws TestCompilerCompiletimeException {
+			compiler.compile(code);
+		}
 	};
+	
+	protected TestCompilerSettings getSettings() {
+		return settings;
+	}
 	
 	protected TestCompiler getCompiler() {
 		return runtimeCheckedCompiler;
@@ -64,7 +66,7 @@ public abstract class SpecificationTest {
 	
 	// Used for backward compatibility tests with the <code>@Compatibility</code> annotation.
 	@Rule
-	public CompatibilityRule comaptibilityRule = new CompatibilityRule(getCompiler());
+	public CompatibilityRule comaptibilityRule = new CompatibilityRule(getSettings());
 	
 	
 	/**
@@ -87,7 +89,7 @@ public abstract class SpecificationTest {
 	}
 	
 	protected void assertReturns(String code, String... expected) throws TestCompilerException {
-		if(!getCompiler().isRuntimeSupported()) {
+		if(!getSettings().isRuntimeSupported) {
 			assertValid(code);
 			return;
 		}
@@ -125,7 +127,7 @@ public abstract class SpecificationTest {
 	}
 	
 	protected void assertWrites(String code, String expected) throws TestCompilerException {
-		if(!getCompiler().isRuntimeSupported()) {
+		if(!getSettings().isRuntimeSupported) {
 			assertValid(code);
 			return;
 		}

--- a/test/arden/tests/specification/testcompiler/SpecificationTest.java
+++ b/test/arden/tests/specification/testcompiler/SpecificationTest.java
@@ -163,12 +163,12 @@ public abstract class SpecificationTest {
 	}
 	
 	protected void assertValidStatement(String statement) throws TestCompilerException {
-		String code = createCodeBuilder().addAction(statement).toString();
+		String code = createCodeBuilder().addData(statement).toString();
 		assertValid(code);
 	}
 	
 	protected void assertInvalidStatement(String statement) throws TestCompilerException {
-		String code = createCodeBuilder().addAction(statement).toString();
+		String code = createCodeBuilder().addData(statement).toString();
 		assertInvalid(code);
 	}
 	

--- a/test/arden/tests/specification/testcompiler/SpecificationTest.java
+++ b/test/arden/tests/specification/testcompiler/SpecificationTest.java
@@ -43,6 +43,13 @@ public abstract class SpecificationTest {
 		public void compile(String code) throws TestCompilerCompiletimeException {
 			compiler.compile(code);
 		}
+		@Override
+		public TestCompilerDelayedMessage[] compileAndRunForEvent(String code, String eventMapping,
+				int messagesToCollect) throws TestCompilerException {
+			assumeTrue("Compiler doesn't support runtime tests", getSettings().isRuntimeSupported);
+			assumeTrue("Compiler doesn't support event tests", getSettings().runDelayTests);
+			return compiler.compileAndRunForEvent(code, eventMapping, messagesToCollect);
+		}
 	};
 	
 	protected TestCompilerSettings getSettings() {

--- a/test/arden/tests/specification/testcompiler/Template_Resources.mlm
+++ b/test/arden/tests/specification/testcompiler/Template_Resources.mlm
@@ -1,0 +1,28 @@
+maintenance:
+    title: Test;;
+    mlmname: test_mlm;;
+    arden: Version 2.6;;
+    version: 1.00;;
+    institution: PLRI;;
+    author: Mike;;
+    specialist: Mike;;
+    date: 2016-01-31;;
+    validation: testing;;
+library:
+    purpose: Template for unit tests;;
+    explanation: This MLM is a template for several unit tests.;;
+    keywords: test; testing; unit tests; template;;
+    citations: ;;
+    links: ;;
+knowledge:
+    type: data_driven;;
+    data: ;;
+    priority: 50;;
+    evoke: ;;
+    logic: CONCLUDE TRUE; ;;
+    action: ;;
+    urgency: 50;;
+resources:
+    default: en;;
+    language: en;;
+end:

--- a/test/arden/tests/specification/testcompiler/Template_V1.mlm
+++ b/test/arden/tests/specification/testcompiler/Template_V1.mlm
@@ -1,0 +1,24 @@
+maintenance:
+    title: Test;;
+    filename: test_mlm.mlm;;
+    version: 1.00;;
+    institution: PLRI;;
+    author: Mike;;
+    specialist: Mike;;
+    date: 2016-01-31;;
+    validation: testing;;
+library:
+    purpose: Template for unit tests;;
+    explanation: This MLM is a template for several unit tests.;;
+    keywords: test; testing; unit tests; template;;
+    citations: ;;
+    links: ;;
+knowledge:
+    type: data_driven;;
+    data: ;;
+    priority: 50;;
+    evoke: ;;
+    logic: CONCLUDE TRUE; ;;
+    action: ;;
+    urgency: 50;;
+end:

--- a/test/arden/tests/specification/testcompiler/TestCompiler.java
+++ b/test/arden/tests/specification/testcompiler/TestCompiler.java
@@ -30,7 +30,7 @@ public interface TestCompiler {
 	 * Compile the given code
 	 * 
 	 * @param code
-	 *            Arden Syntax code, which may contain multiple mlms.
+	 *            Arden Syntax code, which may contain multiple MLMs.
 	 * @throws TestCompilerCompiletimeException
 	 *             e.g. on a a lexer, parser or validation error
 	 */
@@ -40,12 +40,59 @@ public interface TestCompiler {
 	 * Compile and run the given code
 	 * 
 	 * @param code
-	 *            Arden Syntax code, which may contain multiple mlms. In that
+	 *            Arden Syntax code, which may contain multiple MLMs. In that
 	 *            case the first mlm is run.
 	 * @return {@link TestCompilerResult}
 	 * @throws TestCompilerException
+	 *             e.g. a {@link TestCompilerRuntimeException} on a runtime
+	 *             error
 	 * @see TestCompilerResult
 	 */
 	public TestCompilerResult compileAndRun(String code) throws TestCompilerException;
 
+	/**
+	 * Compile one or multiple MLMs and call an event that triggers them. Then
+	 * collect a certain number of {@link TestCompilerDelayedMessage#message
+	 * messages} and their {@link TestCompilerDelayedMessage#delayMillis delay},
+	 * and return them as a list of {@link TestCompilerDelayedMessage}s. <br>
+	 * Used to test delayed/cyclic triggers and delayed calls.
+	 *
+	 * <p>
+	 * Example calculation:
+	 * 
+	 * <pre>
+	 * engine.setMlms(compiler.compile(code));
+	 * long startTime = System.currentTimeMillis();
+	 * engine.callEvent(eventMapping);
+	 * while (messages.size() < messagesToCollect) {
+	 * 	// blocks until a message is received
+	 * 	String message = engine.getNextMessage();
+	 * 	long delay = System.currentTimeMillis() - startTime;
+	 * 	messages.add(new TestCompilerDelayedMessage(delay, message));
+	 * }
+	 * engine.shutdown();
+	 * </pre>
+	 * </p>
+	 * 
+	 * <p>
+	 * This method may block the execution of the current test until a result is
+	 * available.<br>
+	 * The long running tests that use this method can be skipped via the
+	 * {@link TestCompilerSettings#runDelayedTests} setting.
+	 * </p>
+	 * 
+	 * @param code
+	 *            Arden Syntax code, which may contain multiple MLMs. All MLMs
+	 *            should wait for events.
+	 * @param eventMapping
+	 *            The mapping for an event, that must be called.
+	 * @param messagesToCollect
+	 *            The number of messages that should be collected and returned.
+	 * @return The {@link TestCompilerDelayedMessage messages} that were
+	 *         collected with their respective delay.
+	 * @throws TestCompilerException
+	 * @see {@link TestCompilerDelayedMessage}
+	 */
+	public TestCompilerDelayedMessage[] compileAndRunForEvent(String code, String eventMapping, int messagesToCollect)
+			throws TestCompilerException;
 }

--- a/test/arden/tests/specification/testcompiler/TestCompiler.java
+++ b/test/arden/tests/specification/testcompiler/TestCompiler.java
@@ -7,50 +7,45 @@ package arden.tests.specification.testcompiler;
 public interface TestCompiler {
 
 	/**
-	 * Used to check if runtime tests (e.g. operator tests, which check return
-	 * values) should be run by calling {@link #compileAndRun(String)}, or only
-	 * compiled to check for syntax errors by calling {@link #compile(String)}.
+	 * These settings influence, how the tests are run, e.g. if backward
+	 * compatibility tests should be skipped, or what value the "arden:" slot is
+	 * set to.
 	 * 
-	 * @return <code>true</code> if runtime tests should run, <code>false</code>
-	 *         if they should only be compiled.
+	 * @return {@link TestCompilerSettings}
+	 * @see TestCompilerSettings
 	 */
-	public boolean isRuntimeSupported();
+	public TestCompilerSettings getSettings();
 
 	/**
-	 * Used to only run backward compatibility tests for Arden Syntax versions
-	 * which are supported.
+	 * Used to insert valid mappings into tests, e.g. a <code>READ</code>
+	 * mapping or <code>INTERFACE</code> mapping .
 	 * 
-	 * @param version
-	 *            The {@link ArdenVersion} to check against
-	 * @return <code>true</code> if backward compatibility tests for this
-	 *         version should run, <code>false</code> otherwise.
+	 * @return {@link TestCompilerMappings} or <code>null</code> to skip tests
+	 *         which required mappings.
+	 * @see TestCompilerMappings
 	 */
-	public boolean isVersionSupported(ArdenVersion version);
-	
+	public TestCompilerMappings getMappings();
+
 	/**
 	 * Compile the given code
 	 * 
-	 * @param code Arden Syntax code, which may contain multiple mlms.
-	 * @throws TestCompilerCompiletimeException e.g. on a a lexer, parser or validation error
+	 * @param code
+	 *            Arden Syntax code, which may contain multiple mlms.
+	 * @throws TestCompilerCompiletimeException
+	 *             e.g. on a a lexer, parser or validation error
 	 */
 	public void compile(String code) throws TestCompilerCompiletimeException;
-	
+
 	/**
 	 * Compile and run the given code
 	 * 
-	 * @param code Arden Syntax code, which may contain multiple mlms. In that case the first mlm is run. 
+	 * @param code
+	 *            Arden Syntax code, which may contain multiple mlms. In that
+	 *            case the first mlm is run.
 	 * @return {@link TestCompilerResult}
 	 * @throws TestCompilerException
 	 * @see TestCompilerResult
 	 */
 	public TestCompilerResult compileAndRun(String code) throws TestCompilerException;
-	
-	/**
-	 * Used to insert mappings into tests, e.g. a <code>READ</code> mapping or <code>INTERFACE</code> mapping . 
-	 * 
-	 * @return {@link TestCompilerMappings} or <code>null</code> to skip tests which required mappings.
-	 * @see TestCompilerMappings
-	 */
-	public TestCompilerMappings getMappings();
 
 }

--- a/test/arden/tests/specification/testcompiler/TestCompilerDelayedMessage.java
+++ b/test/arden/tests/specification/testcompiler/TestCompilerDelayedMessage.java
@@ -1,0 +1,40 @@
+package arden.tests.specification.testcompiler;
+
+/**
+ * Represents a message that is written after an event. See each fields comment
+ * for more information.
+ */
+public class TestCompilerDelayedMessage {
+	public static final int PRECISION_MILLIS = 200;
+
+	/**
+	 * The delay between the occurrence/call of an event and the time the
+	 * message arrived. For example:
+	 * <ol>
+	 * <li>MLM1 has the following trigger:
+	 * <code>5 SECONDS AFTER TIME OF the_event;</code>
+	 * <li>MLM1 calls MLM2 with a delay: <code>CALL mlm2 DELAY 2 SECONDS;</code>
+	 * <li>MLM2 writes a message: <code>WRITE "a message";</code>
+	 * </ol>
+	 * 
+	 * The expected delay would be 5 seconds + 2 seconds = 7 seconds, i.e. 7000
+	 * milliseconds. <br>
+	 * This is similar to <code>TRIGGERTIME - EVENTTIME</code> if
+	 * <code>EVENTTIME</code> is the time the event is called. <br>
+	 * 
+	 * <p>
+	 * Should be precise up to {@value #PRECISION_MILLIS} milliseconds.
+	 * </p>
+	 */
+	public final long delayMillis;
+
+	/**
+	 * The text/message from a <code>WRITE</code> statement as a String.
+	 */
+	public final String message;
+
+	public TestCompilerDelayedMessage(long delayMillis, String message) {
+		this.delayMillis = delayMillis;
+		this.message = message;
+	}
+}

--- a/test/arden/tests/specification/testcompiler/TestCompilerMappings.java
+++ b/test/arden/tests/specification/testcompiler/TestCompilerMappings.java
@@ -5,19 +5,18 @@ package arden.tests.specification.testcompiler;
  */
 public class TestCompilerMappings {
 	protected String interfaceMapping;
-	protected String eventMapping;
 	protected String messageMapping;
 	protected String destinationMapping;
 	protected String readMapping;
 	protected String readMultipleMapping;
+	private long eventNr = 0;
 
 	public TestCompilerMappings() {
 	}
 
-	public TestCompilerMappings(String interfaceMapping, String eventMapping, String messageMapping,
+	public TestCompilerMappings(String interfaceMapping, String messageMapping,
 			String destinationMapping, String readMapping, String readMultipleMapping) {
 		this.interfaceMapping = interfaceMapping;
-		this.eventMapping = eventMapping;
 		this.messageMapping = messageMapping;
 		this.destinationMapping = destinationMapping;
 		this.readMapping = readMapping;
@@ -41,13 +40,14 @@ public class TestCompilerMappings {
 
 	/**
 	 * This method is used to test events. <br>
-	 * Test mlms must be able to subscribe to the event for this mapping via the
-	 * evoke slot. It must also be possible to <code>CALL</code> the event.
+	 * Test MLMs must be able to subscribe to the event for this mapping via the
+	 * evoke slot. It must also be possible to <code>CALL</code> the event. <br>
+	 * A mapping for a different event should be returned every time.
 	 * 
 	 * @return a mapping for an event
 	 */
-	public String getEventMapping() {
-		return eventMapping;
+	public String createEventMapping() {
+		return "event " + eventNr++;
 	}
 
 	/**

--- a/test/arden/tests/specification/testcompiler/TestCompilerMappings.java
+++ b/test/arden/tests/specification/testcompiler/TestCompilerMappings.java
@@ -1,16 +1,18 @@
 package arden.tests.specification.testcompiler;
 
 /**
- * Container for test mappings.
- * See each methods comment for more information.
+ * Container for test mappings. See each methods comment for more information.
  */
 public class TestCompilerMappings {
-	public String interfaceMapping;
-	public String eventMapping;
-	public String messageMapping;
-	public String destinationMapping;
-	public String readMapping;
-	public String readMultipleMapping;
+	protected String interfaceMapping;
+	protected String eventMapping;
+	protected String messageMapping;
+	protected String destinationMapping;
+	protected String readMapping;
+	protected String readMultipleMapping;
+
+	public TestCompilerMappings() {
+	}
 
 	public TestCompilerMappings(String interfaceMapping, String eventMapping, String messageMapping,
 			String destinationMapping, String readMapping, String readMultipleMapping) {
@@ -21,14 +23,14 @@ public class TestCompilerMappings {
 		this.readMapping = readMapping;
 		this.readMultipleMapping = readMultipleMapping;
 	}
-	
+
 	/**
 	 * This method is used to test <code>INTERFACE</code> mappings. <br>
 	 * It must be possible to <code>CALL</code> the interface for this mapping.
 	 * It must accept parameters and return the following two values: <br>
 	 * <ol>
-	 * <li><code>args[0] + args[1]</code></li>
-	 * <li><code>args[0] * args[1]</code></li>
+	 * 	<li><code>args[0] + args[1]</code></li>
+	 * 	<li><code>args[0] * args[1]</code></li>
 	 * </ol>
 	 * 
 	 * @return a mapping for an interface
@@ -36,28 +38,28 @@ public class TestCompilerMappings {
 	public String getInterfaceMapping() {
 		return interfaceMapping;
 	}
-	
+
 	/**
 	 * This method is used to test events. <br>
-	 * Test mlms must be able to subscribe to the event for this mapping via the evoke slot.
-	 * It must also be possible to <code>CALL</code> the event.
+	 * Test mlms must be able to subscribe to the event for this mapping via the
+	 * evoke slot. It must also be possible to <code>CALL</code> the event.
 	 * 
 	 * @return a mapping for an event
 	 */
 	public String getEventMapping() {
 		return eventMapping;
 	}
-	
+
 	/**
-	 * This method is used to test messages.
-	 * The message for this mapping must contain the text "test message".
+	 * This method is used to test messages. The message for this mapping must
+	 * contain the text "test message".
 	 * 
 	 * @return a mapping for a message
 	 */
 	public String getMessageMapping() {
 		return messageMapping;
 	}
-	
+
 	/**
 	 * This method is used to test destinations.
 	 * 
@@ -69,7 +71,8 @@ public class TestCompilerMappings {
 
 	/**
 	 * This method is used to test the <code>READ</code> statement. <br>
-	 * When the mapping is read, it must return a list of the following values with their respective primary time:
+	 * When the mapping is read, it must return a list of the following values
+	 * with their respective primary time:
 	 * 
 	 * <table summary="database content">
 	 *   <tr>
@@ -97,10 +100,12 @@ public class TestCompilerMappings {
 	public String getReadMapping() {
 		return readMapping;
 	}
-	
+
 	/**
-	 * This method is used to test the <code>READ</code> and <code>READ AS</code> statements. <br>
-	 * When the mapping is read, it must return two lists, one for each of the following value columns:
+	 * This method is used to test the <code>READ</code> and
+	 * <code>READ AS</code> statements. <br>
+	 * When the mapping is read, it must return two lists, one for each of the
+	 * following value columns:
 	 * 
 	 * <table summary="database content">
 	 *   <tr>

--- a/test/arden/tests/specification/testcompiler/TestCompilerResult.java
+++ b/test/arden/tests/specification/testcompiler/TestCompilerResult.java
@@ -4,20 +4,31 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * Container for the result of an MLM execution. Contains the return value of
- * the MLM and the outputtext (e.g. messages at destinations).
+ * Container for the result of an MLM execution. Contains the return values of
+ * the MLM and the written messages.
+ * 
  * <p>
- * For durations the internal representation (seconds, months), not the localized string
- * representation, must be used. <br>
+ * For durations the internal representation (seconds, months), not the
+ * localized string representation, must be used. It must be correctly pluralized<br>
  * For times the trailing zeros must be removed. <br>
- * For List no whitespace is allowed before/after commas and single element lists start with a comma.
+ * For lists no whitespace is allowed before/after commas and single element
+ * lists start with a comma. <br>
+ * Truth values 0 and 1 must return FALSE/TRUE. <br>
+ * String constants must be enclosed in double quotes <br>
+ * Case doesn't matter. <br>
+ * </p>
+ * 
  * <h4>Allowed:</h4>
  * <ul>
+ *   <li>"A string"</li>
  *   <li>5 seconds</li>
+ *   <li>1 second</li>
  *   <li>10 months</li>
  *   <li>1990-11-26T22:57:05.4</li>
  *   <li>(1,2,3)</li>
  *   <li>(,1)</li>
+ *   <li>()</li>
+ *   <li>TRUE</li>
  * </ul>
  * <h4>Not allowed:</h4>
  * <ul>
@@ -26,24 +37,18 @@ import java.util.List;
  *   <li>1990-11-26T22:57:05.400</li>
  *   <li>(1, 2, 3)</li>
  *   <li>(1)</li>
+ *   <li>truth value 1</li>
  * </ul>
  */
 public class TestCompilerResult {
-	public final List<String> returnValues = new LinkedList<String>();
-	public final List<TestCompilerOutputText> outputTexts = new LinkedList<TestCompilerOutputText>();
-
 	/**
-	 * Output of the "WRITE" statement. For example: <br>
-	 * 
-	 * <code>dest := DESTINATION{log.txt}; WRITE "hello world" at dest;</code>
+	 * Output of the <code>RETURN</code> statement.
 	 */
-	public static class TestCompilerOutputText {
-		public final String destination;
-		public final String text;
+	public final List<String> returnValues = new LinkedList<String>();
+	
+	/**
+	 * Output of the <code>WRITE</code> statement. Destination doesn't matter.
+	 */
+	public final List<String> messages = new LinkedList<String>();
 
-		public TestCompilerOutputText(String destination, String text) {
-			this.destination = destination;
-			this.text = text;
-		}
-	}
 }

--- a/test/arden/tests/specification/testcompiler/TestCompilerSettings.java
+++ b/test/arden/tests/specification/testcompiler/TestCompilerSettings.java
@@ -1,0 +1,61 @@
+package arden.tests.specification.testcompiler;
+
+/**
+ * These settings influence, how the tests are run. See each fields comment for
+ * more information.
+ */
+public class TestCompilerSettings {
+
+	/**
+	 * The highest Arden Syntax version, which this compiler supports.
+	 * <p>
+	 * Tests that require features from newer versions will be skipped.<br>
+	 * The chosen {@linkplain ArdenCodeBuilder#ArdenCodeBuilder(ArdenVersion)
+	 * MLM template} may change depending on this version. See
+	 * {@link SpecificationTest#createCodeBuilder()} for how the template for
+	 * MLMs is chosen, depending on the targetVersion.
+	 * </p>
+	 */
+	public final ArdenVersion targetVersion;
+
+	/**
+	 * The lowest Arden Syntax version, which this compiler supports.
+	 * <p>
+	 * Tests that require deprecated or removed features from older versions
+	 * will be skipped. E.g. tests for the "filename:" slot or the free text in
+	 * the "citations:" and "links:" slot, when lowestVersion is Version 2.
+	 * </p>
+	 * <p>
+	 * This is also used in tests, that create MLMs in every version from
+	 * lowestVersion to {@linkplain #targetVersion} (inclusive), and check that
+	 * no languages features newer than the specified version are usable. <br>
+	 * These tests are necessary as otherwise portability of the MLMs can not be
+	 * guaranteed.
+	 * </p>
+	 */
+	public final ArdenVersion lowestVersion;
+
+	/**
+	 * Used to check if runtime tests (e.g. operator tests, which check return
+	 * values) should be run by calling
+	 * {@link TestCompiler#compileAndRun(String)}, or only compiled to check for
+	 * syntax errors by calling {@link TestCompiler#compile(String)}. <br>
+	 * This is useful for testing parsers in text editors, which can't run code.
+	 */
+	public final boolean isRuntimeSupported;
+
+	/**
+	 * Whether possibly long running tests that call the
+	 * {@link TestCompiler#compileAndRunForEvent(String, String, int)} method
+	 * should be run.
+	 */
+	public final boolean runDelayTests;
+
+	public TestCompilerSettings(ArdenVersion targetVersion, ArdenVersion lowestVersion, boolean isRuntimeSupported,
+			boolean runDelayTests) {
+		this.targetVersion = targetVersion;
+		this.lowestVersion = lowestVersion;
+		this.isRuntimeSupported = isRuntimeSupported;
+		this.runDelayTests = runDelayTests;
+	}
+}

--- a/test/arden/tests/specification/testcompiler/TestCompilerSettings.java
+++ b/test/arden/tests/specification/testcompiler/TestCompilerSettings.java
@@ -1,5 +1,7 @@
 package arden.tests.specification.testcompiler;
 
+import arden.tests.specification.testcompiler.CompatibilityRule.Compatibility;
+
 /**
  * These settings influence, how the tests are run. See each fields comment for
  * more information.
@@ -25,13 +27,6 @@ public class TestCompilerSettings {
 	 * will be skipped. E.g. tests for the "filename:" slot or the free text in
 	 * the "citations:" and "links:" slot, when lowestVersion is Version 2.
 	 * </p>
-	 * <p>
-	 * This is also used in tests, that create MLMs in every version from
-	 * lowestVersion to {@linkplain #targetVersion} (inclusive), and check that
-	 * no languages features newer than the specified version are usable. <br>
-	 * These tests are necessary as otherwise portability of the MLMs can not be
-	 * guaranteed.
-	 * </p>
 	 */
 	public final ArdenVersion lowestVersion;
 
@@ -39,10 +34,16 @@ public class TestCompilerSettings {
 	 * Used to check if runtime tests (e.g. operator tests, which check return
 	 * values) should be run by calling
 	 * {@link TestCompiler#compileAndRun(String)}, or only compiled to check for
-	 * syntax errors by calling {@link TestCompiler#compile(String)}. <br>
+	 * syntax errors by calling {@link TestCompiler#compile(String)}.<br>
 	 * This is useful for testing parsers in text editors, which can't run code.
 	 */
 	public final boolean isRuntimeSupported;
+
+	/**
+	 * Used to check whether tests marked as
+	 * {@linkplain Compatibility#pedantic() pedantic} should run.
+	 */
+	public final boolean runPedanticTests;
 
 	/**
 	 * Whether possibly long running tests that call the
@@ -52,10 +53,11 @@ public class TestCompilerSettings {
 	public final boolean runDelayTests;
 
 	public TestCompilerSettings(ArdenVersion targetVersion, ArdenVersion lowestVersion, boolean isRuntimeSupported,
-			boolean runDelayTests) {
+			boolean runDelayTests, boolean runPedanticTests) {
 		this.targetVersion = targetVersion;
 		this.lowestVersion = lowestVersion;
 		this.isRuntimeSupported = isRuntimeSupported;
 		this.runDelayTests = runDelayTests;
+		this.runPedanticTests = runPedanticTests;
 	}
 }

--- a/test/arden/tests/specification/testcompiler/impl/TestCompilerImpl.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestCompilerImpl.java
@@ -80,7 +80,7 @@ public class TestCompilerImpl implements TestCompiler {
 				result.returnValues.add(stringValue);
 			}
 		}
-		result.outputTexts.addAll(context.getOutputText());
+		result.messages.addAll(context.getMessages());
 	
 		return result;
 	}

--- a/test/arden/tests/specification/testcompiler/impl/TestCompilerImpl.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestCompilerImpl.java
@@ -27,7 +27,6 @@ public class TestCompilerImpl implements TestCompiler {
 
 	private TestCompilerMappings mappings = new TestCompilerMappings(
 			TestContext.INTERFACE_MAPPING,
-			TestContext.EVENT_MAPPING,
 			TestContext.MESSAGE_MAPPING,
 			TestContext.DESTINATION_MAPPING,
 			TestContext.READ_MAPPING,

--- a/test/arden/tests/specification/testcompiler/impl/TestCompilerImpl.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestCompilerImpl.java
@@ -14,29 +14,37 @@ import arden.tests.specification.testcompiler.TestCompilerException;
 import arden.tests.specification.testcompiler.TestCompilerMappings;
 import arden.tests.specification.testcompiler.TestCompilerResult;
 import arden.tests.specification.testcompiler.TestCompilerRuntimeException;
+import arden.tests.specification.testcompiler.TestCompilerSettings;
 
 public class TestCompilerImpl implements TestCompiler {
-	
+
 	private arden.compiler.Compiler compiler = new arden.compiler.Compiler();
-	
+
 	private TestCompilerMappings mappings = new TestCompilerMappings(TestContext.INTERFACE_MAPPING,
 			TestContext.EVENT_MAPPING, TestContext.MESSAGE_MAPPING, TestContext.DESTINATION_MAPPING,
 			TestContext.READ_MAPPING, TestContext.READ_MULTIPLE_MAPPING);
-	
+
+	private TestCompilerSettings settings = new TestCompilerSettings(ArdenVersion.V2_5, ArdenVersion.V1, true, true);
+
 	@Override
-	public boolean isRuntimeSupported() {
-		return true;
+	public TestCompilerSettings getSettings() {
+		return settings;
 	}
 
 	@Override
-	public boolean isVersionSupported(ArdenVersion version) {
-		// backwards compatible to all versions up to v2.5
-		return version.ordinal() <= ArdenVersion.V2_5.ordinal();
-	}
-	
-	@Override
 	public TestCompilerMappings getMappings() {
 		return mappings;
+	}
+
+	@Override
+	public void compile(String code) throws TestCompilerCompiletimeException {
+		try {
+			compiler.compile(new StringReader(code));
+		} catch (CompilerException e) {
+			throw new TestCompilerCompiletimeException(e);
+		} catch (IOException e) {
+			throw new TestCompilerCompiletimeException(e);
+		}
 	}
 
 	@Override
@@ -50,12 +58,12 @@ public class TestCompilerImpl implements TestCompiler {
 		} catch (IOException e) {
 			throw new TestCompilerCompiletimeException(e);
 		}
-
+	
 		// run and save return values
 		CompiledMlm firstMlm = compiledMlms.get(0);
 		TestContext context = new TestContext(compiledMlms, firstMlm.getMaintenance().getInstitution());
 		TestCompilerResult result = new TestCompilerResult();
-		
+	
 		ArdenValue[] returnValues;
 		try {
 			returnValues = firstMlm.run(context, null);
@@ -64,26 +72,15 @@ public class TestCompilerImpl implements TestCompiler {
 		} catch (Error e) {
 			throw new TestCompilerRuntimeException(e);
 		}
-		if(returnValues != null) {
+		if (returnValues != null) {
 			for (ArdenValue returnValue : returnValues) {
 				String stringValue = new NormalizedArdenValue(returnValue).toString();
 				result.returnValues.add(stringValue);
 			}
 		}
 		result.outputTexts.addAll(context.getOutputText());
-
-		return result;
-	}
 	
-	@Override
-	public void compile(String code) throws TestCompilerCompiletimeException {
-		try {
-			compiler.compile(new StringReader(code));
-		} catch (CompilerException e) {
-			throw new TestCompilerCompiletimeException(e);
-		} catch (IOException e) {
-			throw new TestCompilerCompiletimeException(e);
-		}
+		return result;
 	}
 
 }

--- a/test/arden/tests/specification/testcompiler/impl/TestCompilerImpl.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestCompilerImpl.java
@@ -24,7 +24,9 @@ public class TestCompilerImpl implements TestCompiler {
 			TestContext.EVENT_MAPPING, TestContext.MESSAGE_MAPPING, TestContext.DESTINATION_MAPPING,
 			TestContext.READ_MAPPING, TestContext.READ_MULTIPLE_MAPPING);
 
-	private TestCompilerSettings settings = new TestCompilerSettings(ArdenVersion.V2_5, ArdenVersion.V1, true, true);
+	private TestCompilerSettings settings = new TestCompilerSettings(
+			ArdenVersion.V2_5, ArdenVersion.V1,
+			true, true, false);
 
 	@Override
 	public TestCompilerSettings getSettings() {

--- a/test/arden/tests/specification/testcompiler/impl/TestContext.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestContext.java
@@ -17,7 +17,6 @@ import arden.runtime.ArdenValue;
 import arden.runtime.DatabaseQuery;
 import arden.runtime.ExecutionContext;
 import arden.tests.specification.testcompiler.TestCompiler;
-import arden.tests.specification.testcompiler.TestCompilerResult.TestCompilerOutputText;
 
 /**
  * See the requirements at the {@link TestCompiler} interface.
@@ -46,7 +45,7 @@ public class TestContext extends ExecutionContext {
 			new ArdenString("a", new GregorianCalendar(2000,Calendar.JANUARY,1).getTimeInMillis())
 	};
 	
-	private List<TestCompilerOutputText> outputTexts = new LinkedList<TestCompilerOutputText>();
+	private List<String> messages = new LinkedList<String>();
 	private List<CompiledMlm> mlms;
 	private String institutionSelf;
 	enum Validation {
@@ -166,10 +165,11 @@ public class TestContext extends ExecutionContext {
 	public void write(ArdenValue message, String destination) {
 		// save messages
 		String stringMessage = ((ArdenString) message).value;
-		outputTexts.add(new TestCompilerOutputText(destination, stringMessage));
+		messages.add(stringMessage);
 	}
 
-	public List<TestCompilerOutputText> getOutputText() {
-		return outputTexts;
+	public List<String> getMessages() {
+		return messages;
 	}
+
 }

--- a/test/arden/tests/specification/testcompiler/impl/TestContext.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestContext.java
@@ -22,7 +22,6 @@ import arden.tests.specification.testcompiler.TestCompiler;
  * See the requirements at the {@link TestCompiler} interface.
  */
 public class TestContext extends ExecutionContext {
-	static final String EVENT_MAPPING = "test event";
 	static final String INTERFACE_MAPPING = "test interface";
 	static final String MESSAGE_MAPPING = "test message";
 	static final String READ_MAPPING = "select id from database";
@@ -30,14 +29,14 @@ public class TestContext extends ExecutionContext {
 	static final String DESTINATION_MAPPING = "dest";
 	
 	// TODO DatabaseQuery should automatically sort by time
-	private static ArdenValue[] values1 = new ArdenValue[] {
+	private final ArdenValue[] values1 = new ArdenValue[] {
 			ArdenNumber.create(5, new GregorianCalendar(1970,Calendar.JANUARY,1).getTimeInMillis()),
 			ArdenNumber.create(3, new GregorianCalendar(1990,Calendar.JANUARY,1).getTimeInMillis()),
 			ArdenNumber.create(2, new GregorianCalendar(1990,Calendar.JANUARY,2).getTimeInMillis()),
 			ArdenNumber.create(4, new GregorianCalendar(1990,Calendar.JANUARY,3).getTimeInMillis()),
 			ArdenNumber.create(1, new GregorianCalendar(2000,Calendar.JANUARY,1).getTimeInMillis())
 	};
-	private static ArdenValue[] values2 = new ArdenValue[] {
+	private final ArdenValue[] values2 = new ArdenValue[] {
 			new ArdenString("e", new GregorianCalendar(1970,Calendar.JANUARY,1).getTimeInMillis()),
 			new ArdenString("c", new GregorianCalendar(1990,Calendar.JANUARY,1).getTimeInMillis()),
 			new ArdenString("b", new GregorianCalendar(1990,Calendar.JANUARY,2).getTimeInMillis()),
@@ -131,10 +130,7 @@ public class TestContext extends ExecutionContext {
 	
 	@Override
 	public ArdenEvent getEvent(String mapping) {
-		if(EVENT_MAPPING.equals(mapping)) {
-			return new ArdenEvent(mapping);
-		}
-		return super.getEvent(mapping);
+		return new ArdenEvent(mapping);
 	}
 
 	@Override

--- a/test/arden/tests/specification/testcompiler/impl/TestEngine.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestEngine.java
@@ -1,0 +1,218 @@
+package arden.tests.specification.testcompiler.impl;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.TreeMap;
+
+import arden.compiler.CompiledMlm;
+import arden.runtime.ArdenDuration;
+import arden.runtime.ArdenEvent;
+import arden.runtime.ArdenRunnable;
+import arden.runtime.ArdenString;
+import arden.runtime.ArdenTime;
+import arden.runtime.ArdenValue;
+import arden.runtime.ExecutionContext;
+import arden.runtime.MedicalLogicModule;
+import arden.runtime.evoke.Trigger;
+import arden.tests.specification.testcompiler.TestCompilerDelayedMessage;
+
+/**
+ * An engine for the
+ * {@link TestCompiler#compileAndRunForEvent(String, String, int)} method. <br>
+ * Skips delays by dynamically changing the {@link #getCurrentTime()} value, so
+ * tests don't block.
+ */
+public class TestEngine extends TestContext {
+	private static Comparator<MlmCall> priorityComparator = new Comparator<MlmCall>() {
+		@Override
+		public int compare(MlmCall m1, MlmCall m2) {
+			// highest priority first
+			return (int) (m2.getPriority() - m1.getPriority());
+		}
+	};
+	private List<MedicalLogicModule> mlms = new ArrayList<>();
+	private Schedule scheduledCalls = new Schedule();
+	private Queue<TestCompilerDelayedMessage> messages = new LinkedList<>();
+	private ArdenTime startTime;
+	private ArdenTime currentTime;
+
+	public TestEngine(List<CompiledMlm> mlms, String institutionSelf) {
+		super(mlms, institutionSelf);
+		this.mlms.addAll(mlms);
+	}
+
+	public void callEvent(ArdenEvent event) {
+		this.startTime = new ArdenTime(event.eventTime);
+		currentTime = startTime;
+
+		// check if MLMs are directly triggered
+		for (MedicalLogicModule mlm : mlms) {
+			Trigger trigger;
+			try {
+				trigger = mlm.getTrigger(this, null);
+			} catch (InvocationTargetException e) {
+				throw new RuntimeException(e);
+			}
+			trigger.scheduleEvent(event);
+			if (trigger.runOnEvent(event)) {
+				scheduledCalls.add(currentTime, new MlmCall(mlm, this, null));
+			}
+		}
+
+		// schedule MLMs which may now be triggered
+		Schedule additionalSchedule = createSchedule(mlms);
+		scheduledCalls.add(additionalSchedule);
+	}
+
+	@Override
+	public void callWithDelay(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delayValue) {
+		ArdenDuration delayDuration = (ArdenDuration) delayValue;
+		ArdenTime nextRuntime = new ArdenTime(currentTime.add(delayDuration));
+		scheduledCalls.add(nextRuntime, new MlmCall((MedicalLogicModule) mlm, this, arguments));
+	}
+
+	@Override
+	public void write(ArdenValue message, String destination) {
+		// save messages
+		String stringMessage;
+		if (message instanceof ArdenString) {
+			stringMessage = ((ArdenString) message).value;
+		} else {
+			stringMessage = message.toString();
+		}
+		long delay = currentTime.value - startTime.value;
+		messages.add(new TestCompilerDelayedMessage(delay, stringMessage));
+	}
+
+	@Override
+	public List<String> getMessages() {
+		throw new UnsupportedOperationException();
+	}
+
+	public TestCompilerDelayedMessage getNextDelayedMessage() throws InvocationTargetException {
+		while (messages.isEmpty()) {
+			// get the next MLM
+			Entry<ArdenTime, Queue<MlmCall>> nextEntry = scheduledCalls.firstEntry();
+			if (nextEntry == null) {
+				throw new IllegalStateException("There are no more messages");
+			}
+			ArdenTime nextRunTime = nextEntry.getKey();
+			Queue<MlmCall> queueCalls = nextEntry.getValue();
+			MlmCall nextMlm = queueCalls.poll(); // highest priority
+			if (queueCalls.isEmpty()) {
+				// remove empty list
+				scheduledCalls.pollFirstEntry();
+			}
+
+			// run the next MLM
+			if (nextRunTime.value >= currentTime.value) {
+				currentTime = new ArdenTime(nextRunTime.value+1); // skip delay
+			}
+			nextMlm.run();
+
+			// schedule MLMs which may now be triggered
+			Schedule additionalSchedule = createSchedule(mlms);
+			scheduledCalls.add(additionalSchedule);
+		}
+
+		return messages.remove();
+	}
+
+	@Override
+	public ArdenTime getCurrentTime() {
+		return currentTime;
+	}
+
+	private Schedule createSchedule(List<MedicalLogicModule> mlms) {
+		Schedule schedule = new Schedule();
+
+		// put MLMs which should run at the same time into groups sorted by time
+		for (MedicalLogicModule mlm : mlms) {
+			Trigger trigger;
+			try {
+				trigger = mlm.getTrigger(this, null);
+			} catch (InvocationTargetException e) {
+				// print error and skip this MLM
+				e.printStackTrace();
+				continue;
+			}
+
+			ArdenTime nextRuntime = trigger.getNextRunTime(this);
+			if (nextRuntime == null) {
+				// not scheduled
+				continue;
+			}
+
+			schedule.add(nextRuntime, new MlmCall(mlm, this, null));
+		}
+
+		return schedule;
+	}
+
+	@SuppressWarnings("serial")
+	private static class Schedule extends TreeMap<ArdenTime, Queue<MlmCall>> {
+		public Schedule() {
+			// sort by time
+			super(new ArdenTime.NaturalComparator());
+		}
+
+		public void add(Schedule additionalSchedule) {
+			for (Entry<ArdenTime, Queue<MlmCall>> entry : additionalSchedule.entrySet()) {
+				ArdenTime time = entry.getKey();
+				Queue<MlmCall> scheduleGroup = get(time);
+				if (scheduleGroup == null) {
+					put(time, entry.getValue());
+				} else {
+					scheduleGroup.addAll(entry.getValue());
+				}
+			}
+		}
+
+		public void add(ArdenTime nextRunTime, MlmCall mlm) {
+			Queue<MlmCall> scheduleGroup = get(nextRunTime);
+			if (scheduleGroup == null) {
+				scheduleGroup = new PriorityQueue<MlmCall>(3, priorityComparator);
+				put(nextRunTime, scheduleGroup);
+			}
+			scheduleGroup.add(mlm);
+		}
+	}
+
+	private static class MlmCall implements Runnable {
+		final MedicalLogicModule mlm;
+		final ArdenValue[] args;
+		final int priority;
+		final ExecutionContext context;
+
+		public MlmCall(MedicalLogicModule mlm, ExecutionContext context, ArdenValue[] args, int priority) {
+			this.mlm = mlm;
+			this.args = args;
+			this.priority = priority;
+			this.context = context;
+		}
+
+		public MlmCall(MedicalLogicModule mlm, ExecutionContext context, ArdenValue[] args) {
+			this(mlm, context, args, (int) Math.round(mlm.getPriority()));
+		}
+
+		public int getPriority() {
+			return priority;
+		}
+
+		@Override
+		public void run() {
+			try {
+				mlm.run(context, args);
+			} catch (InvocationTargetException e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
This updates the compiler independent [specification test suite](https://github.com/PLRI/arden2bytecode/tree/master/test/arden/tests/specification) to support compilers up to Arden Syntax version 2.10:

Apart from new and overhauled tests the following features are added:
- Min/Max/Pedantic fields for the annotation:
  - Min/Max: The Arden Syntax version when the tested feature was introduced to the language or removed/deprecated. Test are only run if the compiler supports a version in between these two values. Also the chosen template for the code builder depends on these versions. This is necessary as for example the resource category is required since version 2.9, but doesn't exist in versions before 2.6.
  - Pedantic: Pedantic tests require that the compiler restricts usage of features in some way, instead of being more permissive. This forces that MLMs written with this compiler are guaranteed to be compilable with other standard compliant compilers. For example the filename slot can only be used in version 1. Some permissive compilers may support it in version 2 and upwards, but this is not portable.
- Delayed testing:  
  It is possible to test delayed (`1 SECOND AFTER TIME OF an_event`) or cyclic triggers and event/MLM calls. This is done by asking the compiler to compile some MLMs, then call an event and wait for a certain number of messages (from the `WRITE` statement). The compiler then returns the delay for each message.  How the compiler gets the delay doesn't matter. It could start a timer and block execution until a message arrives, or calculate the delays like in the Arden2ByteCode implementation. 
- TestCompilerSettings class and more comments for a better API.