### PR TITLE
Support MESSAGE/DESTINATION AS

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,14 @@ To run the test suites you can use Eclipse or Ant:
 
 
 ## Standard Conformance
-Daniel:  
-I believe this compiler fully implements Arden Syntax 2.5 with the following exceptions:
+This compiler implements Arden Syntax 2.5 with the following exceptions:
 
 Languages features not implemented:
 
-* From Arden Syntax 2.5 specification:
-    * 11.2.5.2 Message As statement
-    * 11.2.5.6 Destination As statement
-    * 11.2.15 Include Statement
-    * Some string formatting specificiers are not implemented.
-    * Citation/links slots are not syntax checked.
-    * The compiler does not check that no languages features newer than the specified 'Arden Version' are used.
+* Include Statement
+* Some string formatting specificiers are not implemented.
+* Citation/links slots are not syntax checked.
+* The compiler does not check that no languages features newer than the specified 'Arden Version' are used.
 
 
 ## Copyright and license

--- a/src/arden/compiler/DataCompiler.java
+++ b/src/arden/compiler/DataCompiler.java
@@ -289,22 +289,31 @@ final class DataCompiler extends VisitorBase {
 			@Override
 			public void caseAMmapDataAssignPhrase(AMmapDataAssignPhrase node) {
 				// {mmap} message mapping_factor
-				final String mappingString = ParseHelpers.getStringForMapping(node.getMappingFactor());
-				lhs.assign(context, new Switchable() {
-					@Override
-					public void apply(Switch sw) {
-						context.writer.loadVariable(context.executionContextVariable);
-						context.writer.loadStringConstant(mappingString);
-						context.writer.invokeInstance(ExecutionContextMethods.getMessage);
-					}
-				});
+				MessageVariable v = MessageVariable.getMessageVariable(context.codeGenerator, lhs);
+				context.writer.loadThis();
+				context.writer.loadVariable(context.executionContextVariable);
+				String mappingString = ParseHelpers.getStringForMapping(node.getMappingFactor());
+				context.writer.loadStringConstant(mappingString);
+				context.writer.invokeInstance(ExecutionContextMethods.getMessage);
+				context.writer.storeInstanceField(v.field);
 			}
 
 			@Override
 			public void caseAMasmapDataAssignPhrase(AMasmapDataAssignPhrase node) {
 				// {masmap} message as identifier mapping_factor?
-				// TODO Auto-generated method stub
-				super.caseAMasmapDataAssignPhrase(node);
+				MessageVariable v = MessageVariable.getMessageVariable(context.codeGenerator, lhs);
+				context.writer.loadThis();
+				context.writer.loadVariable(context.executionContextVariable);
+				String mappingString = ParseHelpers.getStringForMapping(node.getMappingFactor());
+				context.writer.loadStringConstant(mappingString);
+
+				Variable typeVariable = context.codeGenerator.getVariableOrShowError(node.getIdentifier());
+				if (!(typeVariable instanceof ObjectTypeVariable))
+					throw new RuntimeCompilerException(lhs.getPosition(), "The variable must contain an object declaration");
+				context.writer.loadStaticField(((ObjectTypeVariable) typeVariable).field);
+				
+				context.writer.invokeInstance(ExecutionContextMethods.getMessageAs);
+				context.writer.storeInstanceField(v.field);
 			}
 
 			@Override
@@ -312,15 +321,29 @@ final class DataCompiler extends VisitorBase {
 				// {dmap} destination mapping_factor
 				DestinationVariable v = DestinationVariable.getDestinationVariable(context.codeGenerator, lhs);
 				context.writer.loadThis();
-				context.writer.loadStringConstant(ParseHelpers.getStringForMapping(node.getMappingFactor()));
+				context.writer.loadVariable(context.executionContextVariable);
+				String mappingString = ParseHelpers.getStringForMapping(node.getMappingFactor());
+				context.writer.loadStringConstant(mappingString);
+				context.writer.invokeInstance(ExecutionContextMethods.getDestination);
 				context.writer.storeInstanceField(v.field);
 			}
 
 			@Override
 			public void caseADasmapDataAssignPhrase(ADasmapDataAssignPhrase node) {
 				// {dasmap} destination as identifier mapping_factor?
-				// TODO Auto-generated method stub
-				super.caseADasmapDataAssignPhrase(node);
+				DestinationVariable v = DestinationVariable.getDestinationVariable(context.codeGenerator, lhs);
+				context.writer.loadThis();
+				context.writer.loadVariable(context.executionContextVariable);
+				String mappingString = ParseHelpers.getStringForMapping(node.getMappingFactor());
+				context.writer.loadStringConstant(mappingString);
+
+				Variable typeVariable = context.codeGenerator.getVariableOrShowError(node.getIdentifier());
+				if (!(typeVariable instanceof ObjectTypeVariable))
+					throw new RuntimeCompilerException(lhs.getPosition(), "The variable must contain an object declaration");
+				context.writer.loadStaticField(((ObjectTypeVariable) typeVariable).field);
+				
+				context.writer.invokeInstance(ExecutionContextMethods.getDestinationAs);
+				context.writer.storeInstanceField(v.field);
 			}
 
 			@Override

--- a/src/arden/compiler/DataCompiler.java
+++ b/src/arden/compiler/DataCompiler.java
@@ -227,7 +227,7 @@ final class DataCompiler extends VisitorBase {
 				// {readas} read as identifier read_phrase
 				final Variable v = context.codeGenerator.getVariableOrShowError(node.getIdentifier());
 				if (!(v instanceof ObjectTypeVariable))
-					throw new RuntimeCompilerException(lhs.getPosition(), "EVENT variables must be simple identifiers");
+					throw new RuntimeCompilerException(lhs.getPosition(), "The variable must contain an object declaration");
 				lhs.assign(context, new Switchable() {
 					@Override
 					public void apply(Switch sw) {

--- a/src/arden/compiler/ExecutionContextMethods.java
+++ b/src/arden/compiler/ExecutionContextMethods.java
@@ -33,29 +33,36 @@ import arden.runtime.ArdenEvent;
 import arden.runtime.ArdenRunnable;
 import arden.runtime.ArdenValue;
 import arden.runtime.ExecutionContext;
+import arden.runtime.ObjectType;
 
 /** Contains references to the methods from the ExecutionContext class */
 final class ExecutionContextMethods {
 	public static final Method createQuery;
-	public static final Method write, getMessage;
+	public static final Method getMessage, getMessageAs, getDestination, getDestinationAs, getEvent;
 	public static final Method findModule, findModules, findInterface;
-	public static final Method callWithDelay, callEventWithDelay;
+	public static final Method write, callWithDelay, callEventWithDelay;
 	public static final Method getEventTime, getTriggerTime, getCurrentTime;
-	public static final Method getEvent;
 
 	static {
 		try {
 			createQuery = ExecutionContext.class.getMethod("createQuery", String.class);
-			write = ExecutionContext.class.getMethod("write", ArdenValue.class, String.class);
+
 			getMessage = ExecutionContext.class.getMethod("getMessage", String.class);
+			getMessageAs = ExecutionContext.class.getMethod("getMessageAs", String.class, ObjectType.class);
+			getDestination = ExecutionContext.class.getMethod("getDestination", String.class);
+			getDestinationAs = ExecutionContext.class.getMethod("getDestinationAs", String.class, ObjectType.class);
 			getEvent = ExecutionContext.class.getMethod("getEvent", String.class);
+
 			findModule = ExecutionContext.class.getMethod("findModule", String.class, String.class);
 			findModules = ExecutionContext.class.getMethod("findModules", ArdenEvent.class);
 			findInterface = ExecutionContext.class.getMethod("findInterface", String.class);
+
+			write = ExecutionContext.class.getMethod("write", ArdenValue.class, ArdenValue.class);
 			callWithDelay = ExecutionContext.class.getMethod("callWithDelay", ArdenRunnable.class, ArdenValue[].class,
 					ArdenValue.class);
 			callEventWithDelay = ExecutionContext.class.getMethod("callEventWithDelay", ArdenEvent.class,
 					ArdenValue.class);
+
 			getEventTime = ExecutionContext.class.getMethod("getEventTime");
 			getTriggerTime = ExecutionContext.class.getMethod("getTriggerTime");
 			getCurrentTime = ExecutionContext.class.getMethod("getCurrentTime");

--- a/src/arden/compiler/MessageVariable.java
+++ b/src/arden/compiler/MessageVariable.java
@@ -31,38 +31,44 @@ import java.lang.reflect.Modifier;
 
 import arden.codegenerator.FieldReference;
 import arden.compiler.node.TIdentifier;
+import arden.compiler.node.Token;
 import arden.runtime.ArdenValue;
 
 /**
  * An instance field of type {@link ArdenValue} is stored in the MLM
  * implementation class. It is set in the data block where the
- * <code>DESTINATION</code> or <code>DESTINATION AS</code> statement occurs and
- * used for <code>WRITE AT</code> statements.
+ * <code>MESSAGE</code> or <code>MESSAGE AS</code> statement occurs and used for
+ * <code>WRITE AT</code> statements.
  */
-final class DestinationVariable extends Variable {
+final class MessageVariable extends Variable {
 	final FieldReference field;
 
-	private DestinationVariable(TIdentifier name, FieldReference field) {
+	private MessageVariable(TIdentifier name, FieldReference field) {
 		super(name);
 		this.field = field;
 	}
 
 	/**
-	 * Gets the DestinationVariable for the LHSR, or creates it on demand.
+	 * Gets the MessageVariable for the LHSR, or creates it on demand.
 	 */
-	public static DestinationVariable getDestinationVariable(CodeGenerator codeGen, LeftHandSideResult lhs) {
+	public static MessageVariable getMessageVariable(CodeGenerator codeGen, LeftHandSideResult lhs) {
 		if (!(lhs instanceof LeftHandSideIdentifier))
-			throw new RuntimeCompilerException(lhs.getPosition(), "DESTINATION variables must be simple identifiers");
+			throw new RuntimeCompilerException(lhs.getPosition(), "MESSAGE variables must be simple identifiers");
 		TIdentifier ident = ((LeftHandSideIdentifier) lhs).identifier;
 		Variable variable = codeGen.getVariable(ident.getText());
-		if (variable instanceof DestinationVariable) {
-			return (DestinationVariable) variable;
+		if (variable instanceof MessageVariable) {
+			return (MessageVariable) variable;
 		} else {
 			FieldReference mlmField = codeGen.createField(ident.getText(), ArdenValue.class, Modifier.PRIVATE);
-			DestinationVariable dv = new DestinationVariable(ident, mlmField);
+			MessageVariable dv = new MessageVariable(ident, mlmField);
 			codeGen.addVariable(dv);
 			return dv;
 		}
 	}
 	
+	@Override
+	public void loadValue(CompilerContext context, Token errorPosition) {
+		context.writer.loadThis();
+		context.writer.loadInstanceField(field);
+	}
 }

--- a/src/arden/runtime/ExecutionContext.java
+++ b/src/arden/runtime/ExecutionContext.java
@@ -37,24 +37,36 @@ import java.util.Date;
  */
 public abstract class ExecutionContext {
 	/**
-	 * Creates a database query using a mapping clause. The DatabaseQuery object
-	 * can be used to limit the number of results produced.
+	 * Creates a database query using a mapping clause, as part of a
+	 * <code>READ</code> or <code>READ AS</code> statement. The
+	 * {@link DatabaseQuery} object can be used to limit the number of results
+	 * produced.
 	 * 
 	 * @param mapping
-	 *            The contents of the mapping clause (=text between { and }).
-	 *            The meaning is implementation-defined. The Arden language
-	 *            specification uses mapping clauses like
+	 *            The contents of the statement's mapping clause (text between
+	 *            curly braces). The meaning is implementation-defined. The
+	 *            Arden language specification uses mapping clauses like
 	 *            "medication_cancellation where class = gentamicin".
 	 * 
 	 * @return This method may not return Java null. Instead, it can return
-	 *         DatabaseQuery.NULL, a query that will always produce an empty
-	 *         result set.
+	 *         {@link DatabaseQuery#NULL}, a query that will always produce an
+	 *         empty result set.
 	 */
 	public DatabaseQuery createQuery(String mapping) {
 		return DatabaseQuery.NULL;
 	}
 
-	/** Gets a value represents the message of a MESSAGE variable. */
+	/**
+	 * Gets a value that represents a message, as part of a <code>MESSAGE</code>
+	 * statement.
+	 * 
+	 * @param mapping
+	 *            The contents of the statement's mapping clause.
+	 * 
+	 * @return A (possibly custom) subclass of {@link ArdenValue} that
+	 *         represents the message. This value may be given as a parameter in
+	 *         the {@link #write(ArdenValue, ArdenValue)} method.
+	 */
 	public ArdenValue getMessage(String mapping) {
 		return new ArdenString(mapping);
 	}
@@ -106,29 +118,47 @@ public abstract class ExecutionContext {
 		return new ArdenObject(type);
 	}
 
-	/** Gets an event defined with the EVENT{mapping} statement */
+	/**
+	 * Gets an event as part of the <code>EVENT</code> statement.
+	 * 
+	 * @param mapping
+	 *            The contents of the statement's mapping clause.
+	 * 
+	 * @return An {@link ArdenEvent}. If it is the event, that triggered the
+	 *         MLM, it should flagged as such with
+	 *         {@link ArdenEvent#setEvokingEvent(boolean)}.
+	 */
 	public ArdenEvent getEvent(String mapping) {
 		return new ArdenEvent(mapping);
 	}
 
 	/**
-	 * Called by write statements.
+	 * Called by the <code>WRITE</code> statement.
 	 * 
 	 * @param message
-	 *            The message to be written.
+	 *            The message to be written. This may be an instance returned
+	 *            from {@link #getMessage(String)} or
+	 *            {@link #getMessageAs(String, ObjectType)}, but other values
+	 *            are possible.
+	 * 
 	 * @param destination
-	 *            The mapping clause describing the message destination.
+	 *            The destination for the message. This will be an instance
+	 *            returned from {@link #getDestination(String)} or
+	 *            {@link #getDestinationAs(String, ObjectType)}. May be null, if
+	 *            the default destination should be used.
 	 */
 	public void write(ArdenValue message, ArdenValue destination) {
 	}
 
 	/**
-	 * Retrieves another MLM.
+	 * Retrieves another MLM as part of the <code>MLM</code> statement.
 	 * 
 	 * @param name
 	 *            The name of the requested MLM.
+	 * 
 	 * @param institution
 	 *            The institution of the requested MLM.
+	 * 
 	 * @return The requested MLM.
 	 */
 	public ArdenRunnable findModule(String name, String institution) {
@@ -136,38 +166,44 @@ public abstract class ExecutionContext {
 	}
 
 	/**
-	 * Retrieves all MLMs that are normally evoked by an event.
+	 * Retrieves all MLMs that are normally evoked by an event. This is used as
+	 * part of the event <code>CALL</code> statement in the logic slot.
 	 * 
 	 * @param event
 	 *            The event.
-	 * @param institution
-	 *            The institution of the requested MLM.
+	 * 
 	 * @return The requested MLMs.
 	 */
 	public ArdenRunnable[] findModules(ArdenEvent event) {
-		throw new RuntimeException("findModule not implemented");
+		throw new RuntimeException("findModules not implemented");
 	}
 
 	/**
-	 * Retrieves an interface implementation.
+	 * Retrieves an interface implementation, as part of the
+	 * <code>INTERFACE</code> statement.
 	 * 
 	 * @param mapping
-	 *            The mapping clause of the interface.
-	 * @return The interface implementation.
+	 *            The contents of the statement's mapping clause.
+	 * 
+	 * @return The interface implementation as an {@link ArdenRunnable}.
 	 */
 	public ArdenRunnable findInterface(String mapping) {
 		throw new RuntimeException("findInterface not implemented");
 	}
 
 	/**
-	 * Calls another MLM using a delay.
+	 * Calls another MLM using a delay. This method will be called for all MLM
+	 * calls in the action slot.
 	 * 
 	 * @param mlm
 	 *            The MLM that should be called. This will be an instance
-	 *            returned from findModule() or findInterface().
+	 *            returned from {@link #findModule(String, String)} or
+	 *            {@link #findInterface(String)}.
+	 *            
 	 * @param arguments
 	 *            The arguments being passed. Can be null if no arguments were
 	 *            specified.
+	 * 
 	 * @param delay
 	 *            The delay for calling the MLM (as ArdenDuration).
 	 */
@@ -176,10 +212,12 @@ public abstract class ExecutionContext {
 	}
 
 	/**
-	 * Calls an event using a delay.
+	 * Calls an event using a delay. This method will be called for all event
+	 * calls in the action slot.
 	 * 
 	 * @param event
 	 *            The event that should be called.
+	 * 
 	 * @param delay
 	 *            The delay for calling the event (as ArdenDuration).
 	 */
@@ -190,17 +228,23 @@ public abstract class ExecutionContext {
 	protected ArdenTime eventTime = new ArdenTime(new Date());
 	protected ArdenTime triggerTime = new ArdenTime(new Date());
 
-	/** Gets the eventtime. */
+	/**
+	 * @return The <code>EVENTTIME</code>.
+	 */
 	public ArdenTime getEventTime() {
 		return eventTime;
 	}
 
-	/** Gets the triggertime. */
+	/**
+	 * @return The <code>TRIGGERTIME</code>.
+	 */
 	public ArdenTime getTriggerTime() {
 		return triggerTime;
 	}
 
-	/** Gets the current time. */
+	/**
+	 * @return The <code>CURRENTTIME</code>.
+	 */
 	public ArdenTime getCurrentTime() {
 		return new ArdenTime(new Date());
 	}

--- a/src/arden/runtime/ExecutionContext.java
+++ b/src/arden/runtime/ExecutionContext.java
@@ -59,6 +59,53 @@ public abstract class ExecutionContext {
 		return new ArdenString(mapping);
 	}
 
+	/**
+	 * Gets an object that represents a message, as part of a
+	 * <code>MESSAGE AS</code> statement.
+	 * 
+	 * @param mapping
+	 *            The contents of the statement's mapping clause.
+	 * 
+	 * @param type
+	 *            The type that the returned object should have.
+	 * 
+	 * @return An {@link ArdenObject} of the given {@link ObjectType}.
+	 */
+	public ArdenObject getMessageAs(String mapping, ObjectType type) {
+		return new ArdenObject(type);
+	}
+
+	/**
+	 * Gets a value that represents a destination, as part of the
+	 * <code>DESTINATION</code> statement.
+	 * 
+	 * @param mapping
+	 *            The contents of the statement's mapping clause.
+	 * 
+	 * @return A (possibly custom) subclass of {@link ArdenValue} that
+	 *         represents the destination. This value is used as a parameter in
+	 *         the {@link #write(ArdenValue, ArdenValue)} method.
+	 */
+	public ArdenValue getDestination(String mapping) {
+		return new ArdenString(mapping);
+	}
+
+	/**
+	 * Gets an object that represents a destination, as part of a
+	 * <code>DESTINATION AS</code> statement.
+	 * 
+	 * @param mapping
+	 *            The contents of the statement's mapping clause.
+	 * 
+	 * @param type
+	 *            The type that the returned object should have.
+	 * 
+	 * @return An {@link ArdenObject} of the given {@link ObjectType}.
+	 */
+	public ArdenObject getDestinationAs(String mapping, ObjectType type) {
+		return new ArdenObject(type);
+	}
+
 	/** Gets an event defined with the EVENT{mapping} statement */
 	public ArdenEvent getEvent(String mapping) {
 		return new ArdenEvent(mapping);
@@ -72,7 +119,7 @@ public abstract class ExecutionContext {
 	 * @param destination
 	 *            The mapping clause describing the message destination.
 	 */
-	public void write(ArdenValue message, String destination) {
+	public void write(ArdenValue message, ArdenValue destination) {
 	}
 
 	/**

--- a/src/arden/runtime/StdIOExecutionContext.java
+++ b/src/arden/runtime/StdIOExecutionContext.java
@@ -14,12 +14,13 @@ public class StdIOExecutionContext extends BaseExecutionContext {
 	public StdIOExecutionContext(CommandLineOptions options) {
 		super(options);
 	}
-
+	
+	@Override
 	public DatabaseQuery createQuery(String mapping) {
-		System.out.println("Query mapping: \"" + mapping + "\". Enter result as "
-				+ "Arden Syntax constant (Strings in quotes)");
+		System.out.println(
+				"Query mapping: \"" + mapping + "\". Enter result as " + "Arden Syntax constant (Strings in quotes)");
 		System.out.print(PROMPT_SIGN);
-		
+
 		ArdenValue[] val = null;
 		while (val == null) {
 			if (sc.hasNextLine()) {
@@ -28,7 +29,7 @@ public class StdIOExecutionContext extends BaseExecutionContext {
 					System.out.print(PROMPT_SIGN);
 					continue; // retry
 				}
-				
+
 				try {
 					val = ConstantParser.parseMultiple(line);
 				} catch (ConstantParserException e) {
@@ -42,17 +43,46 @@ public class StdIOExecutionContext extends BaseExecutionContext {
 				val = new ArdenValue[] { ArdenNull.create(System.currentTimeMillis()) };
 			}
 		}
-		
+
 		return new MemoryQuery(val);
 	}
 
+	@Override
 	public ArdenValue getMessage(String mapping) {
 		System.out.println("Message, mapping: " + mapping);
 		return new ArdenString(mapping);
 	}
+	
+	@Override
+	public ArdenObject getMessageAs(String mapping, ObjectType type) {
+		System.out.println("Message, mapping: " + mapping + ", type: " + type.name);
+		ArdenObject object = new ArdenObject(type);
+		if(object.fields.length > 0) {
+			object.fields[0] = new ArdenString(mapping);
+		}
+		return object;
+	}
+	
+	@Override
+	public ArdenValue getDestination(String mapping) {
+		System.out.println("Destination, mapping: " + mapping);
+		return new ArdenString(mapping);
+	}
+	
+	@Override
+	public ArdenObject getDestinationAs(String mapping, ObjectType type) {
+		System.out.println("Destination, mapping: " + mapping + ", type: " + type.name);
+		ArdenObject object = new ArdenObject(type);
+		if(object.fields.length > 0) {
+			object.fields[0] = new ArdenString(mapping);
+		}
+		return object;
+	}
 
-	public void write(ArdenValue message, String destination) {
-		if ("stdout".equalsIgnoreCase(destination)) {
+	@Override
+	public void write(ArdenValue message, ArdenValue destination) {
+		String destString = ArdenString.getStringFromValue(destination);
+		if (destString != null  && "stdout".equalsIgnoreCase(destString)) {
 			// just print string
 			if (message instanceof ArdenString) {
 				System.out.println(ArdenString.getStringFromValue(message));
@@ -61,9 +91,9 @@ public class StdIOExecutionContext extends BaseExecutionContext {
 			}
 		} else {
 			// prepend destination to printed string
-			System.out.print("Destination: \"");
+			System.out.print("Destination: ");
 			System.out.print(destination);
-			System.out.print("\" Message: ");
+			System.out.print(" Message: ");
 			if (message instanceof ArdenString) {
 				System.out.println(ArdenString.getStringFromValue(message));
 			} else {

--- a/src/arden/runtime/jdbc/JDBCExecutionContext.java
+++ b/src/arden/runtime/jdbc/JDBCExecutionContext.java
@@ -82,19 +82,19 @@ public class JDBCExecutionContext extends StdIOExecutionContext {
 		}
 	}
 	
-	public void write(ArdenValue message, String destination) {
-		if ("database".equalsIgnoreCase(destination) || "query".equalsIgnoreCase(destination)) {
+	@Override
+	public void write(ArdenValue message, ArdenValue destination) {
+		String destString = ArdenString.getStringFromValue(destination);
+		if (destString != null && ("database".equalsIgnoreCase(destString) || "query".equalsIgnoreCase(destString))) {
 			String msgString = ArdenString.getStringFromValue(message);
-			
 			// execute query:
 			new JDBCQuery(msgString, connection).execute();
-		} else if ("email".equalsIgnoreCase(destination)) {
-			// TODO: implement email sending
 		} else {
 			super.write(message, destination);
 		}
 	}
 	
+	@Override
 	public DatabaseQuery createQuery(String mapping) {		
 		return new JDBCQuery(mapping, connection);
 	}	

--- a/test/arden/tests/implementation/TestContext.java
+++ b/test/arden/tests/implementation/TestContext.java
@@ -62,7 +62,7 @@ public class TestContext extends ExecutionContext {
 	}
 
 	@Override
-	public void write(ArdenValue message, String destination) {
+	public void write(ArdenValue message, ArdenValue destination) {
 		b.append(((ArdenString) message).value);
 		b.append("\n");
 	}

--- a/test/arden/tests/specification/testcompiler/impl/TestContext.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestContext.java
@@ -129,7 +129,7 @@ public class TestContext extends ExecutionContext {
 	}
 
 	@Override
-	public void write(ArdenValue message, String destination) {
+	public void write(ArdenValue message, ArdenValue destination) {
 		// save messages
 		String stringMessage = ((ArdenString) message).value;
 		messages.add(stringMessage);

--- a/test/arden/tests/specification/testcompiler/impl/TestEngine.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestEngine.java
@@ -85,7 +85,7 @@ public class TestEngine extends TestContext {
 	}
 
 	@Override
-	public void write(ArdenValue message, String destination) {
+	public void write(ArdenValue message, ArdenValue destination) {
 		// save messages
 		String stringMessage;
 		if (message instanceof ArdenString) {
@@ -130,6 +130,11 @@ public class TestEngine extends TestContext {
 		}
 
 		return messages.remove();
+	}
+	
+	@Override
+	public ArdenEvent getEvent(String mapping) {
+		return new ArdenEvent(mapping, getCurrentTime().value);
 	}
 
 	@Override


### PR DESCRIPTION
This adds support for the `MESSAGE AS object_type {mapping}` and `DESTINATION AS object_type {mapping}` statements.

Execution contexts simply need to implement the
```java
public ArdenObject getDestinationAs(String mapping, ObjectType type)
```
and 
```java
public ArdenObject getMessageAs(String mapping, ObjectType type)
```
methods.