### PR TITLE
Fix NoClassDefFoundError

### DIFF
--- a/src/arden/compiler/InMemoryClassLoader.java
+++ b/src/arden/compiler/InMemoryClassLoader.java
@@ -39,6 +39,7 @@ final class InMemoryClassLoader extends ClassLoader {
 	Class<?> loadedClass;
 
 	public InMemoryClassLoader(String className, byte[] data) {
+		super(Thread.currentThread().getContextClassLoader());
 		this.className = className;
 		this.data = data;
 	}


### PR DESCRIPTION
This fixes a rare bug, that happens when the MedicalLogicModuleImplementation class was not loaded yet, when an MLM's bytecode is loaded.

This bug only seems to happen with the Eclipse Java compiler.