### PR TITLE
Use urgency for actions

### DIFF
--- a/src/arden/EventServer.java
+++ b/src/arden/EventServer.java
@@ -92,7 +92,7 @@ public class EventServer implements Runnable {
 					}
 					// send event to context
 					ArdenEvent event = new ArdenEvent(eventName, context.getCurrentTime().value);
-					context.callEventWithDelay(event, ArdenDuration.ZERO);
+					context.call(event, ArdenDuration.ZERO);
 				}
 				scanner.close();
 			} catch (IOException e) {

--- a/src/arden/EventServer.java
+++ b/src/arden/EventServer.java
@@ -92,7 +92,7 @@ public class EventServer implements Runnable {
 					}
 					// send event to context
 					ArdenEvent event = new ArdenEvent(eventName, context.getCurrentTime().value);
-					context.call(event, ArdenDuration.ZERO);
+					context.call(event, ArdenDuration.ZERO, 50);
 				}
 				scanner.close();
 			} catch (IOException e) {

--- a/src/arden/compiler/ActionCompiler.java
+++ b/src/arden/compiler/ActionCompiler.java
@@ -204,7 +204,7 @@ final class ActionCompiler extends VisitorBase {
 		context.writer.loadVariable(context.executionContextVariable);
 		node.getExpr().apply(new ExpressionCompiler(context));
 		context.writer.loadNull();
-		loadUrgency();
+		loadUrgency(context);
 		context.writer.invokeInstance(ExecutionContextMethods.write);
 	}
 
@@ -221,11 +221,11 @@ final class ActionCompiler extends VisitorBase {
 					+ "' is not a valid destination variable.");
 		context.writer.loadThis();
 		context.writer.loadInstanceField(((DestinationVariable) destination).field);
-		loadUrgency();
+		loadUrgency(context);
 		context.writer.invokeInstance(ExecutionContextMethods.write);
 	}
 
