### PR TITLE
Fix NullpointerException for no return values

### DIFF
--- a/src/arden/compiler/DataCompiler.java
+++ b/src/arden/compiler/DataCompiler.java
@@ -488,18 +488,22 @@ final class DataCompiler extends VisitorBase {
 		for (int i = 0; i < idents.size(); i++) {
 			final int identNumber = i;
 			// for each identifier, emit:
-			// var_i = (i < phraseResult.Length)
+			// var_i = (phraseResult != null && i < phraseResult.Length)
 			// ? phraseResult.Length[i] : ArdenNull.Instance;
 			idents.get(i).assign(context, new Switchable() {
 				@Override
 				public void apply(Switch sw) {
 					Label trueLabel = new Label();
+					Label falseLabel = new Label();
 					Label endLabel = new Label();
+					context.writer.loadVariable(phraseResultVar);
+					context.writer.jumpIfNull(falseLabel);
 					context.writer.loadIntegerConstant(identNumber);
 					context.writer.loadVariable(phraseResultVar);
 					context.writer.arrayLength();
 					context.writer.jumpIfLessThan(trueLabel);
 					// false part
+					context.writer.markForwardJumpsOnly(falseLabel);
 					new ANullExprFactorAtom().apply(sw);
 					context.writer.jump(endLabel);
 					// true part


### PR DESCRIPTION
When an MLM does not use the `RETURN` statement, `null` (java) is returned, instead of an array of ArdenValues.
A calling MLM that tries to use the return values, would check the array length of this `null` array, which leads to a Nullpointer Exception.