### PR TITLE
Metadata enums

### DIFF
--- a/src/arden.scc
+++ b/src/arden.scc
@@ -421,7 +421,7 @@ Tokens
   years       = y e a r s;
 
   ct           = 'T';
-  {arden}version_number  = digit ('.' digit)?;
+  {arden}version_number  = digit ('.' digit digit?)?;
 
   {normal}identifier = letter (letter | digit | us)*;
   /* up to 80 characters total (no reserved words allowed) */

--- a/src/arden/compiler/Compiler.java
+++ b/src/arden/compiler/Compiler.java
@@ -65,6 +65,8 @@ import arden.compiler.parser.ParserException;
 import arden.runtime.ArdenValue;
 import arden.runtime.LibraryMetadata;
 import arden.runtime.MaintenanceMetadata;
+import arden.runtime.MaintenanceMetadata.ArdenVersion;
+import arden.runtime.MaintenanceMetadata.Validation;
 import arden.runtime.MedicalLogicModule;
 import arden.runtime.RuntimeHelpers;
 import arden.runtime.evoke.Trigger;
@@ -183,12 +185,15 @@ public final class Compiler {
 	private void compileMaintenance(CodeGenerator codeGen, MaintenanceMetadata maintenance) throws NoSuchMethodException, SecurityException {		
 		FieldReference maintenanceField = codeGen.createStaticFinalField(MaintenanceMetadata.class);
 		MethodWriter init = codeGen.getStaticInitializer();
-		// format = new MaintenanceMetadata(String title, String mlmName, String ardenVersion, String version, String institution, String author, String specialist, Date date, String validation)
+		// format = new MaintenanceMetadata(String title, String mlmName, ArdenVersion ardenVersion, String version, String institution, String author, String specialist, Date date, Validation validation)
 		init.newObject(MaintenanceMetadata.class);
 		init.dup();
 		init.loadStringConstant(maintenance.getTitle());
 		init.loadStringConstant(maintenance.getMlmName());
-		init.loadStringConstant(maintenance.getArdenVersion());
+		
+		init.loadStringConstant(maintenance.getArdenVersion().name());
+		init.invokeStatic(ArdenVersion.class.getMethod("valueOf", String.class));
+		
 		init.loadStringConstant(maintenance.getVersion());
 		init.loadStringConstant(maintenance.getInstitution());
 		init.loadStringConstant(maintenance.getAuthor());
@@ -199,9 +204,10 @@ public final class Compiler {
 		init.loadLongConstant(maintenance.getDate().getTime());
 		init.invokeConstructor(Date.class.getConstructor(new Class<?>[]{Long.TYPE}));
 		
-		init.loadStringConstant(maintenance.getValidation());
+		init.loadStringConstant(maintenance.getValidation().name());
+		init.invokeStatic(Validation.class.getMethod("valueOf", String.class));
 		
-		init.invokeConstructor(MaintenanceMetadata.class.getConstructor(new Class<?>[]{String.class, String.class, String.class, String.class, String.class, String.class, String.class, Date.class, String.class}));
+		init.invokeConstructor(MaintenanceMetadata.class.getConstructor(new Class<?>[]{String.class, String.class, ArdenVersion.class, String.class, String.class, String.class, String.class, Date.class, Validation.class}));
 		init.storeStaticField(maintenanceField);
 		
 		CompilerContext context = codeGen.createMaintenance();

--- a/src/arden/compiler/MetadataCompiler.java
+++ b/src/arden/compiler/MetadataCompiler.java
@@ -56,6 +56,8 @@ import arden.compiler.node.AVrsnArdenVersionSlot;
 import arden.compiler.node.TNumberLiteral;
 import arden.runtime.LibraryMetadata;
 import arden.runtime.MaintenanceMetadata;
+import arden.runtime.MaintenanceMetadata.ArdenVersion;
+import arden.runtime.MaintenanceMetadata.Validation;
 import arden.runtime.RuntimeHelpers;
 
 /**
@@ -112,13 +114,19 @@ final class MetadataCompiler extends DepthFirstAdapter {
 	@Override
 	public void caseAVrsnArdenVersionSlot(AVrsnArdenVersionSlot node) {
 		if (usedFileNameForMlmName)
-			throw new RuntimeCompilerException("Cannot use 'filename' with Arden version 2");
-		maintenance.setArdenVersion(node.getVersionNumber().getText());
+			throw new RuntimeCompilerException("Cannot use 'filename' with Arden version >= 2");
+		String versionNumber = node.getVersionNumber().getText().toLowerCase();
+		String enumVersionNumber = "V" + versionNumber.replace(".", "_");
+		ArdenVersion version = ArdenVersion.valueOf(enumVersionNumber);
+		if (version == ArdenVersion.V1) {
+			throw new RuntimeCompilerException(node.getVersion(), "Arden version 1 does not allow the 'arden' slot");
+		}
+		maintenance.setArdenVersion(version);
 	}
 
 	@Override
 	public void caseAEmptyArdenVersionSlot(AEmptyArdenVersionSlot node) {
-		maintenance.setArdenVersion("1");
+		maintenance.setArdenVersion(ArdenVersion.V1);
 	}
 
 	// version_slot = version colon text semicolons;
@@ -182,22 +190,22 @@ final class MetadataCompiler extends DepthFirstAdapter {
 	// | {exp} expired;
 	@Override
 	public void caseAProdValidationCode(AProdValidationCode node) {
-		maintenance.setValidation("production");
+		maintenance.setValidation(Validation.PRODUCTION);
 	}
 
 	@Override
 	public void caseAResValidationCode(AResValidationCode node) {
-		maintenance.setValidation("research");
+		maintenance.setValidation(Validation.RESEARCH);
 	}
 
 	@Override
 	public void caseATestValidationCode(ATestValidationCode node) {
-		maintenance.setValidation("testing");
+		maintenance.setValidation(Validation.TESTING);
 	}
 
 	@Override
 	public void caseAExpValidationCode(AExpValidationCode node) {
-		maintenance.setValidation("expired");
+		maintenance.setValidation(Validation.EXPIRED);
 	}
 
 	// Library Category

--- a/src/arden/runtime/MaintenanceMetadata.java
+++ b/src/arden/runtime/MaintenanceMetadata.java
@@ -32,21 +32,20 @@ import java.util.Date;
 public class MaintenanceMetadata {
 	private String title;
 	private String mlmName;
-	private String ardenVersion;
+	private ArdenVersion ardenVersion;
 	private String version;
 	private String institution;
 	private String author;
 	private String specialist;
 	private Date date;
-	private String validation;
+	private Validation validation;
 	
 	public MaintenanceMetadata() {
 		
 	}
 	
-	public MaintenanceMetadata(String title, String mlmName, String ardenVersion, String version, String institution,
-			String author, String specialist, Date date, String validation) {
-		super();
+	public MaintenanceMetadata(String title, String mlmName, ArdenVersion ardenVersion, String version, String institution,
+			String author, String specialist, Date date, Validation validation) {
 		this.title = title;
 		this.mlmName = mlmName;
 		this.ardenVersion = ardenVersion;
@@ -74,11 +73,11 @@ public class MaintenanceMetadata {
 		return mlmName;
 	}
 
-	public void setArdenVersion(String ardenVersion) {
+	public void setArdenVersion(ArdenVersion ardenVersion) {
 		this.ardenVersion = ardenVersion;
 	}
 
-	public String getArdenVersion() {
+	public ArdenVersion getArdenVersion() {
 		return ardenVersion;
 	}
 
@@ -122,11 +121,52 @@ public class MaintenanceMetadata {
 		return date;
 	}
 
-	public void setValidation(String validation) {
+	public void setValidation(Validation validation) {
 		this.validation = validation;
 	}
 
-	public String getValidation() {
+	public Validation getValidation() {
 		return validation;
 	}
+
+	public enum Validation {
+		EXPIRED,
+		TESTING,
+		RESEARCH,
+		PRODUCTION
+	}
+
+	public enum ArdenVersion implements Comparable<ArdenVersion> {
+		V1(1, 0), // ASTM E1460-1992
+		V2(2, 0),
+		V2_1(2, 1),
+		V2_5(2, 5);
+		// not supported yet:
+		// V2_6(2, 6),
+		// V2_7(2, 7),
+		// V2_8(2, 8),
+		// V2_9(2, 9),
+		// V2_10(2, 10);
+
+		public final int major;
+		public final int minor;
+
+		private ArdenVersion(int major, int minor) {
+			this.major = major;
+			this.minor = minor;
+		}
+
+		@Override
+		public String toString() {
+			// e.g. "Version 2.5"
+			StringBuilder versionBuilder = new StringBuilder("Version ");
+			versionBuilder.append(major);
+			if (minor != 0) {
+				versionBuilder.append('.');
+				versionBuilder.append(minor);
+			}
+			return versionBuilder.toString();
+		}
+	}
+
 }

--- a/test/arden/tests/implementation/LoadMlmFromBytecodeTest.java
+++ b/test/arden/tests/implementation/LoadMlmFromBytecodeTest.java
@@ -16,6 +16,8 @@ import arden.runtime.ArdenValue;
 import arden.runtime.DatabaseQuery;
 import arden.runtime.LibraryMetadata;
 import arden.runtime.MaintenanceMetadata;
+import arden.runtime.MaintenanceMetadata.ArdenVersion;
+import arden.runtime.MaintenanceMetadata.Validation;
 import arden.runtime.MedicalLogicModule;
 import arden.runtime.MemoryQuery;
 import arden.runtime.RuntimeHelpers;
@@ -172,12 +174,12 @@ public class LoadMlmFromBytecodeTest extends ImplementationTest {
 		MaintenanceMetadata m = compiledMlm.getMaintenance();
 		Assert.assertEquals("Fractional excretion of sodium", m.getTitle());
 		Assert.assertEquals("fractional_na", m.getMlmName());
-		Assert.assertEquals("2", m.getArdenVersion());
+		Assert.assertEquals(ArdenVersion.V2, m.getArdenVersion());
 		Assert.assertEquals("1.00", m.getVersion());
 		Assert.assertEquals("Columbia-Presbyterian Medical Center", m.getInstitution());
 		Assert.assertEquals("George Hripcsak, M.D.(hripcsak@cucis.cis.columbia.edu)", m.getAuthor());
 		Assert.assertNull(m.getSpecialist());
-		Assert.assertEquals("testing", m.getValidation());
+		Assert.assertEquals(Validation.TESTING, m.getValidation());
 
 		LibraryMetadata l = compiledMlm.getLibrary();
 		Assert.assertEquals(3, l.getKeywords().size());
@@ -197,12 +199,12 @@ public class LoadMlmFromBytecodeTest extends ImplementationTest {
 		MaintenanceMetadata m = compiledMlm.getMaintenance();
 		Assert.assertEquals("Check for penicillin allergy", m.getTitle());
 		Assert.assertEquals("pen_allergy", m.getMlmName());
-		Assert.assertEquals("1", m.getArdenVersion());
+		Assert.assertEquals(ArdenVersion.V1, m.getArdenVersion());
 		Assert.assertEquals("1.00", m.getVersion());
 		Assert.assertEquals("Columbia-Presbyterian Medical Center", m.getInstitution());
 		Assert.assertEquals("George Hripcsak, M.D.", m.getAuthor());
 		Assert.assertNull(m.getSpecialist());
-		Assert.assertEquals("testing", m.getValidation());
+		Assert.assertEquals(Validation.TESTING, m.getValidation());
 
 		LibraryMetadata l = compiledMlm.getLibrary();
 		Assert.assertEquals(2, l.getKeywords().size());

--- a/test/arden/tests/implementation/MetadataTest.java
+++ b/test/arden/tests/implementation/MetadataTest.java
@@ -33,6 +33,8 @@ import org.junit.Test;
 import arden.runtime.ExecutionContext;
 import arden.runtime.LibraryMetadata;
 import arden.runtime.MaintenanceMetadata;
+import arden.runtime.MaintenanceMetadata.ArdenVersion;
+import arden.runtime.MaintenanceMetadata.Validation;
 import arden.runtime.MedicalLogicModule;
 import arden.runtime.MedicalLogicModuleImplementation;
 
@@ -44,12 +46,12 @@ public class MetadataTest extends ImplementationTest {
 		MaintenanceMetadata m = mlm.getMaintenance();
 		Assert.assertEquals("Fractional excretion of sodium", m.getTitle());
 		Assert.assertEquals("fractional_na", mlm.getName());
-		Assert.assertEquals("2", m.getArdenVersion());
+		Assert.assertEquals(ArdenVersion.V2, m.getArdenVersion());
 		Assert.assertEquals("1.00", m.getVersion());
 		Assert.assertEquals("Columbia-Presbyterian Medical Center", m.getInstitution());
 		Assert.assertEquals("George Hripcsak, M.D.(hripcsak@cucis.cis.columbia.edu)", m.getAuthor());
 		Assert.assertNull(m.getSpecialist());
-		Assert.assertEquals("testing", m.getValidation());
+		Assert.assertEquals(Validation.TESTING, m.getValidation());
 
 		Assert.assertEquals(3, mlm.getLibrary().getKeywords().size());
 		Assert.assertEquals("fractional excretion", mlm.getLibrary().getKeywords().get(0));
@@ -66,12 +68,12 @@ public class MetadataTest extends ImplementationTest {
 		MaintenanceMetadata m = mlm.getMaintenance();
 		Assert.assertEquals("Check for penicillin allergy", m.getTitle());
 		Assert.assertEquals("pen_allergy", mlm.getName());
-		Assert.assertEquals("1", m.getArdenVersion());
+		Assert.assertEquals(ArdenVersion.V1, m.getArdenVersion());
 		Assert.assertEquals("1.00", m.getVersion());
 		Assert.assertEquals("Columbia-Presbyterian Medical Center", m.getInstitution());
 		Assert.assertEquals("George Hripcsak, M.D.", m.getAuthor());
 		Assert.assertNull(m.getSpecialist());
-		Assert.assertEquals("testing", m.getValidation());
+		Assert.assertEquals(Validation.TESTING, m.getValidation());
 
 		Assert.assertEquals(2, mlm.getLibrary().getKeywords().size());
 		Assert.assertEquals("penicillin", mlm.getLibrary().getKeywords().get(0));
@@ -91,12 +93,12 @@ public class MetadataTest extends ImplementationTest {
 		MaintenanceMetadata m = impl.getMaintenanceMetadata();
 		Assert.assertEquals("Fractional excretion of sodium", m.getTitle());
 		Assert.assertEquals("fractional_na", m.getMlmName());
-		Assert.assertEquals("2", m.getArdenVersion());
+		Assert.assertEquals(ArdenVersion.V2, m.getArdenVersion());
 		Assert.assertEquals("1.00", m.getVersion());
 		Assert.assertEquals("Columbia-Presbyterian Medical Center", m.getInstitution());
 		Assert.assertEquals("George Hripcsak, M.D.(hripcsak@cucis.cis.columbia.edu)", m.getAuthor());
 		Assert.assertNull(m.getSpecialist());
-		Assert.assertEquals("testing", m.getValidation());
+		Assert.assertEquals(Validation.TESTING, m.getValidation());
 
 		LibraryMetadata l = impl.getLibraryMetadata();
 		Assert.assertEquals(3, l.getKeywords().size());
@@ -116,12 +118,12 @@ public class MetadataTest extends ImplementationTest {
 		MaintenanceMetadata m = impl.getMaintenanceMetadata();
 		Assert.assertEquals("Check for penicillin allergy", m.getTitle());
 		Assert.assertEquals("pen_allergy", m.getMlmName());
-		Assert.assertEquals("1", m.getArdenVersion());
+		Assert.assertEquals(ArdenVersion.V1, m.getArdenVersion());
 		Assert.assertEquals("1.00", m.getVersion());
 		Assert.assertEquals("Columbia-Presbyterian Medical Center", m.getInstitution());
 		Assert.assertEquals("George Hripcsak, M.D.", m.getAuthor());
 		Assert.assertNull(m.getSpecialist());
-		Assert.assertEquals("testing", m.getValidation());
+		Assert.assertEquals(Validation.TESTING, m.getValidation());
 
 		LibraryMetadata l = impl.getLibraryMetadata();
 		Assert.assertEquals(2, l.getKeywords().size());

--- a/test/arden/tests/specification/testcompiler/impl/TestContext.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestContext.java
@@ -16,6 +16,7 @@ import arden.runtime.ArdenString;
 import arden.runtime.ArdenValue;
 import arden.runtime.DatabaseQuery;
 import arden.runtime.ExecutionContext;
+import arden.runtime.MaintenanceMetadata.Validation;
 import arden.tests.specification.testcompiler.TestCompiler;
 
 /**
@@ -47,9 +48,6 @@ public class TestContext extends ExecutionContext {
 	private List<String> messages = new LinkedList<String>();
 	private List<CompiledMlm> mlms;
 	private String institutionSelf;
-	enum Validation {
-		EXPIRED, TESTING, RESEARCH, PRODUCTION
-	}
 	
 	public TestContext(List<CompiledMlm> mlms, String institutionSelf) {
 		this.mlms = mlms;
@@ -102,8 +100,8 @@ public class TestContext extends ExecutionContext {
 	}
 
 	private CompiledMlm findBetterValidation(CompiledMlm mlm1, CompiledMlm mlm2) {
-		Validation v1 = Validation.valueOf(mlm1.getMaintenance().getValidation().trim().toUpperCase());
-		Validation v2 = Validation.valueOf(mlm2.getMaintenance().getValidation().trim().toUpperCase());
+		Validation v1 = mlm1.getMaintenance().getValidation();
+		Validation v2 = mlm2.getMaintenance().getValidation();
 		return v1.compareTo(v2) > 0 ? mlm1 : mlm2;
 	}
 


### PR DESCRIPTION
This adds the possible values for the `validation:`  and `arden:` slot as enums, for easier comparison.