-	private void loadUrgency() {
+	static void loadUrgency(CompilerContext context) {
 		context.writer.loadThis();
 		Method getUrgency;
 		try {

--- a/src/arden/compiler/ActionCompiler.java
+++ b/src/arden/compiler/ActionCompiler.java
@@ -27,9 +27,12 @@
 
 package arden.compiler;
 
+import java.lang.reflect.Method;
+
 import arden.codegenerator.Label;
 import arden.compiler.node.*;
 import arden.runtime.ArdenValue;
+import arden.runtime.MedicalLogicModuleImplementation;
 
 /**
  * Compiler for actions.
@@ -201,6 +204,7 @@ final class ActionCompiler extends VisitorBase {
 		context.writer.loadVariable(context.executionContextVariable);
 		node.getExpr().apply(new ExpressionCompiler(context));
 		context.writer.loadNull();
+		loadUrgency();
 		context.writer.invokeInstance(ExecutionContextMethods.write);
 	}
 
@@ -217,7 +221,19 @@ final class ActionCompiler extends VisitorBase {
 					+ "' is not a valid destination variable.");
 		context.writer.loadThis();
 		context.writer.loadInstanceField(((DestinationVariable) destination).field);
+		loadUrgency();
 		context.writer.invokeInstance(ExecutionContextMethods.write);
+	}
+
+	private void loadUrgency() {
+		context.writer.loadThis();
+		Method getUrgency;
+		try {
+			getUrgency = MedicalLogicModuleImplementation.class.getDeclaredMethod("getUrgency");
+		} catch (NoSuchMethodException | SecurityException e) {
+			throw new RuntimeException(e);
+		}
+		context.writer.invokeInstance(getUrgency);
 	}
 
 	@Override

--- a/src/arden/compiler/CallableVariable.java
+++ b/src/arden/compiler/CallableVariable.java
@@ -27,8 +27,6 @@
 
 package arden.compiler;
 
-import java.lang.reflect.Modifier;
-
 import arden.codegenerator.FieldReference;
 import arden.compiler.node.PExpr;
 import arden.compiler.node.TIdentifier;
@@ -41,49 +39,33 @@ import arden.runtime.ExecutionContext;
 /**
  * MLM or INTERFACE Variables.
  * 
- * An instance field of type ArdenRunnable is stored in the MLM implementation
- * class. It is set in the data block where the 'x := MLM y' statement occurs
- * and used for CALL statements.
+ * An instance field of type MedicalLogicModule or ArdenRunnable is stored in
+ * the MLM implementation class. It is set in the data block where the 'x := MLM
+ * y' statement or 'x := INTERFACE y' statement occurs and used for CALL
+ * statements.
  */
-final class CallableVariable extends Variable {
+abstract class CallableVariable extends Variable {
 	// instance field of type ArdenRunnable
-	final FieldReference mlmField;
+	final FieldReference runnableField;
 
-	private CallableVariable(TIdentifier varName, FieldReference mlmField) {
+	protected CallableVariable(TIdentifier varName, FieldReference runnableField) {
 		super(varName);
-		this.mlmField = mlmField;
-	}
-
-	/** Gets the CallableVariable for the LHSR, or creates it on demand. */
-	public static CallableVariable getCallableVariable(CodeGenerator codeGen, LeftHandSideResult lhs) {
-		if (!(lhs instanceof LeftHandSideIdentifier))
-			throw new RuntimeCompilerException(lhs.getPosition(),
-					"MLM or INTERFACE variables must be simple identifiers");
-		TIdentifier ident = ((LeftHandSideIdentifier) lhs).identifier;
-		Variable variable = codeGen.getVariable(ident.getText());
-		if (variable instanceof CallableVariable) {
-			return (CallableVariable) variable;
-		} else {
-			FieldReference mlmField = codeGen.createField(ident.getText(), ArdenRunnable.class, Modifier.PRIVATE);
-			CallableVariable cv = new CallableVariable(ident, mlmField);
-			codeGen.addVariable(cv);
-			return cv;
-		}
+		this.runnableField = runnableField;
 	}
 
 	@Override
 	public void call(CompilerContext context, Token errorPosition, PExpr arguments) {
 		context.writer.sequencePoint(errorPosition.getLine());
 		context.writer.loadThis();
-		context.writer.loadInstanceField(mlmField);
+		context.writer.loadInstanceField(runnableField);
 		context.writer.loadVariable(context.executionContextVariable);
 		if (arguments != null) {
 			new ExpressionCompiler(context).buildArrayForCommaSeparatedExpression(arguments);
 		} else {
 			context.writer.loadNull();
 		}
-		context.writer.invokeStatic(Compiler.getRuntimeHelper("call", ArdenRunnable.class, ExecutionContext.class,
-				ArdenValue[].class));
+		context.writer.invokeStatic(
+				Compiler.getRuntimeHelper("call", ArdenRunnable.class, ExecutionContext.class, ArdenValue[].class));
 	}
 
 	@Override
@@ -91,7 +73,7 @@ final class CallableVariable extends Variable {
 		context.writer.sequencePoint(errorPosition.getLine());
 		context.writer.loadVariable(context.executionContextVariable);
 		context.writer.loadThis();
-		context.writer.loadInstanceField(mlmField);
+		context.writer.loadInstanceField(runnableField);
 		if (arguments != null) {
 			new ExpressionCompiler(context).buildArrayForCommaSeparatedExpression(arguments);
 		} else {

--- a/src/arden/compiler/CallableVariable.java
+++ b/src/arden/compiler/CallableVariable.java
@@ -88,6 +88,7 @@ abstract class CallableVariable extends Variable {
 				throw new RuntimeCompilerException(errorPosition, "Could not create zero delay");
 			}
 		}
+		ActionCompiler.loadUrgency(context);
 		context.writer.invokeInstance(ExecutionContextMethods.call);
 	}
 }

--- a/src/arden/compiler/CallableVariable.java
+++ b/src/arden/compiler/CallableVariable.java
@@ -106,6 +106,6 @@ final class CallableVariable extends Variable {
 				throw new RuntimeCompilerException(errorPosition, "Could not create zero delay");
 			}
 		}
-		context.writer.invokeInstance(ExecutionContextMethods.callWithDelay);
+		context.writer.invokeInstance(ExecutionContextMethods.call);
 	}
 }

--- a/src/arden/compiler/DataCompiler.java
+++ b/src/arden/compiler/DataCompiler.java
@@ -265,13 +265,13 @@ final class DataCompiler extends VisitorBase {
 			@Override
 			public void caseAImapDataAssignPhrase(AImapDataAssignPhrase node) {
 				// {imap} interface mapping_factor
-				CallableVariable var = CallableVariable.getCallableVariable(context.codeGenerator, lhs);
+				CallableVariable var = InterfaceVariable.getVariable(context.codeGenerator, lhs);
 				context.writer.sequencePoint(lhs.getPosition().getLine());
 				context.writer.loadThis();
 				context.writer.loadVariable(context.executionContextVariable);
 				context.writer.loadStringConstant(ParseHelpers.getStringForMapping(node.getMappingFactor()));
 				context.writer.invokeInstance(ExecutionContextMethods.findInterface);
-				context.writer.storeInstanceField(var.mlmField);
+				context.writer.storeInstanceField(var.runnableField);
 			}
 
 			@Override
@@ -412,7 +412,7 @@ final class DataCompiler extends VisitorBase {
 
 	/** Creates an MLM variable. */
 	private void createMlmVariable(LeftHandSideResult lhs, TTerm name, TStringLiteral institution) {
-		CallableVariable var = CallableVariable.getCallableVariable(context.codeGenerator, lhs);
+		CallableVariable var = MedicalLogicModuleVariable.getVariable(context.codeGenerator, lhs);
 		context.writer.sequencePoint(lhs.getPosition().getLine());
 		context.writer.loadThis();
 		if (name == null) {
@@ -427,7 +427,7 @@ final class DataCompiler extends VisitorBase {
 			}
 			context.writer.invokeInstance(ExecutionContextMethods.findModule);
 		}
-		context.writer.storeInstanceField(var.mlmField);
+		context.writer.storeInstanceField(var.runnableField);
 	}
 
 	/** Assigns the argument to the variable. */

--- a/src/arden/compiler/DataCompiler.java
+++ b/src/arden/compiler/DataCompiler.java
@@ -277,7 +277,7 @@ final class DataCompiler extends VisitorBase {
 			@Override
 			public void caseAEmapDataAssignPhrase(AEmapDataAssignPhrase node) {
 				// {emap} event mapping_factor
-				EventVariable e = EventVariable.getEventVariable(context.codeGenerator, lhs);
+				EventVariable e = EventVariable.getVariable(context.codeGenerator, lhs);
 				context.writer.sequencePoint(lhs.getPosition().getLine());
 				context.writer.loadThis();
 				context.writer.loadVariable(context.executionContextVariable);
@@ -289,7 +289,7 @@ final class DataCompiler extends VisitorBase {
 			@Override
 			public void caseAMmapDataAssignPhrase(AMmapDataAssignPhrase node) {
 				// {mmap} message mapping_factor
-				MessageVariable v = MessageVariable.getMessageVariable(context.codeGenerator, lhs);
+				MessageVariable v = MessageVariable.getVariable(context.codeGenerator, lhs);
 				context.writer.loadThis();
 				context.writer.loadVariable(context.executionContextVariable);
 				String mappingString = ParseHelpers.getStringForMapping(node.getMappingFactor());
@@ -301,7 +301,7 @@ final class DataCompiler extends VisitorBase {
 			@Override
 			public void caseAMasmapDataAssignPhrase(AMasmapDataAssignPhrase node) {
 				// {masmap} message as identifier mapping_factor?
-				MessageVariable v = MessageVariable.getMessageVariable(context.codeGenerator, lhs);
+				MessageVariable v = MessageVariable.getVariable(context.codeGenerator, lhs);
 				context.writer.loadThis();
 				context.writer.loadVariable(context.executionContextVariable);
 				String mappingString = ParseHelpers.getStringForMapping(node.getMappingFactor());

--- a/src/arden/compiler/EventVariable.java
+++ b/src/arden/compiler/EventVariable.java
@@ -89,6 +89,7 @@ final class EventVariable extends DataVariable {
 				throw new RuntimeCompilerException(errorPosition, "Could not create zero delay");
 			}
 		}
+		ActionCompiler.loadUrgency(context);
 		context.writer.invokeInstance(ExecutionContextMethods.callEvent);
 	}
 }

--- a/src/arden/compiler/EventVariable.java
+++ b/src/arden/compiler/EventVariable.java
@@ -44,7 +44,7 @@ final class EventVariable extends DataVariable {
 		super(name, field);
 	}
 
-	public static EventVariable getEventVariable(CodeGenerator codeGen, LeftHandSideResult lhs) {
+	public static EventVariable getVariable(CodeGenerator codeGen, LeftHandSideResult lhs) {
 		if (!(lhs instanceof LeftHandSideIdentifier))
 			throw new RuntimeCompilerException(lhs.getPosition(), "EVENT variables must be simple identifiers");
 		TIdentifier ident = ((LeftHandSideIdentifier) lhs).identifier;

--- a/src/arden/compiler/EventVariable.java
+++ b/src/arden/compiler/EventVariable.java
@@ -89,6 +89,6 @@ final class EventVariable extends DataVariable {
 				throw new RuntimeCompilerException(errorPosition, "Could not create zero delay");
 			}
 		}
-		context.writer.invokeInstance(ExecutionContextMethods.callEventWithDelay);
+		context.writer.invokeInstance(ExecutionContextMethods.callEvent);
 	}
 }

--- a/src/arden/compiler/ExecutionContextMethods.java
+++ b/src/arden/compiler/ExecutionContextMethods.java
@@ -58,8 +58,8 @@ final class ExecutionContextMethods {
 			findInterface = ExecutionContext.class.getMethod("findInterface", String.class);
 
 			write = ExecutionContext.class.getMethod("write", ArdenValue.class, ArdenValue.class, double.class);
-			call = ExecutionContext.class.getMethod("call", ArdenRunnable.class, ArdenValue[].class,
-					ArdenValue.class);
+			call = ExecutionContext.class.getMethod("call", ArdenRunnable.class, ArdenValue[].class, ArdenValue.class,
+					double.class);
 			callEvent = ExecutionContext.class.getMethod("call", ArdenEvent.class, ArdenValue.class);
 
 			getEventTime = ExecutionContext.class.getMethod("getEventTime");

--- a/src/arden/compiler/ExecutionContextMethods.java
+++ b/src/arden/compiler/ExecutionContextMethods.java
@@ -60,7 +60,7 @@ final class ExecutionContextMethods {
 			write = ExecutionContext.class.getMethod("write", ArdenValue.class, ArdenValue.class, double.class);
 			call = ExecutionContext.class.getMethod("call", ArdenRunnable.class, ArdenValue[].class, ArdenValue.class,
 					double.class);
-			callEvent = ExecutionContext.class.getMethod("call", ArdenEvent.class, ArdenValue.class);
+			callEvent = ExecutionContext.class.getMethod("call", ArdenEvent.class, ArdenValue.class, double.class);
 
 			getEventTime = ExecutionContext.class.getMethod("getEventTime");
 			getTriggerTime = ExecutionContext.class.getMethod("getTriggerTime");

--- a/src/arden/compiler/ExecutionContextMethods.java
+++ b/src/arden/compiler/ExecutionContextMethods.java
@@ -40,7 +40,7 @@ final class ExecutionContextMethods {
 	public static final Method createQuery;
 	public static final Method getMessage, getMessageAs, getDestination, getDestinationAs, getEvent;
 	public static final Method findModule, findModules, findInterface;
-	public static final Method write, callWithDelay, callEventWithDelay;
+	public static final Method write, call, callEvent;
 	public static final Method getEventTime, getTriggerTime, getCurrentTime;
 
 	static {
@@ -58,10 +58,9 @@ final class ExecutionContextMethods {
 			findInterface = ExecutionContext.class.getMethod("findInterface", String.class);
 
 			write = ExecutionContext.class.getMethod("write", ArdenValue.class, ArdenValue.class);
-			callWithDelay = ExecutionContext.class.getMethod("callWithDelay", ArdenRunnable.class, ArdenValue[].class,
+			call = ExecutionContext.class.getMethod("call", ArdenRunnable.class, ArdenValue[].class,
 					ArdenValue.class);
-			callEventWithDelay = ExecutionContext.class.getMethod("callEventWithDelay", ArdenEvent.class,
-					ArdenValue.class);
+			callEvent = ExecutionContext.class.getMethod("call", ArdenEvent.class, ArdenValue.class);
 
 			getEventTime = ExecutionContext.class.getMethod("getEventTime");
 			getTriggerTime = ExecutionContext.class.getMethod("getTriggerTime");

--- a/src/arden/compiler/ExecutionContextMethods.java
+++ b/src/arden/compiler/ExecutionContextMethods.java
@@ -57,7 +57,7 @@ final class ExecutionContextMethods {
 			findModules = ExecutionContext.class.getMethod("findModules", ArdenEvent.class);
 			findInterface = ExecutionContext.class.getMethod("findInterface", String.class);
 
-			write = ExecutionContext.class.getMethod("write", ArdenValue.class, ArdenValue.class);
+			write = ExecutionContext.class.getMethod("write", ArdenValue.class, ArdenValue.class, double.class);
 			call = ExecutionContext.class.getMethod("call", ArdenRunnable.class, ArdenValue[].class,
 					ArdenValue.class);
 			callEvent = ExecutionContext.class.getMethod("call", ArdenEvent.class, ArdenValue.class);

--- a/src/arden/compiler/InterfaceVariable.java
+++ b/src/arden/compiler/InterfaceVariable.java
@@ -1,0 +1,58 @@
+// arden2bytecode
+// Copyright (c) 2010, Daniel Grunwald
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice, this list
+//   of conditions and the following disclaimer.
+//
+// - Redistributions in binary form must reproduce the above copyright notice, this list
+//   of conditions and the following disclaimer in the documentation and/or other materials
+//   provided with the distribution.
+//
+// - Neither the name of the owner nor the names of its contributors may be used to
+//   endorse or promote products derived from this software without specific prior written
+//   permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &AS IS& AND ANY EXPRESS
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+// IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+// OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package arden.compiler;
+
+import java.lang.reflect.Modifier;
+
+import arden.codegenerator.FieldReference;
+import arden.compiler.node.TIdentifier;
+import arden.runtime.ArdenRunnable;
+
+/** INTERFACE Variables */
+final class InterfaceVariable extends CallableVariable {
+
+	protected InterfaceVariable(TIdentifier varName, FieldReference runnableField) {
+		super(varName, runnableField);
+	}
+
+	/** Gets the InterfaceVariable for the LHSR, or creates it on demand. */
+	public static InterfaceVariable getVariable(CodeGenerator codeGen, LeftHandSideResult lhs) {
+		if (!(lhs instanceof LeftHandSideIdentifier))
+			throw new RuntimeCompilerException(lhs.getPosition(), "INTERFACE variables must be simple identifiers");
+		TIdentifier ident = ((LeftHandSideIdentifier) lhs).identifier;
+		Variable variable = codeGen.getVariable(ident.getText());
+		if (variable instanceof InterfaceVariable) {
+			return (InterfaceVariable) variable;
+		} else {
+			FieldReference mlmField = codeGen.createField(ident.getText(), ArdenRunnable.class, Modifier.PRIVATE);
+			InterfaceVariable cv = new InterfaceVariable(ident, mlmField);
+			codeGen.addVariable(cv);
+			return cv;
+		}
+	}
+}

--- a/src/arden/compiler/MedicalLogicModuleVariable.java
+++ b/src/arden/compiler/MedicalLogicModuleVariable.java
@@ -1,0 +1,58 @@
+// arden2bytecode
+// Copyright (c) 2010, Daniel Grunwald
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice, this list
+//   of conditions and the following disclaimer.
+//
+// - Redistributions in binary form must reproduce the above copyright notice, this list
+//   of conditions and the following disclaimer in the documentation and/or other materials
+//   provided with the distribution.
+//
+// - Neither the name of the owner nor the names of its contributors may be used to
+//   endorse or promote products derived from this software without specific prior written
+//   permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &AS IS& AND ANY EXPRESS
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+// IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+// OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package arden.compiler;
+
+import java.lang.reflect.Modifier;
+
+import arden.codegenerator.FieldReference;
+import arden.compiler.node.TIdentifier;
+import arden.runtime.MedicalLogicModule;
+
+/** MLM Variables */
+final class MedicalLogicModuleVariable extends CallableVariable {
+
+	private MedicalLogicModuleVariable(TIdentifier varName, FieldReference mlmField) {
+		super(varName, mlmField);
+	}
+
+	/** Gets the MedicalLogicModuleVariable for the LHSR, or creates it on demand. */
+	public static MedicalLogicModuleVariable getVariable(CodeGenerator codeGen, LeftHandSideResult lhs) {
+		if (!(lhs instanceof LeftHandSideIdentifier))
+			throw new RuntimeCompilerException(lhs.getPosition(), "MLM variables must be simple identifiers");
+		TIdentifier ident = ((LeftHandSideIdentifier) lhs).identifier;
+		Variable variable = codeGen.getVariable(ident.getText());
+		if (variable instanceof MedicalLogicModuleVariable) {
+			return (MedicalLogicModuleVariable) variable;
+		} else {
+			FieldReference mlmField = codeGen.createField(ident.getText(), MedicalLogicModule.class, Modifier.PRIVATE);
+			MedicalLogicModuleVariable cv = new MedicalLogicModuleVariable(ident, mlmField);
+			codeGen.addVariable(cv);
+			return cv;
+		}
+	}
+}

--- a/src/arden/compiler/MessageVariable.java
+++ b/src/arden/compiler/MessageVariable.java
@@ -51,7 +51,7 @@ final class MessageVariable extends Variable {
 	/**
 	 * Gets the MessageVariable for the LHSR, or creates it on demand.
 	 */
-	public static MessageVariable getMessageVariable(CodeGenerator codeGen, LeftHandSideResult lhs) {
+	public static MessageVariable getVariable(CodeGenerator codeGen, LeftHandSideResult lhs) {
 		if (!(lhs instanceof LeftHandSideIdentifier))
 			throw new RuntimeCompilerException(lhs.getPosition(), "MESSAGE variables must be simple identifiers");
 		TIdentifier ident = ((LeftHandSideIdentifier) lhs).identifier;

--- a/src/arden/runtime/BaseExecutionContext.java
+++ b/src/arden/runtime/BaseExecutionContext.java
@@ -71,7 +71,7 @@ public class BaseExecutionContext extends ExecutionContext {
 	}
 
 	@Override
-	public ArdenRunnable findModule(String name, String institution) {
+	public MedicalLogicModule findModule(String name, String institution) {
 		if (!name.matches("[a-zA-Z0-9\\-_]+")) {
 			throw new RuntimeException("Malformed module name: " + name);
 		}
@@ -131,7 +131,7 @@ public class BaseExecutionContext extends ExecutionContext {
 	}
 
 	@Override
-	public ArdenRunnable[] findModules(ArdenEvent event) {
+	public MedicalLogicModule[] findModules(ArdenEvent event) {
 		if (engine != null) {
 			try {
 				return engine.findModules(event);

--- a/src/arden/runtime/BaseExecutionContext.java
+++ b/src/arden/runtime/BaseExecutionContext.java
@@ -191,7 +191,7 @@ public class BaseExecutionContext extends ExecutionContext {
 	}
 
 	@Override
-	public void call(ArdenEvent event, ArdenValue delay) {
+	public void call(ArdenEvent event, ArdenValue delay, double urgency) {
 		if (engine != null) {
 			// run on engine
 			engine.callEvent(event, ExecutionContextHelpers.delayToMillis(delay));

--- a/src/arden/runtime/BaseExecutionContext.java
+++ b/src/arden/runtime/BaseExecutionContext.java
@@ -174,7 +174,7 @@ public class BaseExecutionContext extends ExecutionContext {
 	}
 
 	@Override
-	public void callWithDelay(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delay) {
+	public void call(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delay) {
 		if (engine != null) {
 			// use urgency as priority
 			int urgency = 50;
@@ -198,7 +198,7 @@ public class BaseExecutionContext extends ExecutionContext {
 	}
 
 	@Override
-	public void callEventWithDelay(ArdenEvent event, ArdenValue delay) {
+	public void call(ArdenEvent event, ArdenValue delay) {
 		if (engine != null) {
 			// run on engine
 			engine.callEvent(event, delayToMillis(delay));

--- a/src/arden/runtime/BaseExecutionContext.java
+++ b/src/arden/runtime/BaseExecutionContext.java
@@ -174,17 +174,10 @@ public class BaseExecutionContext extends ExecutionContext {
 	}
 
 	@Override
-	public void call(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delay) {
+	public void call(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delay, double urgency) {
 		if (engine != null) {
-			// use urgency as priority
-			int urgency = 50;
-			if (mlm instanceof MedicalLogicModule) {
-				MedicalLogicModule module = (MedicalLogicModule) mlm;
-				urgency = (int) Math.round(module.getUrgency());
-			}
-
 			// run on engine
-			engine.callWithDelay(mlm, arguments, urgency, delayToMillis(delay));
+			engine.callWithDelay(mlm, arguments, (int) urgency, ExecutionContextHelpers.delayToMillis(delay));
 		} else {
 			// print delay and run now
 			System.out.println("delay (skipped): " + delay.toString());
@@ -201,7 +194,7 @@ public class BaseExecutionContext extends ExecutionContext {
 	public void call(ArdenEvent event, ArdenValue delay) {
 		if (engine != null) {
 			// run on engine
-			engine.callEvent(event, delayToMillis(delay));
+			engine.callEvent(event, ExecutionContextHelpers.delayToMillis(delay));
 		} else {
 			// run MLMs for event now
 			ArdenRunnable[] mlms = findModules(event);
@@ -219,12 +212,4 @@ public class BaseExecutionContext extends ExecutionContext {
 		}
 	}
 
-	private long delayToMillis(ArdenValue delay) {
-		// get delay
-		if (!(delay instanceof ArdenDuration)) {
-			throw new RuntimeException("Delay must be a duration");
-		}
-		ArdenDuration delayDuration = (ArdenDuration) delay;
-		return Math.round(delayDuration.toSeconds() * 1000);
-	}
 }

--- a/src/arden/runtime/ExecutionContext.java
+++ b/src/arden/runtime/ExecutionContext.java
@@ -202,15 +202,18 @@ public abstract class ExecutionContext {
 	 *            The MLM that should be called. This will be an instance
 	 *            returned from {@link #findModule(String, String)} or
 	 *            {@link #findInterface(String)}.
-	 *            
+	 * 
 	 * @param arguments
 	 *            The arguments being passed. Can be null if no arguments were
 	 *            specified.
 	 * 
 	 * @param delay
 	 *            The delay for calling the MLM (as ArdenDuration).
+	 * 
+	 * @param urgency
+	 *            The urgency from the MLMs urgency slot.
 	 */
-	public void call(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delay) {
+	public void call(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delay, double urgency) {
 		throw new RuntimeException("MLM call not implemented");
 	}
 

--- a/src/arden/runtime/ExecutionContext.java
+++ b/src/arden/runtime/ExecutionContext.java
@@ -227,7 +227,7 @@ public abstract class ExecutionContext {
 	 * @param delay
 	 *            The delay for calling the event (as ArdenDuration).
 	 */
-	public void call(ArdenEvent event, ArdenValue delay) {
+	public void call(ArdenEvent event, ArdenValue delay, double urgency) {
 		throw new RuntimeException("Event call not implemented");
 	}
 

--- a/src/arden/runtime/ExecutionContext.java
+++ b/src/arden/runtime/ExecutionContext.java
@@ -207,8 +207,8 @@ public abstract class ExecutionContext {
 	 * @param delay
 	 *            The delay for calling the MLM (as ArdenDuration).
 	 */
-	public void callWithDelay(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delay) {
-		throw new RuntimeException("callWithDelay not implemented");
+	public void call(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delay) {
+		throw new RuntimeException("MLM call not implemented");
 	}
 
 	/**
@@ -221,8 +221,8 @@ public abstract class ExecutionContext {
 	 * @param delay
 	 *            The delay for calling the event (as ArdenDuration).
 	 */
-	public void callEventWithDelay(ArdenEvent event, ArdenValue delay) {
-		throw new RuntimeException("callEventWithDelay not implemented");
+	public void call(ArdenEvent event, ArdenValue delay) {
+		throw new RuntimeException("Event call not implemented");
 	}
 
 	protected ArdenTime eventTime = new ArdenTime(new Date());

--- a/src/arden/runtime/ExecutionContext.java
+++ b/src/arden/runtime/ExecutionContext.java
@@ -161,7 +161,7 @@ public abstract class ExecutionContext {
 	 * 
 	 * @return The requested MLM.
 	 */
-	public ArdenRunnable findModule(String name, String institution) {
+	public MedicalLogicModule findModule(String name, String institution) {
 		throw new RuntimeException("findModule not implemented");
 	}
 
@@ -174,7 +174,7 @@ public abstract class ExecutionContext {
 	 * 
 	 * @return The requested MLMs.
 	 */
-	public ArdenRunnable[] findModules(ArdenEvent event) {
+	public MedicalLogicModule[] findModules(ArdenEvent event) {
 		throw new RuntimeException("findModules not implemented");
 	}
 

--- a/src/arden/runtime/ExecutionContext.java
+++ b/src/arden/runtime/ExecutionContext.java
@@ -146,8 +146,11 @@ public abstract class ExecutionContext {
 	 *            returned from {@link #getDestination(String)} or
 	 *            {@link #getDestinationAs(String, ObjectType)}. May be null, if
 	 *            the default destination should be used.
+	 * 
+	 * @param urgency
+	 *            The urgency from the MLMs urgency slot.
 	 */
-	public void write(ArdenValue message, ArdenValue destination) {
+	public void write(ArdenValue message, ArdenValue destination, double urgency) {
 	}
 
 	/**

--- a/src/arden/runtime/ExecutionContextHelpers.java
+++ b/src/arden/runtime/ExecutionContextHelpers.java
@@ -5,8 +5,6 @@ import java.util.PriorityQueue;
 import java.util.Queue;
 
 import arden.runtime.MaintenanceMetadata.Validation;
-import arden.runtime.evoke.CallTrigger;
-import arden.runtime.evoke.Trigger;
 
 public class ExecutionContextHelpers {
 
@@ -74,12 +72,6 @@ public class ExecutionContextHelpers {
 			return matches.peek();
 		}
 		return null;
-	}
-
-	public static Trigger combine(Trigger callingMlmsTrigger, long delay) {
-		ArdenEvent event = callingMlmsTrigger.getTriggeringEvent();
-		long combinedDelay = callingMlmsTrigger.getDelay() + delay;
-		return new CallTrigger(event, combinedDelay);
 	}
 
 	public static long delayToMillis(ArdenValue delay) {

--- a/src/arden/runtime/ExecutionContextHelpers.java
+++ b/src/arden/runtime/ExecutionContextHelpers.java
@@ -5,6 +5,8 @@ import java.util.PriorityQueue;
 import java.util.Queue;
 
 import arden.runtime.MaintenanceMetadata.Validation;
+import arden.runtime.evoke.CallTrigger;
+import arden.runtime.evoke.Trigger;
 
 public class ExecutionContextHelpers {
 
@@ -72,6 +74,20 @@ public class ExecutionContextHelpers {
 			return matches.peek();
 		}
 		return null;
+	}
+
+	public static Trigger combine(Trigger callingMlmsTrigger, long delay) {
+		ArdenEvent event = callingMlmsTrigger.getTriggeringEvent();
+		long combinedDelay = callingMlmsTrigger.getDelay() + delay;
+		return new CallTrigger(event, combinedDelay);
+	}
+
+	public static long delayToMillis(ArdenValue delay) {
+		if (!(delay instanceof ArdenDuration)) {
+			throw new IllegalArgumentException("Delay must be a duration");
+		}
+		ArdenDuration delayDuration = (ArdenDuration) delay;
+		return Math.round(delayDuration.toSeconds() * 1000);
 	}
 
 }

--- a/src/arden/runtime/RuntimeHelpers.java
+++ b/src/arden/runtime/RuntimeHelpers.java
@@ -84,10 +84,13 @@ public final class RuntimeHelpers {
 	public static final double DEFAULT_PRIORITY = 50; 
 
 	public static double urgencyGetPrimitiveValue(ArdenValue val) {
-		if (val instanceof ArdenNumber)
-			return ((ArdenNumber) val).value;
-		else
-			return DEFAULT_URGENCY;
+		if (val instanceof ArdenNumber) {
+			double urgency = ((ArdenNumber) val).value;
+			if (urgency >= 1 && urgency <= 99) {
+				return urgency;
+			}
+		}
+		return DEFAULT_URGENCY;
 	}
 
 	/** Converts val to int. Returns -1 if val is not an integer. */

--- a/src/arden/runtime/StdIOExecutionContext.java
+++ b/src/arden/runtime/StdIOExecutionContext.java
@@ -80,7 +80,7 @@ public class StdIOExecutionContext extends BaseExecutionContext {
 	}
 
 	@Override
-	public void write(ArdenValue message, ArdenValue destination) {
+	public void write(ArdenValue message, ArdenValue destination, double urgency) {
 		String destString = ArdenString.getStringFromValue(destination);
 		if (destString != null  && "stdout".equalsIgnoreCase(destString)) {
 			// just print string

--- a/src/arden/runtime/jdbc/JDBCExecutionContext.java
+++ b/src/arden/runtime/jdbc/JDBCExecutionContext.java
@@ -83,14 +83,14 @@ public class JDBCExecutionContext extends StdIOExecutionContext {
 	}
 	
 	@Override
-	public void write(ArdenValue message, ArdenValue destination) {
+	public void write(ArdenValue message, ArdenValue destination, double urgency) {
 		String destString = ArdenString.getStringFromValue(destination);
 		if (destString != null && ("database".equalsIgnoreCase(destString) || "query".equalsIgnoreCase(destString))) {
 			String msgString = ArdenString.getStringFromValue(message);
 			// execute query:
 			new JDBCQuery(msgString, connection).execute();
 		} else {
-			super.write(message, destination);
+			super.write(message, destination, urgency);
 		}
 	}
 	

--- a/test/arden/tests/implementation/TestContext.java
+++ b/test/arden/tests/implementation/TestContext.java
@@ -62,7 +62,7 @@ public class TestContext extends ExecutionContext {
 	}
 
 	@Override
-	public void write(ArdenValue message, ArdenValue destination) {
+	public void write(ArdenValue message, ArdenValue destination, double urgency) {
 		b.append(((ArdenString) message).value);
 		b.append("\n");
 	}

--- a/test/arden/tests/specification/testcompiler/impl/TestContext.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestContext.java
@@ -52,7 +52,7 @@ public class TestContext extends ExecutionContext {
 	}
 
 	@Override
-	public ArdenRunnable findModule(String name, String institution) {
+	public MedicalLogicModule findModule(String name, String institution) {
 		MedicalLogicModule[] mlmArray = mlms.toArray(new MedicalLogicModule[mlms.size()]);
 		MedicalLogicModule foundModule = ExecutionContextHelpers.findModule(name, institution, mlmArray, null);
 		if (foundModule == null) {
@@ -62,7 +62,7 @@ public class TestContext extends ExecutionContext {
 	}
 
 	@Override
-	public ArdenRunnable[] findModules(ArdenEvent event) {
+	public MedicalLogicModule[] findModules(ArdenEvent event) {
 		List<MedicalLogicModule> foundModules = new ArrayList<>();
 		for (MedicalLogicModule mlm : mlms) {
 			try {

--- a/test/arden/tests/specification/testcompiler/impl/TestContext.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestContext.java
@@ -129,7 +129,7 @@ public class TestContext extends ExecutionContext {
 	}
 
 	@Override
-	public void write(ArdenValue message, ArdenValue destination) {
+	public void write(ArdenValue message, ArdenValue destination, double urgency) {
 		// save messages
 		String stringMessage = ((ArdenString) message).value;
 		messages.add(stringMessage);

--- a/test/arden/tests/specification/testcompiler/impl/TestEngine.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestEngine.java
@@ -71,7 +71,7 @@ public class TestEngine extends TestContext {
 	}
 
 	@Override
-	public void call(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delayValue) {
+	public void call(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delayValue, double urgency) {
 		ArdenDuration delayDuration = (ArdenDuration) delayValue;
 		ArdenTime nextRuntime = new ArdenTime(currentTime.add(delayDuration));
 		scheduledCalls.add(nextRuntime, new MlmCall((MedicalLogicModule) mlm, this, arguments));

--- a/test/arden/tests/specification/testcompiler/impl/TestEngine.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestEngine.java
@@ -78,7 +78,7 @@ public class TestEngine extends TestContext {
 	}
 
 	@Override
-	public void call(ArdenEvent event, ArdenValue delayValue) {
+	public void call(ArdenEvent event, ArdenValue delayValue, double urgency) {
 		ArdenDuration delayDuration = (ArdenDuration) delayValue;
 		ArdenTime nextRuntime = new ArdenTime(currentTime.add(delayDuration));
 		scheduledCalls.add(nextRuntime, new EventCall(event, this));

--- a/test/arden/tests/specification/testcompiler/impl/TestEngine.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestEngine.java
@@ -85,7 +85,7 @@ public class TestEngine extends TestContext {
 	}
 
 	@Override
-	public void write(ArdenValue message, ArdenValue destination) {
+	public void write(ArdenValue message, ArdenValue destination, double urgency) {
 		// save messages
 		String stringMessage;
 		if (message instanceof ArdenString) {

--- a/test/arden/tests/specification/testcompiler/impl/TestEngine.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestEngine.java
@@ -71,14 +71,14 @@ public class TestEngine extends TestContext {
 	}
 
 	@Override
-	public void callWithDelay(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delayValue) {
+	public void call(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delayValue) {
 		ArdenDuration delayDuration = (ArdenDuration) delayValue;
 		ArdenTime nextRuntime = new ArdenTime(currentTime.add(delayDuration));
 		scheduledCalls.add(nextRuntime, new MlmCall((MedicalLogicModule) mlm, this, arguments));
 	}
 
 	@Override
-	public void callEventWithDelay(ArdenEvent event, ArdenValue delayValue) {
+	public void call(ArdenEvent event, ArdenValue delayValue) {
 		ArdenDuration delayDuration = (ArdenDuration) delayValue;
 		ArdenTime nextRuntime = new ArdenTime(currentTime.add(delayDuration));
 		scheduledCalls.add(nextRuntime, new EventCall(event, this));


### PR DESCRIPTION
When an MLM or event is called, or when a message is written, the `urgency` slots value is now available to the `ExecutionContext`.
This slot may contain a constant number (between 1 and 99) or may reference a variable. If a variable is used, its value at the time the `WRITE` or `CALL` statement is made is used. This allows changing the urgency for every action separately.