### PR TITLE
Implement MLM search algorithm

### DIFF
--- a/src/arden/compiler/Compiler.java
+++ b/src/arden/compiler/Compiler.java
@@ -152,7 +152,7 @@ public final class Compiler {
 		if (isDebuggingEnabled)
 			codeGen.enableDebugging(sourceFileName);
 		
-		compileData(codeGen, knowledge.getDataSlot());
+		compileData(codeGen, knowledge.getDataSlot(), metadata.maintenance.getInstitution());
 		compileLogic(codeGen, knowledge.getLogicSlot());
 		compileAction(codeGen, knowledge.getActionSlot());
 		compileEvoke(codeGen, knowledge.getEvokeSlot());
@@ -274,10 +274,10 @@ public final class Compiler {
 		context.writer.returnObjectFromFunction();
 	}
 	
-	private void compileData(CodeGenerator codeGen, PDataSlot dataSlot) {
+	private void compileData(CodeGenerator codeGen, PDataSlot dataSlot, String institutionSelf) {
 		int lineNumber = ((ADataSlot) dataSlot).getDataColon().getLine();
 		CompilerContext context = codeGen.createConstructor(lineNumber);
-		dataSlot.apply(new DataCompiler(context));
+		dataSlot.apply(new DataCompiler(context, institutionSelf));
 		context.writer.returnFromProcedure();
 	}
 

--- a/src/arden/compiler/DataCompiler.java
+++ b/src/arden/compiler/DataCompiler.java
@@ -31,7 +31,51 @@ import java.util.ArrayList;
 import java.util.List;
 
 import arden.codegenerator.Label;
-import arden.compiler.node.*;
+import arden.compiler.node.AArgDataAssignPhrase;
+import arden.compiler.node.AAssDataStatement;
+import arden.compiler.node.ABlockDataBlock;
+import arden.compiler.node.ACphrDataAssignPhrase;
+import arden.compiler.node.ADasmapDataAssignPhrase;
+import arden.compiler.node.ADataIfThenElse2;
+import arden.compiler.node.ADataSlot;
+import arden.compiler.node.ADmapDataAssignPhrase;
+import arden.compiler.node.AElseDataElseif;
+import arden.compiler.node.AElseifDataElseif;
+import arden.compiler.node.AEmapDataAssignPhrase;
+import arden.compiler.node.AEmptyDataStatement;
+import arden.compiler.node.AEndDataElseif;
+import arden.compiler.node.AExprDataAssignPhrase;
+import arden.compiler.node.AForDataStatement;
+import arden.compiler.node.AFuncDataBlock;
+import arden.compiler.node.AIdCallPhrase;
+import arden.compiler.node.AIdexCallPhrase;
+import arden.compiler.node.AIfDataStatement;
+import arden.compiler.node.AImapDataAssignPhrase;
+import arden.compiler.node.AIphrDataAssignment;
+import arden.compiler.node.ALaargDataAssignment;
+import arden.compiler.node.ALlbargDataAssignment;
+import arden.compiler.node.ALlphrDataAssignment;
+import arden.compiler.node.ALphrDataAssignment;
+import arden.compiler.node.AMasmapDataAssignPhrase;
+import arden.compiler.node.AMlmDataAssignPhrase;
+import arden.compiler.node.AMlmiDataAssignPhrase;
+import arden.compiler.node.AMlmsDataAssignPhrase;
+import arden.compiler.node.AMmapDataAssignPhrase;
+import arden.compiler.node.ANewobjDataAssignPhrase;
+import arden.compiler.node.ANullExprFactorAtom;
+import arden.compiler.node.AObjectDataAssignPhrase;
+import arden.compiler.node.AReadDataAssignPhrase;
+import arden.compiler.node.AReadasDataAssignPhrase;
+import arden.compiler.node.ATexprDataAssignment;
+import arden.compiler.node.AWhileDataStatement;
+import arden.compiler.node.PCallPhrase;
+import arden.compiler.node.PExpr;
+import arden.compiler.node.PReadPhrase;
+import arden.compiler.node.Switch;
+import arden.compiler.node.Switchable;
+import arden.compiler.node.TIdentifier;
+import arden.compiler.node.TStringLiteral;
+import arden.compiler.node.TTerm;
 import arden.runtime.ArdenValue;
 import arden.runtime.DatabaseQuery;
 import arden.runtime.ObjectType;
@@ -46,9 +90,15 @@ import arden.runtime.ObjectType;
  */
 final class DataCompiler extends VisitorBase {
 	private final CompilerContext context;
+	private final String institutionSelf;
 
-	public DataCompiler(CompilerContext context) {
+	public DataCompiler(CompilerContext context, String institutionSelf) {
 		this.context = context;
+		this.institutionSelf = institutionSelf;
+	}
+	
+	public DataCompiler(CompilerContext context) {
+		this(context, null);
 	}
 
 	// data_slot = data data_block semicolons;
@@ -350,7 +400,7 @@ final class DataCompiler extends VisitorBase {
 			if (institution != null) {
 				context.writer.loadStringConstant(ParseHelpers.getLiteralStringValue(institution));
 			} else {
-				context.writer.loadNull();
+				context.writer.loadStringConstant(institutionSelf);
 			}
 			context.writer.invokeInstance(ExecutionContextMethods.findModule);
 		}

--- a/src/arden/runtime/BaseExecutionContext.java
+++ b/src/arden/runtime/BaseExecutionContext.java
@@ -9,11 +9,11 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import arden.CommandLineOptions;
 import arden.EvokeEngine;
@@ -21,6 +21,7 @@ import arden.MainClass;
 import arden.compiler.CompiledMlm;
 import arden.compiler.Compiler;
 import arden.compiler.CompilerException;
+import arden.runtime.MaintenanceMetadata.Validation;
 import arden.runtime.evoke.Trigger;
 
 /**
@@ -36,7 +37,7 @@ import arden.runtime.evoke.Trigger;
  */
 public class BaseExecutionContext extends ExecutionContext {
 	private List<URL> mlmSearchPath = new LinkedList<URL>();
-	private Map<String, ArdenRunnable> moduleList = new HashMap<String, ArdenRunnable>();
+	private Map<URL, MedicalLogicModule> initializedMlms = new HashMap<URL, MedicalLogicModule>();
 	private EvokeEngine engine;
 
 	public BaseExecutionContext(URL[] mlmSearchPath) {
@@ -76,34 +77,42 @@ public class BaseExecutionContext extends ExecutionContext {
 			throw new RuntimeException("Malformed module name: " + name);
 		}
 
-		ArdenRunnable fromlist = moduleList.get(name.toLowerCase());
-		if (fromlist != null) {
-			return fromlist;
-		}
-
+		name = name.toLowerCase().trim();
 		URLClassLoader loader = new URLClassLoader(mlmSearchPath.toArray(new URL[] {}));
-		InputStream in = loader.getResourceAsStream(name + ".class");
-		if (in != null) {
-			try {
-				ArdenRunnable module = new CompiledMlm(in, name);
-				moduleList.put(name.toLowerCase(), module);
-				return module;
-			} catch (IOException e) {
-				throw new RuntimeException(e);
-			} finally {
-				try {
-					loader.close();
-				} catch (IOException e) {
-					throw new RuntimeException(e);
+
+		try {
+			// look for matching .class files
+			Enumeration<URL> mlmClassUrls = loader.getResources(name + ".class");
+			while (mlmClassUrls.hasMoreElements()) {
+				URL url = mlmClassUrls.nextElement();
+				if (initializedMlms.containsKey(url)) {
+					// already loaded
+					continue;
+				}
+
+				InputStream in = url.openStream();
+				if (in != null) {
+					MedicalLogicModule module = new CompiledMlm(in, name);
+					cacheModule(url, module);
 				}
 			}
 
-		}
-		in = loader.getResourceAsStream(name + MainClass.MLM_FILE_EXTENSION);
-		Compiler compiler = new Compiler();
-		MedicalLogicModule mlm;
-		try {
-			mlm = compiler.compile(new InputStreamReader(in, "UTF-8")).get(0);
+			// look for matching .mlm files
+			Enumeration<URL> mlmUrls = loader.getResources(name + MainClass.MLM_FILE_EXTENSION);
+			while (mlmUrls.hasMoreElements()) {
+				URL url = mlmUrls.nextElement();
+				if (initializedMlms.containsKey(url)) {
+					// already loaded
+					continue;
+				}
+
+				InputStream in = url.openStream();
+
+				Compiler compiler = new Compiler();
+				MedicalLogicModule mlm;
+				mlm = compiler.compile(new InputStreamReader(in, "UTF-8")).get(0);
+				cacheModule(url, mlm);
+			}
 		} catch (CompilerException | IOException e) {
 			throw new RuntimeException(e);
 		} finally {
@@ -113,8 +122,36 @@ public class BaseExecutionContext extends ExecutionContext {
 				throw new RuntimeException(e);
 			}
 		}
-		moduleList.put(name.toLowerCase(), mlm);
-		return mlm;
+
+		MedicalLogicModule[] mlms = initializedMlms.values().toArray(new MedicalLogicModule[initializedMlms.size()]);
+		MedicalLogicModule foundMlm = ExecutionContextHelpers.findModule(name, institution, mlms, null);
+		if (foundMlm == null) {
+			throw new RuntimeException("MLM not found");
+		}
+		return foundMlm;
+	}
+
+	private void cacheModule(URL url, MedicalLogicModule mlm) {
+		// reuse already initialized MLM (e.g. already loaded from .class file
+		// instead of .mlm file)
+		for (MedicalLogicModule initializedMlm : initializedMlms.values()) {
+			MaintenanceMetadata m1 = initializedMlm.getMaintenance();
+			String m1Name = m1.getMlmName().toLowerCase().trim();
+			String m1Institution = m1.getInstitution().toLowerCase().trim();
+			Validation m1Validation = m1.getValidation();
+			String m1Version = m1.getVersion();
+			MaintenanceMetadata m2 = mlm.getMaintenance();
+			String m2Name = m2.getMlmName().toLowerCase().trim();
+			String m2Institution = m2.getInstitution().toLowerCase().trim();
+			Validation m2Validation = m2.getValidation();
+			String m2Version = m2.getVersion();
+			if (m1Name.equals(m2Name) && m1Institution.equals(m2Institution) && m1Validation == m2Validation
+					&& m1Version.equals(m2Version)) {
+				initializedMlms.put(url, initializedMlm);
+				return;
+			}
+		}
+		initializedMlms.put(url, mlm);
 	}
 
 	public void setEngine(EvokeEngine engine) {
@@ -161,24 +198,18 @@ public class BaseExecutionContext extends ExecutionContext {
 		} else {
 			// run MLMs for event now
 			System.out.println("event: " + event.name);
-			for (Entry<String, ArdenRunnable> entry : moduleList.entrySet()) {
-				ArdenRunnable runnable = entry.getValue();
-				if (runnable instanceof MedicalLogicModule) {
-					MedicalLogicModule mlm = (MedicalLogicModule) runnable;
-
-					try {
-						Trigger trigger = mlm.getTrigger(this, null);
-						if (trigger.runOnEvent(event)) {
-							super.eventTime = eventTime;
-							mlm.run(this, null);
-						}
-					} catch (InvocationTargetException e) {
-						System.err.println("Could not run MLM:");
-						e.printStackTrace();
+			// FIXME also runs MLM on classpath, not only the selected MLMs
+			for (MedicalLogicModule mlm : initializedMlms.values()) {
+				try {
+					Trigger trigger = mlm.getTrigger(this, null);
+					if (trigger.runOnEvent(event)) {
+						super.eventTime = eventTime;
+						mlm.run(this, null);
 					}
-
+				} catch (InvocationTargetException e) {
+					System.err.println("Could not run MLM:");
+					e.printStackTrace();
 				}
-
 			}
 		}
 	}

--- a/src/arden/runtime/ExecutionContextHelpers.java
+++ b/src/arden/runtime/ExecutionContextHelpers.java
@@ -1,0 +1,77 @@
+package arden.runtime;
+
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.Queue;
+
+import arden.runtime.MaintenanceMetadata.Validation;
+
+public class ExecutionContextHelpers {
+
+	/**
+	 * The algorithm for the MLM statement.
+	 * 
+	 * @param name
+	 *            Name of the MLM to find.
+	 * @param institution
+	 *            Institution of the MLM to find. May be <code>null</code> to
+	 *            signify that no institution is specified.
+	 * @param institutionSelf
+	 *            The calling MLMs institution. Only used if institution is
+	 *            <code>null</code>.
+	 * @param mlms
+	 *            All MLMs which should be search for a match.
+	 * @param versionComparator
+	 *            A {@link Comparator} to compare versions in the MLMs
+	 *            "version:" slot. May be <code>null</code>.
+	 * @return The best matching MLM or <code>null</code> if none is found.
+	 */
+	public static MedicalLogicModule findModule(String name, String institution, MedicalLogicModule[] mlms,
+			final Comparator<String> versionComparator) {
+		if (!name.matches("[a-zA-Z0-9\\-_]+")) {
+			throw new IllegalArgumentException("Malformed module name: " + name);
+		}
+
+		institution = institution.toLowerCase().trim();
+
+		name = name.toLowerCase().trim();
+
+		// sort results by validation and version
+		Comparator<MedicalLogicModule> mlmComparator = new Comparator<MedicalLogicModule>() {
+			@Override
+			public int compare(MedicalLogicModule mlm1, MedicalLogicModule mlm2) {
+				Validation validation1 = mlm1.getMaintenance().getValidation();
+				Validation validation2 = mlm2.getMaintenance().getValidation();
+				// highest validation first
+				int result = validation2.compareTo(validation1);
+				if (result != 0) {
+					return result;
+				} else if (versionComparator != null) {
+					String version1 = mlm1.getMaintenance().getVersion().trim();
+					String version2 = mlm2.getMaintenance().getVersion().trim();
+					// highest version first
+					return versionComparator.compare(version2, version1);
+				} else {
+					return 0;
+				}
+			}
+		};
+		Queue<MedicalLogicModule> matches = new PriorityQueue<MedicalLogicModule>(11, mlmComparator);
+
+		// find mlms with matching institution name
+		for (MedicalLogicModule mlm : mlms) {
+			MaintenanceMetadata maintenance = mlm.getMaintenance();
+			String curMlmname = maintenance.getMlmName().toLowerCase().trim();
+			String curInstitution = maintenance.getInstitution().toLowerCase().trim();
+			if (curInstitution.equals(institution) && curMlmname.equals(name)) {
+				matches.add(mlm);
+			}
+		}
+
+		if (!matches.isEmpty()) {
+			return matches.peek();
+		}
+		return null;
+	}
+
+}

--- a/test/arden/tests/specification/testcompiler/impl/TestCompilerImpl.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestCompilerImpl.java
@@ -7,10 +7,10 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
 
-import arden.compiler.CompiledMlm;
 import arden.compiler.CompilerException;
 import arden.runtime.ArdenEvent;
 import arden.runtime.ArdenValue;
+import arden.runtime.MedicalLogicModule;
 import arden.tests.specification.testcompiler.ArdenVersion;
 import arden.tests.specification.testcompiler.TestCompiler;
 import arden.tests.specification.testcompiler.TestCompilerCompiletimeException;
@@ -60,9 +60,9 @@ public class TestCompilerImpl implements TestCompiler {
 	@Override
 	public TestCompilerResult compileAndRun(String code) throws TestCompilerException {
 		// compile
-		List<CompiledMlm> compiledMlms;
+		List<MedicalLogicModule> compiledMlms = new ArrayList<>();
 		try {
-			compiledMlms = compiler.compile(new StringReader(code));
+			compiledMlms.addAll(compiler.compile(new StringReader(code)));
 		} catch (CompilerException e) {
 			throw new TestCompilerCompiletimeException(e);
 		} catch (IOException e) {
@@ -70,8 +70,8 @@ public class TestCompilerImpl implements TestCompiler {
 		}
 
 		// run and save return values
-		CompiledMlm firstMlm = compiledMlms.get(0);
-		TestContext context = new TestContext(compiledMlms, firstMlm.getMaintenance().getInstitution());
+		MedicalLogicModule firstMlm = compiledMlms.get(0);
+		TestContext context = new TestContext(compiledMlms);
 		TestCompilerResult result = new TestCompilerResult();
 
 		ArdenValue[] returnValues;
@@ -97,9 +97,9 @@ public class TestCompilerImpl implements TestCompiler {
 	public TestCompilerDelayedMessage[] compileAndRunForEvent(String code, String eventMapping, int messagesToCollect)
 			throws TestCompilerException {
 		// compile
-		List<CompiledMlm> compiledMlms = new ArrayList<>();
+		List<MedicalLogicModule> compiledMlms = new ArrayList<>();
 		try {
-			compiledMlms = compiler.compile(new StringReader(code));
+			compiledMlms.addAll(compiler.compile(new StringReader(code)));
 		} catch (CompilerException e) {
 			throw new TestCompilerCompiletimeException(e);
 		} catch (IOException e) {
@@ -112,8 +112,8 @@ public class TestCompilerImpl implements TestCompiler {
 		ArdenEvent event = new ArdenEvent(eventMapping, calendar.getTimeInMillis());
 
 		// collect messages
-		CompiledMlm firstMlm = compiledMlms.get(0);
-		TestEngine engine = new TestEngine(compiledMlms, firstMlm.getMaintenance().getInstitution());
+		MedicalLogicModule firstMlm = compiledMlms.get(0);
+		TestEngine engine = new TestEngine(compiledMlms, firstMlm);
 		List<TestCompilerDelayedMessage> messages = new ArrayList<>();
 		try {
 			engine.callEvent(event);

--- a/test/arden/tests/specification/testcompiler/impl/TestEngine.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestEngine.java
@@ -10,7 +10,6 @@ import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.TreeMap;
 
-import arden.compiler.CompiledMlm;
 import arden.runtime.ArdenDuration;
 import arden.runtime.ArdenEvent;
 import arden.runtime.ArdenRunnable;
@@ -20,6 +19,7 @@ import arden.runtime.ArdenValue;
 import arden.runtime.ExecutionContext;
 import arden.runtime.MedicalLogicModule;
 import arden.runtime.evoke.Trigger;
+import arden.tests.specification.testcompiler.TestCompiler;
 import arden.tests.specification.testcompiler.TestCompilerDelayedMessage;
 
 /**
@@ -42,8 +42,8 @@ public class TestEngine extends TestContext {
 	private ArdenTime startTime;
 	private ArdenTime currentTime;
 
-	public TestEngine(List<CompiledMlm> mlms, String institutionSelf) {
-		super(mlms, institutionSelf);
+	public TestEngine(List<MedicalLogicModule> mlms, MedicalLogicModule callingMlm) {
+		super(mlms);
 		this.mlms.addAll(mlms);
 	}
 


### PR DESCRIPTION
This adds the MLM search algorithm as a static method in a execution context helper class. Also the institution given to the context's `findModule()` method is now never `null` as it is the calling MLM's institution if not specified.

The BaseExecution context now searches for all MLMs with a matching filename, initializes them and then uses the algorithm, which also looks at the institution, version, etc. Previously only the filename was used to find MLMs. This answers my question (#39) about not initializing every MLM on the classpath and still finding the correct one. 