### PR TITLE
Support eventtime, triggertime, and events as booleans

### DIFF
--- a/src/arden/EvokeEngine.java
+++ b/src/arden/EvokeEngine.java
@@ -67,7 +67,7 @@ public class EvokeEngine implements Runnable {
 	public MedicalLogicModule[] findModules(ArdenEvent event) throws InvocationTargetException {
 		List<MedicalLogicModule> foundModules = new ArrayList<>();
 		for (MedicalLogicModule mlm : mlms) {
-			for (Trigger trigger : mlm.getTriggers(context, null)) {
+			for (Trigger trigger : mlm.getTriggers(context)) {
 				if (trigger.runOnEvent(event)) {
 					foundModules.add(mlm);
 				}
@@ -182,7 +182,7 @@ public class EvokeEngine implements Runnable {
 		for (MedicalLogicModule mlm : mlms) {
 			Trigger[] triggers;
 			try {
-				triggers = mlm.getTriggers(context, null);
+				triggers = mlm.getTriggers(context);
 			} catch (InvocationTargetException e) {
 				// print error and skip this MLM
 				e.printStackTrace();
@@ -240,7 +240,7 @@ public class EvokeEngine implements Runnable {
 			for (MedicalLogicModule mlm : mlms) {
 				Trigger[] triggers;
 				try {
-					triggers = mlm.getTriggers(context, null);
+					triggers = mlm.getTriggers(context);
 				} catch (InvocationTargetException e) {
 					// print error and skip this MLM
 					e.printStackTrace();

--- a/src/arden/EvokeEngine.java
+++ b/src/arden/EvokeEngine.java
@@ -190,7 +190,7 @@ public class EvokeEngine implements Runnable {
 			}
 			for (Trigger trigger : triggers) {
 
-				ArdenTime nextRuntime = trigger.getNextRunTime(context);
+				ArdenTime nextRuntime = trigger.getNextRunTime();
 				if (nextRuntime == null) {
 					// not scheduled
 					continue;

--- a/src/arden/EvokeEngine.java
+++ b/src/arden/EvokeEngine.java
@@ -19,6 +19,7 @@ import arden.runtime.ArdenValue;
 import arden.runtime.BaseExecutionContext;
 import arden.runtime.ExecutionContext;
 import arden.runtime.MedicalLogicModule;
+import arden.runtime.evoke.CallTrigger;
 import arden.runtime.evoke.Trigger;
 
 /**
@@ -281,7 +282,8 @@ public class EvokeEngine implements Runnable {
 		public void run() {
 			// run MLM now
 			try {
-				runnable.run(context, args);
+				// TODO use correct delay
+				runnable.run(context, args, new CallTrigger());
 			} catch (InvocationTargetException e) {
 				// print error and skip this MLM
 				e.printStackTrace();

--- a/src/arden/EvokeEngine.java
+++ b/src/arden/EvokeEngine.java
@@ -19,7 +19,6 @@ import arden.runtime.ArdenValue;
 import arden.runtime.BaseExecutionContext;
 import arden.runtime.ExecutionContext;
 import arden.runtime.MedicalLogicModule;
-import arden.runtime.evoke.CallTrigger;
 import arden.runtime.evoke.Trigger;
 
 /**
@@ -65,6 +64,7 @@ public class EvokeEngine implements Runnable {
 		context.setEngine(this);
 	}
 
+	/** @see {@link ExecutionContext#findModules(ArdenEvent)} */
 	public MedicalLogicModule[] findModules(ArdenEvent event) throws InvocationTargetException {
 		List<MedicalLogicModule> foundModules = new ArrayList<>();
 		for (MedicalLogicModule mlm : mlms) {
@@ -77,14 +77,26 @@ public class EvokeEngine implements Runnable {
 		return foundModules.toArray(new MedicalLogicModule[foundModules.size()]);
 	}
 
-	public void callEvent(ArdenEvent event, long delay) {
+	/**
+	 * Call all MLMs for an event, after a delay
+	 * 
+	 * @param event
+	 *            the event, which will be called "as is" without changing the
+	 *            eventtime
+	 * @param delay
+	 *            the delay in milliseconds
+	 * @param urgency
+	 *            a number from 1 (low urgency) to 99 (high urgency), which is
+	 *            used to decide in which order to evaluate events.
+	 */
+	public void call(ArdenEvent event, long delay, int urgency) {
 		/*
 		 * Checking the evoke statements may require running the data slot,
 		 * which should not run concurrent to other (possibly data changing)
 		 * MLMs. Therefore add an EventCall to messages, so it is run on the
 		 * engines thread.
 		 */
-		final EventCall call = new EventCall(event);
+		final EventCall call = new EventCall(event, urgency);
 		if (delay <= 0) {
 			// run event as soon as possible
 			messages.add(call);
@@ -99,8 +111,24 @@ public class EvokeEngine implements Runnable {
 		}
 	}
 
-	public void callWithDelay(ArdenRunnable mlm, ArdenValue[] arguments, int urgency, long delay) {
-		final MlmCall call = new MlmCall(mlm, arguments, urgency);
+	/**
+	 * Call an MLM after a delay.
+	 * 
+	 * @param mlm
+	 *            the MLM to call
+	 * @param arguments
+	 *            parameters to te MLM
+	 * @param delay
+	 *            the delay in milliseconds
+	 * @param evokingTrigger
+	 *            the trigger, that will be given to the MLM "as is", without
+	 *            changing the delay
+	 * @param urgency
+	 *            a number from 1 (low urgency) to 99 (high urgency), which is
+	 *            used to decide in which order to evaluate MLMs.
+	 */
+	public void call(ArdenRunnable mlm, ArdenValue[] arguments, long delay, Trigger evokingTrigger, int urgency) {
+		final MlmCall call = new MlmCall(mlm, arguments, evokingTrigger, urgency);
 		if (delay <= 0) {
 			// run MLM as soon as possible
 			messages.add(call);
@@ -133,7 +161,7 @@ public class EvokeEngine implements Runnable {
 
 			// execute MlmCall or EventCall on this thread
 			message.run();
-			
+
 			// check for MLMs which may now be triggered
 			scheduleTriggers();
 		}
@@ -190,7 +218,6 @@ public class EvokeEngine implements Runnable {
 				continue;
 			}
 			for (Trigger trigger : triggers) {
-
 				ArdenTime nextRuntime = trigger.getNextRunTime();
 				if (nextRuntime == null) {
 					// not scheduled
@@ -202,7 +229,7 @@ public class EvokeEngine implements Runnable {
 					scheduleGroup = new ArrayList<MlmCall>();
 					schedule.put(nextRuntime, scheduleGroup);
 				}
-				scheduleGroup.add(new MlmCall(mlm, null));
+				scheduleGroup.add(new MlmCall(mlm, null, trigger));
 			}
 		}
 
@@ -224,15 +251,17 @@ public class EvokeEngine implements Runnable {
 
 	private class EventCall implements Message {
 		ArdenEvent event;
+		int urgency;
 
-		public EventCall(ArdenEvent event) {
+		public EventCall(ArdenEvent event, int urgency) {
 			this.event = event;
+			this.urgency = urgency;
 		}
 
 		@Override
 		public int getPriority() {
-			// always handle events before MlmCalls
-			return Integer.MAX_VALUE;
+			// handle events before MlmCalls (highest priority/urgency is 99)
+			return 99 + urgency;
 		}
 
 		@Override
@@ -251,7 +280,7 @@ public class EvokeEngine implements Runnable {
 				for (Trigger trigger : triggers) {
 					trigger.scheduleEvent(event);
 					if (trigger.runOnEvent(event)) {
-						messages.add(new MlmCall(mlm, null));
+						messages.add(new MlmCall(mlm, null, trigger));
 					}
 				}
 			}
@@ -262,15 +291,17 @@ public class EvokeEngine implements Runnable {
 		ArdenRunnable runnable;
 		ArdenValue[] args;
 		int priority;
+		Trigger trigger;
 
-		public MlmCall(ArdenRunnable runnable, ArdenValue[] args, int priority) {
+		public MlmCall(ArdenRunnable runnable, ArdenValue[] args, Trigger trigger, int priority) {
 			this.runnable = runnable;
 			this.args = args;
+			this.trigger = trigger;
 			this.priority = priority;
 		}
 
-		public MlmCall(MedicalLogicModule mlm, ArdenValue[] args) {
-			this(mlm, args, (int) Math.round(mlm.getPriority()));
+		public MlmCall(MedicalLogicModule mlm, ArdenValue[] args, Trigger trigger) {
+			this(mlm, args, trigger, (int) Math.round(mlm.getPriority()));
 		}
 
 		@Override
@@ -282,8 +313,7 @@ public class EvokeEngine implements Runnable {
 		public void run() {
 			// run MLM now
 			try {
-				// TODO use correct delay
-				runnable.run(context, args, new CallTrigger());
+				runnable.run(context, args, trigger);
 			} catch (InvocationTargetException e) {
 				// print error and skip this MLM
 				e.printStackTrace();

--- a/src/arden/MainClass.java
+++ b/src/arden/MainClass.java
@@ -58,6 +58,7 @@ import arden.runtime.BaseExecutionContext;
 import arden.runtime.ExecutionContext;
 import arden.runtime.MedicalLogicModule;
 import arden.runtime.StdIOExecutionContext;
+import arden.runtime.evoke.CallTrigger;
 import arden.runtime.jdbc.JDBCExecutionContext;
 
 public class MainClass {
@@ -448,7 +449,7 @@ public class MainClass {
 	public static ArdenValue[] runMlm(MedicalLogicModule mlm, ExecutionContext context, ArdenValue[] arguments) throws MainException {
 		ArdenValue[] result = null;
 		try {
-			result = mlm.run(context, arguments);
+			result = mlm.run(context, arguments, new CallTrigger());
 			if (result != null && result.length == 1) {
 				System.out.println("Return Value: " + result[0].toString());
 			} else if (result != null && result.length > 1) {

--- a/src/arden/compiler/CallableVariable.java
+++ b/src/arden/compiler/CallableVariable.java
@@ -35,6 +35,7 @@ import arden.runtime.ArdenDuration;
 import arden.runtime.ArdenRunnable;
 import arden.runtime.ArdenValue;
 import arden.runtime.ExecutionContext;
+import arden.runtime.evoke.Trigger;
 
 /**
  * MLM or INTERFACE Variables.
@@ -64,8 +65,10 @@ abstract class CallableVariable extends Variable {
 		} else {
 			context.writer.loadNull();
 		}
-		context.writer.invokeStatic(
-				Compiler.getRuntimeHelper("call", ArdenRunnable.class, ExecutionContext.class, ArdenValue[].class));
+		context.writer.loadThis();
+		context.writer.loadInstanceField(context.codeGenerator.getTriggerField());
+		context.writer.invokeStatic(Compiler.getRuntimeHelper("call", ArdenRunnable.class, ExecutionContext.class,
+				ArdenValue[].class, Trigger.class));
 	}
 
 	@Override
@@ -88,6 +91,8 @@ abstract class CallableVariable extends Variable {
 				throw new RuntimeCompilerException(errorPosition, "Could not create zero delay");
 			}
 		}
+		context.writer.loadThis();
+		context.writer.loadInstanceField(context.codeGenerator.getTriggerField());
 		ActionCompiler.loadUrgency(context);
 		context.writer.invokeInstance(ExecutionContextMethods.call);
 	}

--- a/src/arden/compiler/CodeGenerator.java
+++ b/src/arden/compiler/CodeGenerator.java
@@ -70,6 +70,7 @@ final class CodeGenerator {
 	private FieldReference nowField;
 	private FieldReference eventTimeField;
 	private FieldReference triggerTimeField;
+	private FieldReference triggerField;
 
 	private static final String literalPrefix = "$literal";
 
@@ -354,6 +355,13 @@ final class CodeGenerator {
 		return triggerTimeField;
 	}
 
+	public FieldReference getTriggerField() {
+		if (triggerField == null) {
+			triggerField = classFileWriter.declareField("$trigger", Trigger.class, Modifier.PRIVATE);
+		}
+		return triggerField;
+	}
+
 	public FieldReference createField(String name, Class<?> type, int modifiers) {
 		return classFileWriter.declareField(name, type, modifiers);
 	}
@@ -425,6 +433,11 @@ final class CodeGenerator {
 				ctor.loadVariable(1); // executionContextVariable
 				ctor.invokeInstance(ExecutionContextMethods.getCurrentTime);
 				ctor.storeInstanceField(nowField);
+			}
+			if (triggerField != null) {
+				ctor.loadThis();
+				ctor.loadVariable(4); // triggerVariable
+				ctor.storeInstanceField(triggerField);
 			}
 			if (eventTimeField != null) {
 				ctor.loadThis();

--- a/src/arden/compiler/CodeGenerator.java
+++ b/src/arden/compiler/CodeGenerator.java
@@ -190,7 +190,7 @@ final class CodeGenerator {
 	
 	public CompilerContext createConstructor(int lineNumberForInitializationSequencePoint) {
 		ctor = classFileWriter.createConstructor(Modifier.PUBLIC, new Class<?>[] { ExecutionContext.class,
-				MedicalLogicModule.class, ArdenValue[].class });
+				MedicalLogicModule.class, ArdenValue[].class, Trigger.class });
 		this.lineNumberForInitializationSequencePoint = lineNumberForInitializationSequencePoint;
 		if (isDebuggingEnabled) {
 			ctor.enableLineNumberTable();
@@ -206,7 +206,7 @@ final class CodeGenerator {
 		}
 		ctor.jump(ctorInitCodeLabel);
 		ctor.mark(ctorUserCodeLabel);
-		return new CompilerContext(this, ctor, 3);
+		return new CompilerContext(this, ctor, 4);
 	}
 	
 	public CompilerContext createParameterLessConstructor() {
@@ -219,7 +219,7 @@ final class CodeGenerator {
 		} catch (NoSuchMethodException e) {
 			throw new RuntimeException(e);
 		}
-		return new CompilerContext(this, ctor, 3);
+		return new CompilerContext(this, ctor, 0);
 	}
 
 	public CompilerContext createLogic() {
@@ -267,11 +267,7 @@ final class CodeGenerator {
 	}
 	
 	public CompilerContext createTriggers() {
-		MethodWriter w = classFileWriter.createMethod(
-				"getTriggers",
-				Modifier.PUBLIC, 
-				new Class<?>[] { ExecutionContext.class }, 
-				Trigger[].class);
+		MethodWriter w = classFileWriter.createMethod("getTriggers", Modifier.PUBLIC, new Class<?>[] { ExecutionContext.class }, Trigger[].class);
 		if (isDebuggingEnabled)
 			w.enableLineNumberTable();
 		return new CompilerContext(this, w, 1);

--- a/src/arden/compiler/CompiledMlm.java
+++ b/src/arden/compiler/CompiledMlm.java
@@ -240,11 +240,11 @@ public final class CompiledMlm implements MedicalLogicModule {
 	 * data set in the constructor, the data section of the MLM is run.
 	 */
 	@Override
-	public Trigger[] getTriggers(ExecutionContext context, ArdenValue[] arguments) throws InvocationTargetException {
+	public Trigger[] getTriggers(ExecutionContext context) throws InvocationTargetException {
 		if (triggers == null) {
 			MedicalLogicModuleImplementation instance = initializedInstance;
 			if (instance == null) {
-				instance = createInstance(context, arguments);
+				instance = createInstance(context, null);
 			}
 			triggers = instance.getTriggers(context);
 		}

--- a/src/arden/compiler/CompilerContext.java
+++ b/src/arden/compiler/CompilerContext.java
@@ -42,6 +42,7 @@ final class CompilerContext {
 	public final int executionContextVariable;
 	public final int selfMLMVariable;
 	public final int argumentsVariable;
+	public final int triggerVariable;
 	private int nextFreeVariable;
 	/** Stack of currently active 'it' variables */
 	private Stack<Integer> itVariables = new Stack<Integer>();
@@ -55,14 +56,22 @@ final class CompilerContext {
 			executionContextVariable = 1;
 		else
 			executionContextVariable = -1;
+
 		if (parameters >= 2)
 			selfMLMVariable = 2;
 		else
 			selfMLMVariable = -1;
+
 		if (parameters >= 3)
 			argumentsVariable = 3;
 		else
 			argumentsVariable = -1;
+
+		if (parameters >= 4)
+			triggerVariable = 4;
+		else
+			triggerVariable = -1;
+
 		nextFreeVariable = parameters + 1;
 	}
 

--- a/src/arden/compiler/DataCompiler.java
+++ b/src/arden/compiler/DataCompiler.java
@@ -76,9 +76,11 @@ import arden.compiler.node.Switchable;
 import arden.compiler.node.TIdentifier;
 import arden.compiler.node.TStringLiteral;
 import arden.compiler.node.TTerm;
+import arden.runtime.ArdenEvent;
 import arden.runtime.ArdenValue;
 import arden.runtime.DatabaseQuery;
 import arden.runtime.ObjectType;
+import arden.runtime.evoke.Trigger;
 
 /**
  * Compiler for data block.
@@ -283,6 +285,10 @@ final class DataCompiler extends VisitorBase {
 				context.writer.loadVariable(context.executionContextVariable);
 				context.writer.loadStringConstant(ParseHelpers.getStringForMapping(node.getMappingFactor()));
 				context.writer.invokeInstance(ExecutionContextMethods.getEvent);
+				context.writer.loadThis();
+				context.writer.loadInstanceField(context.codeGenerator.getTriggerField());
+				context.writer
+						.invokeStatic(Compiler.getRuntimeHelper("flagEvokingEvent", ArdenEvent.class, Trigger.class));
 				context.writer.storeInstanceField(e.field);
 			}
 

--- a/src/arden/compiler/EventVariable.java
+++ b/src/arden/compiler/EventVariable.java
@@ -78,8 +78,17 @@ final class EventVariable extends DataVariable {
 	public void callWithDelay(CompilerContext context, Token errorPosition, PExpr arguments, PExpr delay) {
 		context.writer.sequencePoint(errorPosition.getLine());
 		context.writer.loadVariable(context.executionContextVariable);
+
+		// set the event's EVENTTIME to the calling MLMs TRIGGERTIME
 		context.writer.loadThis();
 		context.writer.loadInstanceField(field);
+		context.writer.loadThis();
+		context.writer.loadInstanceField(context.codeGenerator.getNowField());
+		context.writer.loadThis();
+		context.writer.loadInstanceField(context.codeGenerator.getTriggerTimeField());
+		context.writer.invokeStatic(
+				Compiler.getRuntimeHelper("prepareForCall", ArdenEvent.class, ArdenValue.class, ArdenValue.class));
+
 		if (delay != null) {
 			delay.apply(new ExpressionCompiler(context));
 		} else {
@@ -89,7 +98,9 @@ final class EventVariable extends DataVariable {
 				throw new RuntimeCompilerException(errorPosition, "Could not create zero delay");
 			}
 		}
+
 		ActionCompiler.loadUrgency(context);
+
 		context.writer.invokeInstance(ExecutionContextMethods.callEvent);
 	}
 }

--- a/src/arden/compiler/ExecutionContextMethods.java
+++ b/src/arden/compiler/ExecutionContextMethods.java
@@ -34,6 +34,7 @@ import arden.runtime.ArdenRunnable;
 import arden.runtime.ArdenValue;
 import arden.runtime.ExecutionContext;
 import arden.runtime.ObjectType;
+import arden.runtime.evoke.Trigger;
 
 /** Contains references to the methods from the ExecutionContext class */
 final class ExecutionContextMethods {
@@ -59,7 +60,7 @@ final class ExecutionContextMethods {
 
 			write = ExecutionContext.class.getMethod("write", ArdenValue.class, ArdenValue.class, double.class);
 			call = ExecutionContext.class.getMethod("call", ArdenRunnable.class, ArdenValue[].class, ArdenValue.class,
-					double.class);
+					Trigger.class, double.class);
 			callEvent = ExecutionContext.class.getMethod("call", ArdenEvent.class, ArdenValue.class, double.class);
 
 			getCurrentTime = ExecutionContext.class.getMethod("getCurrentTime");

--- a/src/arden/compiler/ExecutionContextMethods.java
+++ b/src/arden/compiler/ExecutionContextMethods.java
@@ -41,7 +41,7 @@ final class ExecutionContextMethods {
 	public static final Method getMessage, getMessageAs, getDestination, getDestinationAs, getEvent;
 	public static final Method findModule, findModules, findInterface;
 	public static final Method write, call, callEvent;
-	public static final Method getEventTime, getTriggerTime, getCurrentTime;
+	public static final Method getCurrentTime;
 
 	static {
 		try {
@@ -62,8 +62,6 @@ final class ExecutionContextMethods {
 					double.class);
 			callEvent = ExecutionContext.class.getMethod("call", ArdenEvent.class, ArdenValue.class, double.class);
 
-			getEventTime = ExecutionContext.class.getMethod("getEventTime");
-			getTriggerTime = ExecutionContext.class.getMethod("getTriggerTime");
 			getCurrentTime = ExecutionContext.class.getMethod("getCurrentTime");
 		} catch (SecurityException e) {
 			throw new RuntimeException(e);

--- a/src/arden/compiler/ExpressionCompiler.java
+++ b/src/arden/compiler/ExpressionCompiler.java
@@ -966,15 +966,15 @@ final class ExpressionCompiler extends VisitorBase {
 	@Override
 	public void caseAEtimTimeValue(AEtimTimeValue node) {
 		// time_value = {etim} eventtime
-		context.writer.loadVariable(context.executionContextVariable);
-		context.writer.invokeInstance(ExecutionContextMethods.getEventTime);
+		context.writer.loadThis();
+		context.writer.loadInstanceField(context.codeGenerator.getEventTimeField());
 	}
 
 	@Override
 	public void caseATtimTimeValue(ATtimTimeValue node) {
 		// time_value = {ttim} triggertime
-		context.writer.loadVariable(context.executionContextVariable);
-		context.writer.invokeInstance(ExecutionContextMethods.getTriggerTime);
+		context.writer.loadThis();
+		context.writer.loadInstanceField(context.codeGenerator.getTriggerTimeField());
 	}
 
 	@Override

--- a/src/arden/runtime/ArdenEvent.java
+++ b/src/arden/runtime/ArdenEvent.java
@@ -1,12 +1,9 @@
 package arden.runtime;
 
-/**
- * Represents an <code>EVENT</code> object. Subclasses can customize the default
- * behavior, e.g. by overriding {@link #equals(Object)}.
- */
-public class ArdenEvent extends ArdenValue {
+/** Represents an <code>EVENT</code> object. */
+public final class ArdenEvent extends ArdenValue {
 	public final String name;
-	public boolean isEvokingEvent = false;
+	public final boolean isEvokingEvent;
 	/**
 	 * The <code>TIME OF an_event</code> (the primary time) is the clinically
 	 * relevant time, e.g. the time when a sample was taken. <br>
@@ -21,19 +18,29 @@ public class ArdenEvent extends ArdenValue {
 	public ArdenEvent(String name) {
 		super();
 		this.name = name;
-		this.eventTime = super.primaryTime;
+		this.eventTime = NOPRIMARYTIME;
+		this.isEvokingEvent = false;
 	}
 
 	public ArdenEvent(String name, long primaryTime) {
 		super(primaryTime);
 		this.name = name;
 		this.eventTime = primaryTime;
+		this.isEvokingEvent = false;
 	}
 
 	public ArdenEvent(String name, long primaryTime, long eventTime) {
 		super(primaryTime);
 		this.name = name;
 		this.eventTime = eventTime;
+		this.isEvokingEvent = false;
+	}
+
+	private ArdenEvent(String name, long primaryTime, long eventTime, boolean isEvokingEvent) {
+		super(primaryTime);
+		this.name = name;
+		this.eventTime = eventTime;
+		this.isEvokingEvent = true;
 	}
 
 	@Override
@@ -46,8 +53,8 @@ public class ArdenEvent extends ArdenValue {
 		return new ArdenEvent(name, newPrimaryTime);
 	}
 
-	public void setEvokingEvent(boolean isEvokingEvent) {
-		this.isEvokingEvent = isEvokingEvent;
+	public ArdenEvent setEvokingEvent(boolean isEvokingEvent) {
+		return new ArdenEvent(name, primaryTime, eventTime, isEvokingEvent);
 	}
 
 	@Override

--- a/src/arden/runtime/ArdenRunnable.java
+++ b/src/arden/runtime/ArdenRunnable.java
@@ -29,7 +29,9 @@ package arden.runtime;
 
 import java.lang.reflect.InvocationTargetException;
 
-/** 
+import arden.runtime.evoke.Trigger;
+
+/**
  * 
  * Represents an executable entity (example: MedicalLogicModule).
  * 
@@ -43,5 +45,6 @@ public interface ArdenRunnable {
 	 * @return Returns the value(s) provided by the "return" statement, or
 	 *         (Java) null if no return statement was executed.
 	 */
-	ArdenValue[] run(ExecutionContext context, ArdenValue[] arguments) throws InvocationTargetException;
+	ArdenValue[] run(ExecutionContext context, ArdenValue[] arguments, Trigger evokingTrigger)
+			throws InvocationTargetException;
 }

--- a/src/arden/runtime/BaseExecutionContext.java
+++ b/src/arden/runtime/BaseExecutionContext.java
@@ -176,15 +176,17 @@ public class BaseExecutionContext extends ExecutionContext {
 	}
 
 	@Override
-	public void call(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delay, Trigger trigger, double urgency) {
+	public void call(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delay, Trigger callerTrigger, double urgency) {
+		long delayMillis = ExecutionContextHelpers.delayToMillis(delay);
+		Trigger calleeTrigger = ExecutionContextHelpers.combine(callerTrigger, delayMillis);
 		if (engine != null) {
 			// run on engine
-			engine.callWithDelay(mlm, arguments, (int) urgency, ExecutionContextHelpers.delayToMillis(delay));
+			engine.call(mlm, arguments, delayMillis, calleeTrigger, (int) urgency);
 		} else {
 			// print delay and run now
 			System.out.println("delay (skipped): " + delay.toString());
 			try {
-				mlm.run(this, arguments, new CallTrigger(0));
+				mlm.run(this, arguments, calleeTrigger);
 			} catch (InvocationTargetException e) {
 				System.err.println("Could not run MLM:");
 				e.printStackTrace();
@@ -194,18 +196,20 @@ public class BaseExecutionContext extends ExecutionContext {
 
 	@Override
 	public void call(ArdenEvent event, ArdenValue delay, double urgency) {
+		long delayMillis = ExecutionContextHelpers.delayToMillis(delay);
+		ArdenEvent eventAfterDelay = ExecutionContextHelpers.combine(event, delayMillis);
 		if (engine != null) {
 			// run on engine
-			engine.callEvent(event, ExecutionContextHelpers.delayToMillis(delay));
+			engine.call(eventAfterDelay, delayMillis, (int) urgency);
 		} else {
 			// run MLMs for event now
-			ArdenRunnable[] mlms = findModules(event);
+			ArdenRunnable[] mlms = findModules(eventAfterDelay);
 			System.out.println("delay (skipped): " + delay.toString());
-			System.out.println("event: " + event.name);
+			System.out.println("event: " + eventAfterDelay.name);
 
 			for (ArdenRunnable mlm : mlms) {
 				try {
-					mlm.run(this, null, new CallTrigger(event, 0));
+					mlm.run(this, null, new CallTrigger(eventAfterDelay, 0));
 				} catch (InvocationTargetException e) {
 					System.err.println("Could not run MLM:");
 					e.printStackTrace();

--- a/src/arden/runtime/BaseExecutionContext.java
+++ b/src/arden/runtime/BaseExecutionContext.java
@@ -22,6 +22,8 @@ import arden.compiler.CompiledMlm;
 import arden.compiler.Compiler;
 import arden.compiler.CompilerException;
 import arden.runtime.MaintenanceMetadata.Validation;
+import arden.runtime.evoke.CallTrigger;
+import arden.runtime.evoke.EventTrigger;
 
 /**
  * <p>
@@ -182,7 +184,7 @@ public class BaseExecutionContext extends ExecutionContext {
 			// print delay and run now
 			System.out.println("delay (skipped): " + delay.toString());
 			try {
-				mlm.run(this, arguments);
+				mlm.run(this, arguments, new CallTrigger(0));
 			} catch (InvocationTargetException e) {
 				System.err.println("Could not run MLM:");
 				e.printStackTrace();
@@ -203,7 +205,7 @@ public class BaseExecutionContext extends ExecutionContext {
 
 			for (ArdenRunnable mlm : mlms) {
 				try {
-					mlm.run(this, null);
+					mlm.run(this, null, new EventTrigger(event));
 				} catch (InvocationTargetException e) {
 					System.err.println("Could not run MLM:");
 					e.printStackTrace();

--- a/src/arden/runtime/BaseExecutionContext.java
+++ b/src/arden/runtime/BaseExecutionContext.java
@@ -23,7 +23,7 @@ import arden.compiler.Compiler;
 import arden.compiler.CompilerException;
 import arden.runtime.MaintenanceMetadata.Validation;
 import arden.runtime.evoke.CallTrigger;
-import arden.runtime.evoke.EventTrigger;
+import arden.runtime.evoke.Trigger;
 
 /**
  * <p>
@@ -176,7 +176,7 @@ public class BaseExecutionContext extends ExecutionContext {
 	}
 
 	@Override
-	public void call(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delay, double urgency) {
+	public void call(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delay, Trigger trigger, double urgency) {
 		if (engine != null) {
 			// run on engine
 			engine.callWithDelay(mlm, arguments, (int) urgency, ExecutionContextHelpers.delayToMillis(delay));
@@ -205,7 +205,7 @@ public class BaseExecutionContext extends ExecutionContext {
 
 			for (ArdenRunnable mlm : mlms) {
 				try {
-					mlm.run(this, null, new EventTrigger(event));
+					mlm.run(this, null, new CallTrigger(event, 0));
 				} catch (InvocationTargetException e) {
 					System.err.println("Could not run MLM:");
 					e.printStackTrace();

--- a/src/arden/runtime/ExecutionContext.java
+++ b/src/arden/runtime/ExecutionContext.java
@@ -127,8 +127,7 @@ public abstract class ExecutionContext {
 	 *            The contents of the statement's mapping clause.
 	 * 
 	 * @return An {@link ArdenEvent}. If it is the event, that triggered the
-	 *         MLM, it should flagged as such with
-	 *         {@link ArdenEvent#setEvokingEvent(boolean)}.
+	 *         MLM, it will automatically flagged as such.
 	 */
 	public ArdenEvent getEvent(String mapping) {
 		return new ArdenEvent(mapping);

--- a/src/arden/runtime/ExecutionContext.java
+++ b/src/arden/runtime/ExecutionContext.java
@@ -231,23 +231,6 @@ public abstract class ExecutionContext {
 		throw new RuntimeException("Event call not implemented");
 	}
 
-	protected ArdenTime eventTime = new ArdenTime(new Date());
-	protected ArdenTime triggerTime = new ArdenTime(new Date());
-
-	/**
-	 * @return The <code>EVENTTIME</code>.
-	 */
-	public ArdenTime getEventTime() {
-		return eventTime;
-	}
-
-	/**
-	 * @return The <code>TRIGGERTIME</code>.
-	 */
-	public ArdenTime getTriggerTime() {
-		return triggerTime;
-	}
-
 	/**
 	 * @return The <code>CURRENTTIME</code>.
 	 */

--- a/src/arden/runtime/ExecutionContext.java
+++ b/src/arden/runtime/ExecutionContext.java
@@ -29,6 +29,8 @@ package arden.runtime;
 
 import java.util.Date;
 
+import arden.runtime.evoke.Trigger;
+
 /**
  * Describes the environment in which a Medical Logic Module is executed.
  * 
@@ -210,10 +212,14 @@ public abstract class ExecutionContext {
 	 * @param delay
 	 *            The delay for calling the MLM (as ArdenDuration).
 	 * 
+	 * @param trigger
+	 *            The calling MLMs trigger. Used to calculate the called MLMs
+	 *            <code>EVENTTIME</code> and <code>TRIGGERTIME</code>.
+	 * 
 	 * @param urgency
 	 *            The urgency from the MLMs urgency slot.
 	 */
-	public void call(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delay, double urgency) {
+	public void call(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delay, Trigger trigger, double urgency) {
 		throw new RuntimeException("MLM call not implemented");
 	}
 

--- a/src/arden/runtime/ExecutionContextHelpers.java
+++ b/src/arden/runtime/ExecutionContextHelpers.java
@@ -5,6 +5,8 @@ import java.util.PriorityQueue;
 import java.util.Queue;
 
 import arden.runtime.MaintenanceMetadata.Validation;
+import arden.runtime.evoke.CallTrigger;
+import arden.runtime.evoke.Trigger;
 
 public class ExecutionContextHelpers {
 
@@ -72,6 +74,19 @@ public class ExecutionContextHelpers {
 			return matches.peek();
 		}
 		return null;
+	}
+
+	public static Trigger combine(Trigger callingMlmsTrigger, long delay) {
+		ArdenEvent event = callingMlmsTrigger.getTriggeringEvent();
+		long combinedDelay = callingMlmsTrigger.getDelay() + delay;
+		return new CallTrigger(event, combinedDelay);
+	}
+
+	public static ArdenEvent combine(ArdenEvent event, long delay) {
+		if (event.eventTime == ArdenValue.NOPRIMARYTIME) {
+			throw new IllegalArgumentException("Event must have a valid EVENTTIME");
+		}
+		return new ArdenEvent(event.name, event.primaryTime, event.eventTime + delay);
 	}
 
 	public static long delayToMillis(ArdenValue delay) {

--- a/src/arden/runtime/MedicalLogicModule.java
+++ b/src/arden/runtime/MedicalLogicModule.java
@@ -31,7 +31,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import arden.runtime.evoke.Trigger;
 
-
 /**
  * Represents a compiled medical logic module.
  * 
@@ -56,15 +55,26 @@ public interface MedicalLogicModule extends ArdenRunnable {
 
 	/** Gets the urgency value of this module. */
 	double getUrgency();
-	
-	/** Gets the triggers telling when to run this MLM
-	 * @throws InvocationTargetException */
-	Trigger[] getTriggers(ExecutionContext context, ArdenValue[] arguments) throws InvocationTargetException;
-	
+
 	/**
-	 * Gets the value of a variable declared in a Medical Logic Module
-	 * @param name Name of the value in the MLM
-	 * @return the variable value or null if the MLM has not been run yet or the value does not exist, or ArdenNull if the variable is not yet initialized
+	 * Gets the triggers telling when to run this MLM. Requires running the data
+	 * slot to get event definitions.
+	 * 
+	 * @param context
+	 *            The execution context, which creates event definitions.
+	 * 
+	 * @throws InvocationTargetException
+	 */
+	Trigger[] getTriggers(ExecutionContext context) throws InvocationTargetException;
+
+	/**
+	 * Gets the value of a variable declared in a Medical Logic Module.
+	 * 
+	 * @param name
+	 *            Name of the value in the MLM.
+	 * @return The variable value or null if the MLM has not been run yet or the
+	 *         value does not exist. ArdenNull if the variable is not yet
+	 *         initialized.
 	 */
 	ArdenValue getValue(String name);
 }

--- a/src/arden/runtime/MedicalLogicModule.java
+++ b/src/arden/runtime/MedicalLogicModule.java
@@ -38,7 +38,7 @@ import arden.runtime.evoke.Trigger;
  */
 public interface MedicalLogicModule extends ArdenRunnable {
 	/** Creates a new instance of the implementation class. */
-	MedicalLogicModuleImplementation createInstance(ExecutionContext context, ArdenValue[] arguments)
+	MedicalLogicModuleImplementation createInstance(ExecutionContext context, ArdenValue[] arguments, Trigger evokingTrigger)
 			throws InvocationTargetException;
 
 	/** Gets the mlmname */

--- a/src/arden/runtime/MedicalLogicModuleImplementation.java
+++ b/src/arden/runtime/MedicalLogicModuleImplementation.java
@@ -38,7 +38,7 @@ import arden.runtime.evoke.Trigger;
 public abstract class MedicalLogicModuleImplementation {
 	// All derived classes are expected to have a constructor taking:
 	// (ExecutionContext context, MedicalLogicModule self, ArdenValue[]
-	// arguments)
+	// arguments, Trigger evokingTrigger)
 	// None of the arguments may be null.
 
 	/** Executes the logic block. */

--- a/src/arden/runtime/RuntimeHelpers.java
+++ b/src/arden/runtime/RuntimeHelpers.java
@@ -38,6 +38,7 @@ import java.util.GregorianCalendar;
 import java.util.List;
 
 import arden.runtime.evoke.CallTrigger;
+import arden.runtime.evoke.Trigger;
 
 
 /**
@@ -347,5 +348,27 @@ public final class RuntimeHelpers {
 				setObjectMember(listEntry, upperCaseFieldName, newValue);
 			}
 		}
+	}
+
+	public static ArdenValue getEventTime(Trigger trigger) {
+		ArdenEvent triggeringEvent = trigger.getTriggeringEvent();
+		if (triggeringEvent != null) {
+			long eventTime = triggeringEvent.eventTime;
+			if (eventTime != ArdenValue.NOPRIMARYTIME) {
+				return new ArdenTime(eventTime);
+			}
+		}
+		return ArdenNull.INSTANCE;
+	}
+
+	public static ArdenValue getTriggerTime(Trigger trigger) {
+		ArdenEvent triggeringEvent = trigger.getTriggeringEvent();
+		if (triggeringEvent != null) {
+			long eventTime = triggeringEvent.eventTime;
+			if (eventTime != ArdenValue.NOPRIMARYTIME) {
+				return new ArdenTime(eventTime + trigger.getDelay());
+			}
+		}
+		return ArdenNull.INSTANCE;
 	}
 }

--- a/src/arden/runtime/RuntimeHelpers.java
+++ b/src/arden/runtime/RuntimeHelpers.java
@@ -380,4 +380,12 @@ public final class RuntimeHelpers {
 			return (ArdenEvent) event.setTime(ArdenValue.NOPRIMARYTIME);
 		}
 	}
+
+	public static ArdenEvent flagEvokingEvent(ArdenEvent event, Trigger trigger) {
+		ArdenEvent triggeringEvent = trigger.getTriggeringEvent();
+		if (triggeringEvent != null && event.equals(triggeringEvent)) {
+			return triggeringEvent.setEvokingEvent(true);
+		}
+		return event;
+	}
 }

--- a/src/arden/runtime/RuntimeHelpers.java
+++ b/src/arden/runtime/RuntimeHelpers.java
@@ -55,10 +55,9 @@ public final class RuntimeHelpers {
 		}
 	}
 
-	public static ArdenValue[] call(ArdenRunnable mlm, ExecutionContext context, ArdenValue[] arguments) {
+	public static ArdenValue[] call(ArdenRunnable mlm, ExecutionContext context, ArdenValue[] arguments, Trigger trigger) {
 		try {
-			// TODO use correct trigger
-			return mlm.run(context, arguments, new CallTrigger());
+			return mlm.run(context, arguments, trigger);
 		} catch (InvocationTargetException e) {
 			throw new RuntimeException(e);
 		}

--- a/src/arden/runtime/RuntimeHelpers.java
+++ b/src/arden/runtime/RuntimeHelpers.java
@@ -37,6 +37,8 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 
+import arden.runtime.evoke.CallTrigger;
+
 
 /**
  * Static helper methods.
@@ -54,7 +56,8 @@ public final class RuntimeHelpers {
 
 	public static ArdenValue[] call(ArdenRunnable mlm, ExecutionContext context, ArdenValue[] arguments) {
 		try {
-			return mlm.run(context, arguments);
+			// TODO use correct trigger
+			return mlm.run(context, arguments, new CallTrigger());
 		} catch (InvocationTargetException e) {
 			throw new RuntimeException(e);
 		}
@@ -64,7 +67,7 @@ public final class RuntimeHelpers {
 		List<ArdenValue> returnValues = new ArrayList<>();
 		for (ArdenRunnable mlm : context.findModules(event)) {
 			try {
-				ArdenValue[] values = mlm.run(context, arguments);
+				ArdenValue[] values = mlm.run(context, arguments, new CallTrigger(event, 0));
 				// ignore single NULL
 				if (!(values.length == 1 && values[0] instanceof ArdenNull)) {
 					Collections.addAll(returnValues, values);

--- a/src/arden/runtime/RuntimeHelpers.java
+++ b/src/arden/runtime/RuntimeHelpers.java
@@ -370,4 +370,14 @@ public final class RuntimeHelpers {
 		}
 		return ArdenNull.INSTANCE;
 	}
+
+	public static ArdenEvent prepareForCall(ArdenEvent event, ArdenValue now, ArdenValue triggertime) {
+		if (triggertime instanceof ArdenTime) {
+			return (ArdenEvent) event.setTime(((ArdenTime) triggertime).value);
+		} else if (now instanceof ArdenTime) {
+			return (ArdenEvent) event.setTime(((ArdenTime) now).value);
+		} else {
+			return (ArdenEvent) event.setTime(ArdenValue.NOPRIMARYTIME);
+		}
+	}
 }

--- a/src/arden/runtime/evoke/AfterTrigger.java
+++ b/src/arden/runtime/evoke/AfterTrigger.java
@@ -8,11 +8,10 @@ import arden.runtime.ArdenEvent;
 import arden.runtime.ArdenTime;
 import arden.runtime.ExecutionContext;
 
-public class AfterTrigger implements Trigger {
-
-	Trigger target;
-	ArdenDuration duration;
-	SortedSet<ArdenTime> additionalSchedules;
+public final class AfterTrigger implements Trigger {
+	private final Trigger target;
+	private final ArdenDuration duration;
+	private final SortedSet<ArdenTime> additionalSchedules;
 
 	public AfterTrigger(ArdenDuration duration, Trigger target) {
 		this.duration = duration;
@@ -63,5 +62,4 @@ public class AfterTrigger implements Trigger {
 	public long getDelay() {
 		return target.getDelay() + (long) (duration.toSeconds() * 1000);
 	}
-
 }

--- a/src/arden/runtime/evoke/AfterTrigger.java
+++ b/src/arden/runtime/evoke/AfterTrigger.java
@@ -6,7 +6,6 @@ import java.util.TreeSet;
 import arden.runtime.ArdenDuration;
 import arden.runtime.ArdenEvent;
 import arden.runtime.ArdenTime;
-import arden.runtime.ExecutionContext;
 
 public final class AfterTrigger implements Trigger {
 	private final Trigger target;
@@ -20,8 +19,8 @@ public final class AfterTrigger implements Trigger {
 	}
 
 	@Override
-	public ArdenTime getNextRunTime(ExecutionContext context) {
-		ArdenTime nextRunTime = target.getNextRunTime(context);
+	public ArdenTime getNextRunTime() {
+		ArdenTime nextRunTime = target.getNextRunTime();
 		if (nextRunTime != null) {
 			nextRunTime = new ArdenTime(nextRunTime.add(duration));
 		}

--- a/src/arden/runtime/evoke/AnyTrigger.java
+++ b/src/arden/runtime/evoke/AnyTrigger.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import arden.runtime.ArdenEvent;
 import arden.runtime.ArdenTime;
-import arden.runtime.ExecutionContext;
 
 public final class AnyTrigger implements Trigger {
 	private final List<Trigger> triggers;
@@ -19,11 +18,11 @@ public final class AnyTrigger implements Trigger {
 	}
 
 	@Override
-	public ArdenTime getNextRunTime(ExecutionContext context) {
+	public ArdenTime getNextRunTime() {
 		// Find oldest trigger/event
 		ArdenTime oldest = null;
 		for (Trigger trigger : triggers) {
-			ArdenTime nextRunTime = trigger.getNextRunTime(context);
+			ArdenTime nextRunTime = trigger.getNextRunTime();
 			if (nextRunTime != null && (oldest == null || oldest.compareTo(nextRunTime) > 0)) {
 				oldest = nextRunTime;
 			}

--- a/src/arden/runtime/evoke/AnyTrigger.java
+++ b/src/arden/runtime/evoke/AnyTrigger.java
@@ -7,10 +7,8 @@ import arden.runtime.ArdenEvent;
 import arden.runtime.ArdenTime;
 import arden.runtime.ExecutionContext;
 
-public class AnyTrigger implements Trigger {
-
-	private Trigger activeTrigger = null;
-	private List<Trigger> triggers;
+public final class AnyTrigger implements Trigger {
+	private final List<Trigger> triggers;
 
 	public AnyTrigger(Trigger[] triggers) {
 		this.triggers = Arrays.asList(triggers);
@@ -55,7 +53,6 @@ public class AnyTrigger implements Trigger {
 		for (Trigger trigger : triggers) {
 			ArdenEvent triggeringEvent = trigger.getTriggeringEvent();
 			if (triggeringEvent != null) {
-				activeTrigger = trigger;
 				return triggeringEvent;
 			}
 		}
@@ -64,10 +61,12 @@ public class AnyTrigger implements Trigger {
 
 	@Override
 	public long getDelay() {
-		if (activeTrigger == null) {
-			return 0;
+		for (Trigger trigger : triggers) {
+			ArdenEvent triggeringEvent = trigger.getTriggeringEvent();
+			if (triggeringEvent != null) {
+				return trigger.getDelay();
+			}
 		}
-		return activeTrigger.getDelay();
+		return 0;
 	}
-
 }

--- a/src/arden/runtime/evoke/CallTrigger.java
+++ b/src/arden/runtime/evoke/CallTrigger.java
@@ -1,0 +1,49 @@
+package arden.runtime.evoke;
+
+import arden.runtime.ArdenEvent;
+import arden.runtime.ArdenTime;
+
+/** A special trigger, that implies that the MLM was called, by another MLM. */
+public final class CallTrigger implements Trigger {
+	private final ArdenEvent event;
+	private final long delay;
+
+	public CallTrigger(ArdenEvent event, long delay) {
+		this.event = event;
+		this.delay = delay;
+	}
+
+	public CallTrigger(long delay) {
+		this(null, delay);
+	}
+
+	public CallTrigger() {
+		this(null, 0);
+	}
+
+	@Override
+	public ArdenTime getNextRunTime() {
+		return null;
+	}
+
+	@Override
+	public boolean runOnEvent(ArdenEvent event) {
+		return false;
+	}
+
+	@Override
+	public void scheduleEvent(ArdenEvent event) {
+
+	}
+
+	@Override
+	public ArdenEvent getTriggeringEvent() {
+		return event;
+	}
+
+	@Override
+	public long getDelay() {
+		return delay;
+	}
+
+}

--- a/src/arden/runtime/evoke/CallTrigger.java
+++ b/src/arden/runtime/evoke/CallTrigger.java
@@ -12,6 +12,10 @@ public final class CallTrigger implements Trigger {
 		this.event = event;
 		this.delay = delay;
 	}
+	
+	public CallTrigger(ArdenEvent event) {
+		this(event, 0);
+	}
 
 	public CallTrigger(long delay) {
 		this(null, delay);

--- a/src/arden/runtime/evoke/CyclicTrigger.java
+++ b/src/arden/runtime/evoke/CyclicTrigger.java
@@ -7,7 +7,6 @@ import java.util.List;
 import arden.runtime.ArdenDuration;
 import arden.runtime.ArdenEvent;
 import arden.runtime.ArdenTime;
-import arden.runtime.ExecutionContext;
 
 public final class CyclicTrigger implements Trigger {
 	private final ArdenDuration interval;
@@ -23,9 +22,9 @@ public final class CyclicTrigger implements Trigger {
 	}
 
 	@Override
-	public ArdenTime getNextRunTime(ExecutionContext context) {
+	public ArdenTime getNextRunTime() {
 		// Check if the starting trigger has happened
-		ArdenTime startTime = starting.getNextRunTime(context);
+		ArdenTime startTime = starting.getNextRunTime();
 		if (startTime != null) {
 			ArdenTime end = new ArdenTime(startTime.add(length));
 			ScheduledCycle cycle = new ScheduledCycle(startTime, end);

--- a/src/arden/runtime/evoke/CyclicTrigger.java
+++ b/src/arden/runtime/evoke/CyclicTrigger.java
@@ -9,12 +9,11 @@ import arden.runtime.ArdenEvent;
 import arden.runtime.ArdenTime;
 import arden.runtime.ExecutionContext;
 
-public class CyclicTrigger implements Trigger {
-
-	private ArdenDuration interval;
-	private ArdenDuration length;
-	private Trigger starting;
-	private List<ScheduledCycle> scheduledCycles = new ArrayList<>();
+public final class CyclicTrigger implements Trigger {
+	private final ArdenDuration interval;
+	private final ArdenDuration length;
+	private final Trigger starting;
+	private final List<ScheduledCycle> scheduledCycles = new ArrayList<>();
 	private long currentDelay = 0;
 
 	public CyclicTrigger(ArdenDuration interval, ArdenDuration length, Trigger starting) {
@@ -42,9 +41,13 @@ public class CyclicTrigger implements Trigger {
 
 			// Calculate next run time
 			boolean sameTimeButNotStartTime = current.compareTo(cycle.next) == 0 && current.compareTo(cycle.start) != 0;
-			while (cycle.next.compareTo(cycle.end) <= 0 && ( // cycle has not ended
-						current.compareTo(cycle.next) > 0 // cycles next value lies in the past 
-						|| sameTimeButNotStartTime)) { // or value is same, but not the start (start is inclusive)
+			while (cycle.next.compareTo(cycle.end) <= 0 && ( // cycle has not
+																// ended
+			current.compareTo(cycle.next) > 0 // cycles next value lies in the
+												// past
+					|| sameTimeButNotStartTime)) { // or value is same, but not
+													// the start (start is
+													// inclusive)
 				cycle.next = new ArdenTime(cycle.next.add(interval));
 				cycle.nextReturned = false;
 			}
@@ -117,5 +120,4 @@ public class CyclicTrigger implements Trigger {
 			this.end = end;
 		}
 	}
-
 }

--- a/src/arden/runtime/evoke/EventTrigger.java
+++ b/src/arden/runtime/evoke/EventTrigger.java
@@ -4,9 +4,8 @@ import arden.runtime.ArdenEvent;
 import arden.runtime.ArdenTime;
 import arden.runtime.ExecutionContext;
 
-public class EventTrigger implements Trigger {
-
-	private ArdenEvent event;
+public final class EventTrigger implements Trigger {
+	private final ArdenEvent event;
 	private ArdenEvent triggeringEvent = null;
 
 	public EventTrigger(ArdenEvent event) {
@@ -41,5 +40,4 @@ public class EventTrigger implements Trigger {
 	public long getDelay() {
 		return 0;
 	}
-
 }

--- a/src/arden/runtime/evoke/EventTrigger.java
+++ b/src/arden/runtime/evoke/EventTrigger.java
@@ -2,7 +2,6 @@ package arden.runtime.evoke;
 
 import arden.runtime.ArdenEvent;
 import arden.runtime.ArdenTime;
-import arden.runtime.ExecutionContext;
 
 public final class EventTrigger implements Trigger {
 	private final ArdenEvent event;
@@ -16,7 +15,7 @@ public final class EventTrigger implements Trigger {
 	}
 
 	@Override
-	public ArdenTime getNextRunTime(ExecutionContext context) {
+	public ArdenTime getNextRunTime() {
 		return null;
 	}
 

--- a/src/arden/runtime/evoke/FixedDateTrigger.java
+++ b/src/arden/runtime/evoke/FixedDateTrigger.java
@@ -4,9 +4,8 @@ import arden.runtime.ArdenEvent;
 import arden.runtime.ArdenTime;
 import arden.runtime.ExecutionContext;
 
-public class FixedDateTrigger implements Trigger {
-
-	private ArdenTime date;
+public final class FixedDateTrigger implements Trigger {
+	private final ArdenTime date;
 	protected boolean triggered = false;
 
 	public FixedDateTrigger(ArdenTime date) {
@@ -42,5 +41,4 @@ public class FixedDateTrigger implements Trigger {
 	public long getDelay() {
 		return 0;
 	}
-
 }

--- a/src/arden/runtime/evoke/FixedDateTrigger.java
+++ b/src/arden/runtime/evoke/FixedDateTrigger.java
@@ -2,7 +2,6 @@ package arden.runtime.evoke;
 
 import arden.runtime.ArdenEvent;
 import arden.runtime.ArdenTime;
-import arden.runtime.ExecutionContext;
 
 public final class FixedDateTrigger implements Trigger {
 	private final ArdenTime date;
@@ -13,7 +12,7 @@ public final class FixedDateTrigger implements Trigger {
 	}
 
 	@Override
-	public ArdenTime getNextRunTime(ExecutionContext context) {
+	public ArdenTime getNextRunTime() {
 		if (triggered) {
 			// Don't run again
 			return null;

--- a/src/arden/runtime/evoke/Trigger.java
+++ b/src/arden/runtime/evoke/Trigger.java
@@ -30,7 +30,7 @@ public interface Trigger {
 	 * 
 	 * @return The next run time or null if there is no next run time.
 	 */
-	public ArdenTime getNextRunTime(ExecutionContext context);
+	public ArdenTime getNextRunTime();
 
 	/**
 	 * Whether to immediately (no delay) run for an external event such as

--- a/src/arden/runtime/evoke/Trigger.java
+++ b/src/arden/runtime/evoke/Trigger.java
@@ -5,7 +5,6 @@ import arden.runtime.ArdenTime;
 import arden.runtime.ExecutionContext;
 
 public interface Trigger {
-
 	/**
 	 * <p>
 	 * Calculates when the trigger should run next. Triggers are stateful, i.e.

--- a/src/arden/runtime/evoke/Trigger.java
+++ b/src/arden/runtime/evoke/Trigger.java
@@ -18,15 +18,14 @@ public interface Trigger {
 	 * 
 	 * <pre>
 	 * {@code
-	 * EVERY 5 MINUTES FOR 1 HOUR STARTING TIME OF an_event
+	 * EVERY 10 MINUTES FOR 1 HOUR STARTING TIME OF an_event;
 	 * }
 	 * </pre>
 	 * 
 	 * will return <code>null</code> until <code>an_event</code> has happened.
-	 * Immediately after the event it will return the time of the event. It will
-	 * then return <code>null</code> until 5 minutes have passed. Then it will
-	 * return the time of the event + 5 minutes. After that it will return
-	 * <code>null</code> again until another 5 minutes have passed, etc.
+	 * After the event it will return the time of the event. Then it will return
+	 * the time of the event + 10 minutes, etc. On the 8th call it will return
+	 * <code>null</code> again, as the cycle has finished.
 	 * </p>
 	 * 
 	 * @return The next run time or null if there is no next run time.

--- a/src/arden/runtime/evoke/UntilTrigger.java
+++ b/src/arden/runtime/evoke/UntilTrigger.java
@@ -4,9 +4,9 @@ import arden.runtime.ArdenEvent;
 import arden.runtime.ArdenTime;
 import arden.runtime.ExecutionContext;
 
-public class UntilTrigger implements Trigger {
-	private Trigger cycle;
-	private ArdenTime until; // FIXME Should be a boolean expression
+public final class UntilTrigger implements Trigger {
+	private final Trigger cycle;
+	private final ArdenTime until; // FIXME Should be a boolean expression
 
 	public UntilTrigger(Trigger cycle, ArdenTime until) {
 		this.cycle = cycle;
@@ -40,5 +40,4 @@ public class UntilTrigger implements Trigger {
 	public long getDelay() {
 		return cycle.getDelay();
 	}
-
 }

--- a/src/arden/runtime/evoke/UntilTrigger.java
+++ b/src/arden/runtime/evoke/UntilTrigger.java
@@ -2,7 +2,6 @@ package arden.runtime.evoke;
 
 import arden.runtime.ArdenEvent;
 import arden.runtime.ArdenTime;
-import arden.runtime.ExecutionContext;
 
 public final class UntilTrigger implements Trigger {
 	private final Trigger cycle;
@@ -14,8 +13,8 @@ public final class UntilTrigger implements Trigger {
 	}
 
 	@Override
-	public ArdenTime getNextRunTime(ExecutionContext context) {
-		ArdenTime next = cycle.getNextRunTime(context);
+	public ArdenTime getNextRunTime() {
+		ArdenTime next = cycle.getNextRunTime();
 		if (until.compareTo(next) > 0) {
 			return next;
 		}

--- a/test/arden/tests/implementation/EvokeTest.java
+++ b/test/arden/tests/implementation/EvokeTest.java
@@ -275,28 +275,13 @@ public class EvokeTest extends ImplementationTest {
 	}
 
 	@Test
-	public void testCyclicEventBeginningInThePast() throws Exception {
-		TestContext context = new TestContext(createDate(1990, 0, 1));
-
-		CompiledMlm mlm = parseEvoke("every 5 days for 10 years starting 5 days after 1989-03-04");
-		Trigger trigger = mlm.getTriggers(context)[0];
-		Assert.assertTrue(trigger instanceof CyclicTrigger);
-
-		Assert.assertEquals(createDate(1990, 0, 3), trigger.getNextRunTime(context));
-		Assert.assertNull(trigger.getNextRunTime(context));
-
-		context.setCurrentTime(createDate(1990, 0, 4));
-		Assert.assertEquals(createDate(1990, 0, 8), trigger.getNextRunTime(context));
-	}
-	
-	@Test
 	public void testCyclicAnyEvents() throws Exception {
 		TestContext context = new TestContext(createDate(1990, 0, 1));
 		MedicalLogicModule mlm = parseEvoke(
 						"event1 := EVENT{test 1};"
 						+ "event2 := EVENT{test 2};"
 						+ "event3 := EVENT{test 3};",
-				"every 5 days for 10 years starting time of any of (event1, event2, event3)");
+				"every 5 days for 10 days starting time of any of (event1, event2, event3)");
 		Trigger trigger = mlm.getTriggers(context)[0];
 		Assert.assertTrue(trigger instanceof CyclicTrigger);
 		
@@ -304,9 +289,8 @@ public class EvokeTest extends ImplementationTest {
 		trigger.scheduleEvent(event);
 
 		Assert.assertEquals(createDate(1990, 0, 1), trigger.getNextRunTime(context));
-		Assert.assertNull(trigger.getNextRunTime(context));
-
-		context.setCurrentTime(createDate(1990, 0, 3));
 		Assert.assertEquals(createDate(1990, 0, 6), trigger.getNextRunTime(context));
+		Assert.assertEquals(createDate(1990, 0, 11), trigger.getNextRunTime(context));
+		Assert.assertNull(trigger.getNextRunTime(context));
 	}
 }

--- a/test/arden/tests/implementation/EvokeTest.java
+++ b/test/arden/tests/implementation/EvokeTest.java
@@ -80,7 +80,7 @@ public class EvokeTest extends ImplementationTest {
 		MedicalLogicModule mlm = parseEvoke("3 days after 1992-01-01T00:00:00");
 
 		Trigger trigger = mlm.getTriggers(context)[0];
-		Assert.assertEquals(createDate(1992, 0, 4), trigger.getNextRunTime(context));
+		Assert.assertEquals(createDate(1992, 0, 4), trigger.getNextRunTime());
 		Assert.assertNull(trigger.getTriggeringEvent());
 	}
 
@@ -109,7 +109,7 @@ public class EvokeTest extends ImplementationTest {
 		trigger.scheduleEvent(event);
 		Assert.assertEquals(event, trigger.getTriggeringEvent());
 
-		Assert.assertEquals(createDate(1992, 0, 4), trigger.getNextRunTime(context));
+		Assert.assertEquals(createDate(1992, 0, 4), trigger.getNextRunTime());
 	}
 
 	@Test
@@ -124,7 +124,7 @@ public class EvokeTest extends ImplementationTest {
 		trigger.scheduleEvent(event);
 		Assert.assertEquals(event, trigger.getTriggeringEvent());
 
-		Assert.assertEquals(createDate(1992, 0, 6), trigger.getNextRunTime(context));
+		Assert.assertEquals(createDate(1992, 0, 6), trigger.getNextRunTime());
 		Assert.assertEquals(1000 * 60 * 60 * 24 * 5, trigger.getDelay());
 	}
 
@@ -135,7 +135,7 @@ public class EvokeTest extends ImplementationTest {
 		MedicalLogicModule mlm = parseEvoke("1992-03-04");
 		Trigger trigger = mlm.getTriggers(context)[0];
 
-		Assert.assertEquals(createDate(1992, 2, 4), trigger.getNextRunTime(context));
+		Assert.assertEquals(createDate(1992, 2, 4), trigger.getNextRunTime());
 	}
 
 	@Test
@@ -145,7 +145,7 @@ public class EvokeTest extends ImplementationTest {
 		MedicalLogicModule mlm = parseEvoke("1992-01-03T14:23:17.0");
 		Trigger trigger = mlm.getTriggers(context)[0];
 
-		Assert.assertEquals(createDateTime(1992, 0, 3, 14, 23, 17), trigger.getNextRunTime(context));
+		Assert.assertEquals(createDateTime(1992, 0, 3, 14, 23, 17), trigger.getNextRunTime());
 
 		Assert.assertNull(trigger.getTriggeringEvent());
 	}
@@ -219,7 +219,7 @@ public class EvokeTest extends ImplementationTest {
 		Trigger trigger = mlm.getTriggers(context)[0];
 
 		Assert.assertTrue(trigger instanceof AfterTrigger);
-		Assert.assertEquals(null, trigger.getNextRunTime(context));
+		Assert.assertEquals(null, trigger.getNextRunTime());
 
 		ArdenEvent event = new ArdenEvent("test", context.getCurrentTime().value);
 		Assert.assertFalse(trigger.runOnEvent(event));
@@ -228,7 +228,7 @@ public class EvokeTest extends ImplementationTest {
 		Assert.assertFalse(trigger.runOnEvent(event));
 		Assert.assertEquals(event, trigger.getTriggeringEvent());
 		Assert.assertEquals(1000 * 60 * 60 * 24 * 3, trigger.getDelay());
-		Assert.assertEquals(createDate(1990, 0, 4), trigger.getNextRunTime(context));
+		Assert.assertEquals(createDate(1990, 0, 4), trigger.getNextRunTime());
 	}
 
 	@Test
@@ -239,9 +239,9 @@ public class EvokeTest extends ImplementationTest {
 		Trigger trigger = mlm.getTriggers(context)[0];
 		Assert.assertTrue(trigger instanceof CyclicTrigger);
 
-		Assert.assertEquals(createDate(1992, 2, 9), trigger.getNextRunTime(context));
+		Assert.assertEquals(createDate(1992, 2, 9), trigger.getNextRunTime());
 		context.setCurrentTime(createDate(1992, 2, 10));
-		Assert.assertEquals(createDate(1992, 2, 14), trigger.getNextRunTime(context));
+		Assert.assertEquals(createDate(1992, 2, 14), trigger.getNextRunTime());
 	}
 
 	@Test
@@ -254,22 +254,22 @@ public class EvokeTest extends ImplementationTest {
 		ArdenEvent event = new ArdenEvent("test", context.getCurrentTime().value);
 
 		trigger.scheduleEvent(event);
-		Assert.assertEquals(createDate(1990, 0, 4), trigger.getNextRunTime(context));
+		Assert.assertEquals(createDate(1990, 0, 4), trigger.getNextRunTime());
 		Assert.assertEquals(event, trigger.getTriggeringEvent());
 		Assert.assertEquals(1000 * 60 * 60 * 24 * 3, trigger.getDelay());
 
 		context.setCurrentTime(createDateTime(1990, 0, 4, 0, 0, 1));
-		Assert.assertEquals(createDate(1990, 0, 5), trigger.getNextRunTime(context));
+		Assert.assertEquals(createDate(1990, 0, 5), trigger.getNextRunTime());
 		Assert.assertEquals(event, trigger.getTriggeringEvent());
 		Assert.assertEquals(1000 * 60 * 60 * 24 * 4, trigger.getDelay());
 
 		context.setCurrentTime(createDateTime(1990, 0, 5, 0, 0, 1));
-		Assert.assertEquals(createDate(1990, 0, 6), trigger.getNextRunTime(context));
+		Assert.assertEquals(createDate(1990, 0, 6), trigger.getNextRunTime());
 		Assert.assertEquals(event, trigger.getTriggeringEvent());
 		Assert.assertEquals(1000 * 60 * 60 * 24 * 5, trigger.getDelay());
 
 		context.setCurrentTime(createDateTime(1990, 0, 6, 0, 0, 1));
-		Assert.assertNull(trigger.getNextRunTime(context));
+		Assert.assertNull(trigger.getNextRunTime());
 
 		trigger.scheduleEvent(event);
 	}
@@ -288,9 +288,9 @@ public class EvokeTest extends ImplementationTest {
 		ArdenEvent event = new ArdenEvent("test 2", context.getCurrentTime().value);
 		trigger.scheduleEvent(event);
 
-		Assert.assertEquals(createDate(1990, 0, 1), trigger.getNextRunTime(context));
-		Assert.assertEquals(createDate(1990, 0, 6), trigger.getNextRunTime(context));
-		Assert.assertEquals(createDate(1990, 0, 11), trigger.getNextRunTime(context));
-		Assert.assertNull(trigger.getNextRunTime(context));
+		Assert.assertEquals(createDate(1990, 0, 1), trigger.getNextRunTime());
+		Assert.assertEquals(createDate(1990, 0, 6), trigger.getNextRunTime());
+		Assert.assertEquals(createDate(1990, 0, 11), trigger.getNextRunTime());
+		Assert.assertNull(trigger.getNextRunTime());
 	}
 }

--- a/test/arden/tests/implementation/EvokeTest.java
+++ b/test/arden/tests/implementation/EvokeTest.java
@@ -79,7 +79,7 @@ public class EvokeTest extends ImplementationTest {
 
 		MedicalLogicModule mlm = parseEvoke("3 days after 1992-01-01T00:00:00");
 
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 		Assert.assertEquals(createDate(1992, 0, 4), trigger.getNextRunTime(context));
 		Assert.assertNull(trigger.getTriggeringEvent());
 	}
@@ -89,7 +89,7 @@ public class EvokeTest extends ImplementationTest {
 		TestContext context = new TestContext();
 
 		MedicalLogicModule mlm = parseEvoke("penicillin_storage := EVENT{penicillin storage}", "penicillin_storage");
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 
 		ArdenEvent event = new ArdenEvent("penicillin storage");
 		Assert.assertTrue(trigger.runOnEvent(event));
@@ -102,7 +102,7 @@ public class EvokeTest extends ImplementationTest {
 		TestContext context = new TestContext();
 
 		CompiledMlm mlm = parseEvoke("event1 := EVENT{penicillin storage}", "3 days after time of event1");
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 		ArdenEvent event = new ArdenEvent("penicillin storage", createDate(1992, 0, 1).value);
 
 		Assert.assertFalse(trigger.runOnEvent(event));
@@ -117,7 +117,7 @@ public class EvokeTest extends ImplementationTest {
 		TestContext context = new TestContext();
 
 		CompiledMlm mlm = parseEvoke("event1 := EVENT{penicillin storage}", "3 days after 2 days after time of event1");
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 		ArdenEvent event = new ArdenEvent("penicillin storage", createDate(1992, 0, 1).value);
 
 		Assert.assertFalse(trigger.runOnEvent(event));
@@ -133,7 +133,7 @@ public class EvokeTest extends ImplementationTest {
 		TestContext context = new TestContext();
 
 		MedicalLogicModule mlm = parseEvoke("1992-03-04");
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 
 		Assert.assertEquals(createDate(1992, 2, 4), trigger.getNextRunTime(context));
 	}
@@ -143,7 +143,7 @@ public class EvokeTest extends ImplementationTest {
 		TestContext context = new TestContext();
 
 		MedicalLogicModule mlm = parseEvoke("1992-01-03T14:23:17.0");
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 
 		Assert.assertEquals(createDateTime(1992, 0, 3, 14, 23, 17), trigger.getNextRunTime(context));
 
@@ -159,7 +159,7 @@ public class EvokeTest extends ImplementationTest {
 						+ "cephalosporin_storage := EVENT{cephalosporin storage};"
 						+ "aminoglycoside_storage := EVENT{aminoglycoside storage};",
 				"penicillin_storage OR cephalosporin_storage OR aminoglycoside_storage");
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 
 		Assert.assertFalse(trigger.runOnEvent(new ArdenEvent("other storage")));
 		Assert.assertTrue(trigger.runOnEvent(new ArdenEvent("aminoglycoside storage")));
@@ -180,7 +180,7 @@ public class EvokeTest extends ImplementationTest {
 						+ "cephalosporin_storage := EVENT{cephalosporin storage};"
 						+ "aminoglycoside_storage := EVENT{aminoglycoside storage};",
 				"ANY OF (penicillin_storage, cephalosporin_storage, aminoglycoside_storage)");
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 
 		Assert.assertFalse(trigger.runOnEvent(new ArdenEvent("other storage")));
 		Assert.assertTrue(trigger.runOnEvent(new ArdenEvent("aminoglycoside storage")));
@@ -200,7 +200,7 @@ public class EvokeTest extends ImplementationTest {
 				"cephalosporin_storage := EVENT{cephalosporin storage};"
 						+ "aminoglycoside_storage := EVENT{aminoglycoside storage};",
 				"ANY OF (cephalosporin_storage, aminoglycoside_storage)");
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 
 		Assert.assertFalse(trigger.runOnEvent(new ArdenEvent("other storage")));
 		Assert.assertTrue(trigger.runOnEvent(new ArdenEvent("cephalosporin storage")));
@@ -216,7 +216,7 @@ public class EvokeTest extends ImplementationTest {
 		TestContext context = new TestContext(createDate(1990, 0, 1));
 
 		CompiledMlm mlm = parseEvoke("event1 := EVENT{test}", "3 days after time of event1");
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 
 		Assert.assertTrue(trigger instanceof AfterTrigger);
 		Assert.assertEquals(null, trigger.getNextRunTime(context));
@@ -236,7 +236,7 @@ public class EvokeTest extends ImplementationTest {
 		TestContext context = new TestContext(createDate(1990, 0, 1));
 
 		CompiledMlm mlm = parseEvoke("every 5 days for 10 years starting 5 days after 1992-03-04");
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 		Assert.assertTrue(trigger instanceof CyclicTrigger);
 
 		Assert.assertEquals(createDate(1992, 2, 9), trigger.getNextRunTime(context));
@@ -250,7 +250,7 @@ public class EvokeTest extends ImplementationTest {
 
 		CompiledMlm mlm = parseEvoke("event1 := EVENT{test}",
 				"every 1 day for 2 days starting 3 days after time of event1");
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 		ArdenEvent event = new ArdenEvent("test", context.getCurrentTime().value);
 
 		trigger.scheduleEvent(event);
@@ -279,7 +279,7 @@ public class EvokeTest extends ImplementationTest {
 		TestContext context = new TestContext(createDate(1990, 0, 1));
 
 		CompiledMlm mlm = parseEvoke("every 5 days for 10 years starting 5 days after 1989-03-04");
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 		Assert.assertTrue(trigger instanceof CyclicTrigger);
 
 		Assert.assertEquals(createDate(1990, 0, 3), trigger.getNextRunTime(context));
@@ -297,7 +297,7 @@ public class EvokeTest extends ImplementationTest {
 						+ "event2 := EVENT{test 2};"
 						+ "event3 := EVENT{test 3};",
 				"every 5 days for 10 years starting time of any of (event1, event2, event3)");
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 		Assert.assertTrue(trigger instanceof CyclicTrigger);
 		
 		ArdenEvent event = new ArdenEvent("test 2", context.getCurrentTime().value);

--- a/test/arden/tests/implementation/ExampleEvokeTest.java
+++ b/test/arden/tests/implementation/ExampleEvokeTest.java
@@ -51,7 +51,7 @@ public class ExampleEvokeTest extends ImplementationTest {
 		MedicalLogicModule mlm = compile("x3.1.mlm");
 
 		TestContext context = new TestContext();
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 
 		Assert.assertTrue(trigger instanceof EventTrigger);
 		ArdenEvent event = new ArdenEvent("storage of urine electrolytes", context.getCurrentTime().value);
@@ -63,7 +63,7 @@ public class ExampleEvokeTest extends ImplementationTest {
 		MedicalLogicModule mlm = compile("x3.2.mlm");
 
 		TestContext context = new TestContext();
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 
 		Assert.assertTrue(trigger instanceof EventTrigger);
 		ArdenEvent event = new ArdenEvent("'06210519','06210669'", context.getCurrentTime().value);
@@ -74,7 +74,7 @@ public class ExampleEvokeTest extends ImplementationTest {
 	public void x33noAllergies() throws Exception {
 		MedicalLogicModule mlm = compile("x3.3.mlm");
 		TestContext context = new TestContext();
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 		
 		Assert.assertTrue(trigger instanceof EventTrigger);
 		ArdenEvent event = new ArdenEvent("medication_order where class = penicillin", context.getCurrentTime().value);
@@ -92,7 +92,7 @@ public class ExampleEvokeTest extends ImplementationTest {
 				return new MemoryQuery(new ArdenValue[] { list });
 			}
 		};
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 		
 		Assert.assertTrue(trigger instanceof EventTrigger);
 		ArdenEvent event = new ArdenEvent("medication_order where class = penicillin", context.getCurrentTime().value);
@@ -110,7 +110,7 @@ public class ExampleEvokeTest extends ImplementationTest {
 				return new MemoryQuery(new ArdenValue[] { list });
 			}
 		};
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 		
 		Assert.assertTrue(trigger instanceof EventTrigger);
 		ArdenEvent event = new ArdenEvent("medication_order where class = penicillin", context.getCurrentTime().value);
@@ -122,7 +122,7 @@ public class ExampleEvokeTest extends ImplementationTest {
 		MedicalLogicModule mlm = compile("x3.4.mlm");
 
 		TestContext context = new TestContext();
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 
 		Assert.assertTrue(trigger instanceof EventTrigger);
 		ArdenEvent event = new ArdenEvent("medication_order where class = gentamicin", context.getCurrentTime().value);
@@ -137,7 +137,7 @@ public class ExampleEvokeTest extends ImplementationTest {
 		ArdenEvent defaultEvent = new ArdenEvent("gentamicin_order", defaultEventDate.value);
 
 		TestContext context = new TestContext(defaultEvent, defaultTime);
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 
 		Assert.assertTrue(trigger instanceof CyclicTrigger);
 		
@@ -168,7 +168,7 @@ public class ExampleEvokeTest extends ImplementationTest {
 		MedicalLogicModule mlm = compile("x3.6.mlm");
 
 		TestContext context = new TestContext();
-		Trigger trigger = mlm.getTriggers(context, null)[0];
+		Trigger trigger = mlm.getTriggers(context)[0];
 
 		Assert.assertTrue(trigger instanceof EventTrigger);
 		ArdenEvent event = new ArdenEvent("STORAGE OF ABSOLUTE_NEUTROPHILE_COUNT", context.getCurrentTime().value);
@@ -180,7 +180,7 @@ public class ExampleEvokeTest extends ImplementationTest {
 		MedicalLogicModule mlm = compile("x3.7.mlm");
 
 		TestContext context = new TestContext();
-		Trigger[] triggers = mlm.getTriggers(context, null);
+		Trigger[] triggers = mlm.getTriggers(context);
 
 		Assert.assertTrue(triggers.length == 0);
 	}
@@ -188,20 +188,8 @@ public class ExampleEvokeTest extends ImplementationTest {
 	@Test
 	public void x38() throws Exception {
 		MedicalLogicModule mlm = compile("x3.8.mlm");
-
 		TestContext context = new TestContext();
-		ArdenList medOrders = new ArdenList(new ArdenValue[] { new ArdenString("order1"), new ArdenString("order2"),
-				new ArdenString("order3") });
-		ArdenList medAllergens = new ArdenList(new ArdenValue[] { new ArdenString("a1"), new ArdenString("a2"),
-				new ArdenString("a3") });
-		ArdenList patientAllergies = new ArdenList(new ArdenValue[] { new ArdenString("a2"), new ArdenString("a2"),
-				new ArdenString("a1") });
-		ArdenList patientReactions = new ArdenList(new ArdenValue[] { new ArdenString("r1"), new ArdenString("r2"),
-				new ArdenString("r3") });
-
-		Trigger[] triggers = mlm.getTriggers(context, new ArdenValue[] { medOrders, medAllergens, patientAllergies,
-				patientReactions });
-
+		Trigger[] triggers = mlm.getTriggers(context);
 		Assert.assertTrue(triggers.length == 0);
 	}
 }

--- a/test/arden/tests/implementation/ExampleEvokeTest.java
+++ b/test/arden/tests/implementation/ExampleEvokeTest.java
@@ -151,7 +151,7 @@ public class ExampleEvokeTest extends ImplementationTest {
 		// default runtime should be 5 days after the event as declared in the MLM:
 		Assert.assertEquals(
 				fiveDaysLater, 
-				trigger.getNextRunTime(context));
+				trigger.getNextRunTime());
 
 		ArdenTime tenDaysLater = new ArdenTime(fiveDaysLater.add(fiveDays));
 		ArdenDuration oneSecond = (ArdenDuration)ArdenDuration.create(1, false, context.getCurrentTime().value);
@@ -160,7 +160,7 @@ public class ExampleEvokeTest extends ImplementationTest {
 		// after the first runtime has been passed, the mlm should be re-run another 5 days later:
 		Assert.assertEquals(
 				tenDaysLater,
-				trigger.getNextRunTime(context)); 
+				trigger.getNextRunTime());
 	}
 
 	@Test

--- a/test/arden/tests/implementation/ExampleTest.java
+++ b/test/arden/tests/implementation/ExampleTest.java
@@ -36,7 +36,9 @@ import arden.runtime.ArdenString;
 import arden.runtime.ArdenValue;
 import arden.runtime.DatabaseQuery;
 import arden.runtime.MedicalLogicModule;
+import arden.runtime.MedicalLogicModuleImplementation;
 import arden.runtime.MemoryQuery;
+import arden.runtime.evoke.CallTrigger;
 
 public class ExampleTest extends ImplementationTest {
 	
@@ -45,7 +47,7 @@ public class ExampleTest extends ImplementationTest {
 		MedicalLogicModule mlm = compile("x3.1.mlm");
 
 		TestContext context = new TestContext();
-		mlm.run(context, null);
+		mlm.run(context, null, new CallTrigger());
 
 		Assert.assertEquals("", context.getOutputText());
 	}
@@ -55,7 +57,7 @@ public class ExampleTest extends ImplementationTest {
 		MedicalLogicModule mlm = compile("x3.2.mlm");
 
 		TestContext context = new TestContext();
-		mlm.run(context, null);
+		mlm.run(context, null, new CallTrigger());
 
 		Assert.assertEquals("", context.getOutputText());
 	}
@@ -64,7 +66,7 @@ public class ExampleTest extends ImplementationTest {
 	public void x33noAllergies() throws Exception {
 		MedicalLogicModule mlm = compile("x3.3.mlm");
 		TestContext context = new TestContext();
-		mlm.run(context, null);
+		mlm.run(context, null, new CallTrigger());
 		Assert.assertEquals("", context.getOutputText());
 	}
 
@@ -79,7 +81,7 @@ public class ExampleTest extends ImplementationTest {
 				return new MemoryQuery(new ArdenValue[] { list });
 			}
 		};
-		mlm.run(context, null);
+		mlm.run(context, null, new CallTrigger());
 		Assert.assertEquals("Caution, the patient has the following allergy to penicillin documented: all2\n", context
 				.getOutputText());
 	}
@@ -95,14 +97,15 @@ public class ExampleTest extends ImplementationTest {
 				return new MemoryQuery(new ArdenValue[] { list });
 			}
 		};
-		mlm.run(context, null);
+		mlm.run(context, null, new CallTrigger());
 		Assert.assertEquals("", context.getOutputText());
 	}
 
 	@Test
 	public void x33urgency() throws Exception {
 		MedicalLogicModule mlm = compile("x3.3.mlm");
-		Assert.assertEquals(51.0, mlm.createInstance(new TestContext(), null).getUrgency(), 0);
+		MedicalLogicModuleImplementation instance = mlm.createInstance(new TestContext(), null, new CallTrigger());
+		Assert.assertEquals(51.0, instance.getUrgency(), 0);
 	}
 
 	@Test
@@ -110,7 +113,7 @@ public class ExampleTest extends ImplementationTest {
 		MedicalLogicModule mlm = compile("x3.4.mlm");
 
 		TestContext context = new TestContext();
-		mlm.run(context, null);
+		mlm.run(context, null, new CallTrigger());
 
 		Assert.assertEquals("", context.getOutputText());
 	}
@@ -120,7 +123,7 @@ public class ExampleTest extends ImplementationTest {
 		MedicalLogicModule mlm = compile("x3.5.mlm");
 
 		TestContext context = new TestContext();
-		mlm.run(context, null);
+		mlm.run(context, null, new CallTrigger());
 
 		Assert.assertEquals(
 				"Suggest obtaining a serum creatinine to follow up on renal function in the setting of gentamicin.\n",
@@ -132,7 +135,7 @@ public class ExampleTest extends ImplementationTest {
 		MedicalLogicModule mlm = compile("x3.6.mlm");
 
 		TestContext context = new TestContext();
-		mlm.run(context, null);
+		mlm.run(context, null, new CallTrigger());
 
 		Assert.assertEquals("", context.getOutputText());
 	}
@@ -142,7 +145,7 @@ public class ExampleTest extends ImplementationTest {
 		MedicalLogicModule mlm = compile("x3.7.mlm");
 
 		TestContext context = new TestContext();
-		mlm.run(context, null);
+		mlm.run(context, null, new CallTrigger());
 
 		Assert.assertEquals("", context.getOutputText());
 	}
@@ -161,7 +164,7 @@ public class ExampleTest extends ImplementationTest {
 		ArdenList patientReactions = new ArdenList(new ArdenValue[] { new ArdenString("r1"), new ArdenString("r2"),
 				new ArdenString("r3") });
 		ArdenValue[] result = mlm.run(context, new ArdenValue[] { medOrders, medAllergens, patientAllergies,
-				patientReactions });
+				patientReactions }, new CallTrigger());
 		Assert.assertEquals(3, result.length);
 
 		Assert.assertEquals("(\"order1\",\"order2\")", result[0].toString());

--- a/test/arden/tests/implementation/GetValueTest.java
+++ b/test/arden/tests/implementation/GetValueTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import arden.runtime.ArdenNumber;
 import arden.runtime.ArdenValue;
 import arden.runtime.MedicalLogicModule;
+import arden.runtime.evoke.CallTrigger;
 
 public class GetValueTest extends ImplementationTest {
 
@@ -17,7 +18,7 @@ public class GetValueTest extends ImplementationTest {
 		Assert.assertNull(mlm.getValue("low_dose_beta_use"));
 		
 		TestContext context = new TestContext();
-		mlm.run(context, null);
+		mlm.run(context, null, new CallTrigger());
 
 		Assert.assertTrue(mlm.getValue("low_dose_beta_use").isFalse());
 		Assert.assertNull(mlm.getValue("does_not_exist"));
@@ -31,7 +32,7 @@ public class GetValueTest extends ImplementationTest {
 		Assert.assertNull(mlm.getValue("num"));
 		
 		TestContext context = new TestContext();
-		mlm.run(context, null);
+		mlm.run(context, null, new CallTrigger());
 		
 		Assert.assertEquals(ArdenNumber.create(2.0, ArdenValue.NOPRIMARYTIME), mlm.getValue("num"));
 		Assert.assertNull(mlm.getValue("does_not_exist"));

--- a/test/arden/tests/implementation/JDBCQueryTest.java
+++ b/test/arden/tests/implementation/JDBCQueryTest.java
@@ -29,6 +29,7 @@ import arden.runtime.ArdenString;
 import arden.runtime.ArdenValue;
 import arden.runtime.ExecutionContext;
 import arden.runtime.MedicalLogicModule;
+import arden.runtime.evoke.CallTrigger;
 import arden.runtime.jdbc.DriverHelper;
 import arden.runtime.jdbc.JDBCExecutionContext;
 import arden.runtime.jdbc.JDBCQuery;
@@ -145,7 +146,7 @@ public class JDBCQueryTest extends ImplementationTest {
 				"(varE, varF) := read {select * from person};\n", 
 				"conclude true;", 
 				"return (varE, varF);");
-		ArdenValue[] result = mlm.run(testContext, null);
+		ArdenValue[] result = mlm.run(testContext, null, new CallTrigger());
 		Assert.assertEquals(1, result.length);
 
 		ArdenValue[] expected = {new ArdenNumber(1), new ArdenNumber(2), 

--- a/test/arden/tests/implementation/LoadMlmFromBytecodeTest.java
+++ b/test/arden/tests/implementation/LoadMlmFromBytecodeTest.java
@@ -18,7 +18,9 @@ import arden.runtime.LibraryMetadata;
 import arden.runtime.MaintenanceMetadata;
 import arden.runtime.MaintenanceMetadata.ArdenVersion;
 import arden.runtime.MaintenanceMetadata.Validation;
+import arden.runtime.evoke.CallTrigger;
 import arden.runtime.MedicalLogicModule;
+import arden.runtime.MedicalLogicModuleImplementation;
 import arden.runtime.MemoryQuery;
 import arden.runtime.RuntimeHelpers;
 
@@ -41,7 +43,7 @@ public class LoadMlmFromBytecodeTest extends ImplementationTest {
 		MedicalLogicModule mlm = compileBytecode("x3.1.mlm");
 
 		TestContext context = new TestContext();
-		mlm.run(context, null);
+		mlm.run(context, null, new CallTrigger());
 
 		Assert.assertEquals("", context.getOutputText());
 	}
@@ -51,7 +53,7 @@ public class LoadMlmFromBytecodeTest extends ImplementationTest {
 		MedicalLogicModule mlm = compileBytecode("x3.2.mlm");
 
 		TestContext context = new TestContext();
-		mlm.run(context, null);
+		mlm.run(context, null, new CallTrigger());
 
 		Assert.assertEquals("", context.getOutputText());
 	}
@@ -60,7 +62,7 @@ public class LoadMlmFromBytecodeTest extends ImplementationTest {
 	public void x33noAllergies() throws Exception {
 		MedicalLogicModule mlm = compile("x3.3.mlm");
 		TestContext context = new TestContext();
-		mlm.run(context, null);
+		mlm.run(context, null, new CallTrigger());
 		Assert.assertEquals("", context.getOutputText());
 	}
 
@@ -75,7 +77,7 @@ public class LoadMlmFromBytecodeTest extends ImplementationTest {
 				return new MemoryQuery(new ArdenValue[] { list });
 			}
 		};
-		mlm.run(context, null);
+		mlm.run(context, null, new CallTrigger());
 		Assert.assertEquals("Caution, the patient has the following allergy to penicillin documented: all2\n", context
 				.getOutputText());
 	}
@@ -91,14 +93,15 @@ public class LoadMlmFromBytecodeTest extends ImplementationTest {
 				return new MemoryQuery(new ArdenValue[] { list });
 			}
 		};
-		mlm.run(context, null);
+		mlm.run(context, null, new CallTrigger());
 		Assert.assertEquals("", context.getOutputText());
 	}
 
 	@Test
 	public void x33urgency() throws Exception {
 		MedicalLogicModule mlm = compileBytecode("x3.3.mlm");
-		Assert.assertEquals(51.0, mlm.createInstance(new TestContext(), null).getUrgency(), 0);
+		MedicalLogicModuleImplementation instance = mlm.createInstance(new TestContext(), null, new CallTrigger());
+		Assert.assertEquals(51.0, instance.getUrgency(), 0);
 	}
 
 	@Test
@@ -106,7 +109,7 @@ public class LoadMlmFromBytecodeTest extends ImplementationTest {
 		MedicalLogicModule mlm = compileBytecode("x3.4.mlm");
 
 		TestContext context = new TestContext();
-		mlm.run(context, null);
+		mlm.run(context, null, new CallTrigger());
 
 		Assert.assertEquals("", context.getOutputText());
 	}
@@ -116,7 +119,7 @@ public class LoadMlmFromBytecodeTest extends ImplementationTest {
 		MedicalLogicModule mlm = compileBytecode("x3.5.mlm");
 
 		TestContext context = new TestContext();
-		mlm.run(context, null);
+		mlm.run(context, null, new CallTrigger());
 
 		Assert.assertEquals(
 				"Suggest obtaining a serum creatinine to follow up on renal function in the setting of gentamicin.\n",
@@ -128,7 +131,7 @@ public class LoadMlmFromBytecodeTest extends ImplementationTest {
 		MedicalLogicModule mlm = compileBytecode("x3.6.mlm");
 
 		TestContext context = new TestContext();
-		mlm.run(context, null);
+		mlm.run(context, null, new CallTrigger());
 
 		Assert.assertEquals("", context.getOutputText());
 	}
@@ -138,7 +141,7 @@ public class LoadMlmFromBytecodeTest extends ImplementationTest {
 		MedicalLogicModule mlm = compileBytecode("x3.7.mlm");
 
 		TestContext context = new TestContext();
-		mlm.run(context, null);
+		mlm.run(context, null, new CallTrigger());
 
 		Assert.assertEquals("", context.getOutputText());
 	}
@@ -157,7 +160,7 @@ public class LoadMlmFromBytecodeTest extends ImplementationTest {
 		ArdenList patientReactions = new ArdenList(new ArdenValue[] { new ArdenString("r1"), new ArdenString("r2"),
 				new ArdenString("r3") });
 		ArdenValue[] result = mlm.run(context, new ArdenValue[] { medOrders, medAllergens, patientAllergies,
-				patientReactions });
+				patientReactions }, new CallTrigger());
 		Assert.assertEquals(3, result.length);
 
 		Assert.assertEquals("(\"order1\",\"order2\")", result[0].toString());

--- a/test/arden/tests/implementation/MetadataTest.java
+++ b/test/arden/tests/implementation/MetadataTest.java
@@ -35,6 +35,7 @@ import arden.runtime.LibraryMetadata;
 import arden.runtime.MaintenanceMetadata;
 import arden.runtime.MaintenanceMetadata.ArdenVersion;
 import arden.runtime.MaintenanceMetadata.Validation;
+import arden.runtime.evoke.CallTrigger;
 import arden.runtime.MedicalLogicModule;
 import arden.runtime.MedicalLogicModuleImplementation;
 
@@ -88,7 +89,7 @@ public class MetadataTest extends ImplementationTest {
 		
 		ExecutionContext cx = new TestContext();
 		
-		MedicalLogicModuleImplementation impl = mlm.createInstance(cx, null);
+		MedicalLogicModuleImplementation impl = mlm.createInstance(cx, null, new CallTrigger());
 
 		MaintenanceMetadata m = impl.getMaintenanceMetadata();
 		Assert.assertEquals("Fractional excretion of sodium", m.getTitle());
@@ -113,7 +114,7 @@ public class MetadataTest extends ImplementationTest {
 
 		ExecutionContext cx = new TestContext();
 		
-		MedicalLogicModuleImplementation impl = mlm.createInstance(cx, null);
+		MedicalLogicModuleImplementation impl = mlm.createInstance(cx, null, new CallTrigger());
 		
 		MaintenanceMetadata m = impl.getMaintenanceMetadata();
 		Assert.assertEquals("Check for penicillin allergy", m.getTitle());

--- a/test/arden/tests/specification/testcompiler/impl/TestCompilerImpl.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestCompilerImpl.java
@@ -11,6 +11,7 @@ import arden.compiler.CompilerException;
 import arden.runtime.ArdenEvent;
 import arden.runtime.ArdenValue;
 import arden.runtime.MedicalLogicModule;
+import arden.runtime.evoke.CallTrigger;
 import arden.tests.specification.testcompiler.ArdenVersion;
 import arden.tests.specification.testcompiler.TestCompiler;
 import arden.tests.specification.testcompiler.TestCompilerCompiletimeException;
@@ -76,7 +77,7 @@ public class TestCompilerImpl implements TestCompiler {
 
 		ArdenValue[] returnValues;
 		try {
-			returnValues = firstMlm.run(context, null);
+			returnValues = firstMlm.run(context, null, new CallTrigger());
 		} catch (Exception e) {
 			throw new TestCompilerRuntimeException(e);
 		} catch (Error e) {

--- a/test/arden/tests/specification/testcompiler/impl/TestCompilerImpl.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestCompilerImpl.java
@@ -8,7 +8,9 @@ import java.util.GregorianCalendar;
 import java.util.List;
 
 import arden.compiler.CompilerException;
+import arden.runtime.ArdenDuration;
 import arden.runtime.ArdenEvent;
+import arden.runtime.ArdenTime;
 import arden.runtime.ArdenValue;
 import arden.runtime.MedicalLogicModule;
 import arden.runtime.evoke.CallTrigger;
@@ -109,15 +111,16 @@ public class TestCompilerImpl implements TestCompiler {
 
 		// create constant time for deterministic tests
 		Calendar calendar = new GregorianCalendar();
-		calendar.set(2010, 1, 2, 3, 4, 5);
+		calendar.clear();
+		ArdenTime startTime = new ArdenTime(calendar.getTimeInMillis());
 		ArdenEvent event = new ArdenEvent(eventMapping, calendar.getTimeInMillis());
+		
+		TestEngine engine = new TestEngine(compiledMlms, startTime);
+		engine.call(event, ArdenDuration.ZERO, 50);
 
 		// collect messages
-		MedicalLogicModule firstMlm = compiledMlms.get(0);
-		TestEngine engine = new TestEngine(compiledMlms, firstMlm);
 		List<TestCompilerDelayedMessage> messages = new ArrayList<>();
 		try {
-			engine.callEvent(event);
 			while (messages.size() < messagesToCollect) {
 				messages.add(engine.getNextDelayedMessage());
 			}

--- a/test/arden/tests/specification/testcompiler/impl/TestContext.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestContext.java
@@ -66,7 +66,7 @@ public class TestContext extends ExecutionContext {
 		List<MedicalLogicModule> foundModules = new ArrayList<>();
 		for (MedicalLogicModule mlm : mlms) {
 			try {
-				for (Trigger trigger : mlm.getTriggers(this, null)) {
+				for (Trigger trigger : mlm.getTriggers(this)) {
 					if (trigger.runOnEvent(event)) {
 						foundModules.add(mlm);
 					}

--- a/test/arden/tests/specification/testcompiler/impl/TestContext.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestContext.java
@@ -101,7 +101,7 @@ public class TestContext extends ExecutionContext {
 
 	@Override
 	public ArdenEvent getEvent(String mapping) {
-		return new ArdenEvent(mapping, super.getEventTime().value);
+		return new ArdenEvent(mapping, getCurrentTime().value);
 	}
 
 	@Override

--- a/test/arden/tests/specification/testcompiler/impl/TestContext.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestContext.java
@@ -84,7 +84,7 @@ public class TestContext extends ExecutionContext {
 			return new ArdenRunnable() {
 
 				@Override
-				public ArdenValue[] run(ExecutionContext context, ArdenValue[] arguments)
+				public ArdenValue[] run(ExecutionContext context, ArdenValue[] arguments, Trigger trigger)
 						throws InvocationTargetException {
 					// RETURN (args[0] + args[1], args[0] * args[1]);
 					ArdenNumber firstArg = (ArdenNumber) arguments[0];

--- a/test/arden/tests/specification/testcompiler/impl/TestEngine.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestEngine.java
@@ -18,6 +18,7 @@ import arden.runtime.ArdenTime;
 import arden.runtime.ArdenValue;
 import arden.runtime.ExecutionContext;
 import arden.runtime.MedicalLogicModule;
+import arden.runtime.evoke.CallTrigger;
 import arden.runtime.evoke.Trigger;
 import arden.tests.specification.testcompiler.TestCompiler;
 import arden.tests.specification.testcompiler.TestCompilerDelayedMessage;
@@ -226,7 +227,7 @@ public class TestEngine extends TestContext {
 		@Override
 		public void run() {
 			try {
-				mlm.run(context, args);
+				mlm.run(context, args, new CallTrigger());
 			} catch (InvocationTargetException e) {
 				throw new RuntimeException(e);
 			}

--- a/test/arden/tests/specification/testcompiler/impl/TestEngine.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestEngine.java
@@ -2,11 +2,9 @@ package arden.tests.specification.testcompiler.impl;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
-import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.TreeMap;
 
@@ -17,8 +15,8 @@ import arden.runtime.ArdenString;
 import arden.runtime.ArdenTime;
 import arden.runtime.ArdenValue;
 import arden.runtime.ExecutionContext;
+import arden.runtime.ExecutionContextHelpers;
 import arden.runtime.MedicalLogicModule;
-import arden.runtime.evoke.CallTrigger;
 import arden.runtime.evoke.Trigger;
 import arden.tests.specification.testcompiler.TestCompiler;
 import arden.tests.specification.testcompiler.TestCompilerDelayedMessage;
@@ -30,59 +28,36 @@ import arden.tests.specification.testcompiler.TestCompilerDelayedMessage;
  * tests don't block.
  */
 public class TestEngine extends TestContext {
-	private static Comparator<Call> priorityComparator = new Comparator<Call>() {
-		@Override
-		public int compare(Call m1, Call m2) {
-			// highest priority first
-			return (int) (m2.getPriority() - m1.getPriority());
-		}
-	};
 	private List<MedicalLogicModule> mlms = new ArrayList<>();
 	private Schedule scheduledCalls = new Schedule();
 	private Queue<TestCompilerDelayedMessage> messages = new LinkedList<>();
 	private ArdenTime startTime;
 	private ArdenTime currentTime;
 
-	public TestEngine(List<MedicalLogicModule> mlms, MedicalLogicModule callingMlm) {
+	public TestEngine(List<MedicalLogicModule> mlms, ArdenTime startTime) {
 		super(mlms);
 		this.mlms.addAll(mlms);
-	}
-
-	public void callEvent(ArdenEvent event) {
-		this.startTime = new ArdenTime(event.eventTime);
+		this.startTime = startTime;
 		currentTime = startTime;
-
-		// check if MLMs are directly triggered
-		for (MedicalLogicModule mlm : mlms) {
-			try {
-				for (Trigger trigger : mlm.getTriggers(this)) {
-					trigger.scheduleEvent(event);
-					if (trigger.runOnEvent(event)) {
-						scheduledCalls.add(currentTime, new MlmCall(mlm, this, null));
-					}
-				}
-			} catch (InvocationTargetException e) {
-				throw new RuntimeException(e);
-			}
-		}
-
-		// schedule MLMs which may now be triggered
-		Schedule additionalSchedule = createSchedule(mlms);
-		scheduledCalls.add(additionalSchedule);
 	}
 
 	@Override
-	public void call(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delayValue, Trigger trigger, double urgency) {
+	public void call(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delayValue, Trigger trigger,
+			double urgency) {
 		ArdenDuration delayDuration = (ArdenDuration) delayValue;
 		ArdenTime nextRuntime = new ArdenTime(currentTime.add(delayDuration));
-		scheduledCalls.add(nextRuntime, new MlmCall((MedicalLogicModule) mlm, this, arguments));
+		Trigger calleeTrigger = ExecutionContextHelpers.combine(trigger,
+				ExecutionContextHelpers.delayToMillis(delayValue));
+		scheduledCalls.add(nextRuntime, new MlmCall((MedicalLogicModule) mlm, arguments, calleeTrigger));
 	}
 
 	@Override
 	public void call(ArdenEvent event, ArdenValue delayValue, double urgency) {
 		ArdenDuration delayDuration = (ArdenDuration) delayValue;
 		ArdenTime nextRuntime = new ArdenTime(currentTime.add(delayDuration));
-		scheduledCalls.add(nextRuntime, new EventCall(event, this));
+		ArdenEvent eventAfterDelay = ExecutionContextHelpers.combine(event,
+				ExecutionContextHelpers.delayToMillis(delayValue));
+		scheduledCalls.add(nextRuntime, new EventCall(eventAfterDelay, this));
 	}
 
 	@Override
@@ -119,9 +94,9 @@ public class TestEngine extends TestContext {
 			}
 
 			// run the next MLM
-			if (nextRunTime.value >= currentTime.value) {
+			if (nextRunTime.value > currentTime.value) {
 				// skip delay
-				currentTime = new ArdenTime(nextRunTime.value + 1);
+				currentTime = new ArdenTime(nextRunTime.value);
 			}
 			nextCall.run();
 
@@ -132,7 +107,7 @@ public class TestEngine extends TestContext {
 
 		return messages.remove();
 	}
-	
+
 	@Override
 	public ArdenEvent getEvent(String mapping) {
 		return new ArdenEvent(mapping, getCurrentTime().value);
@@ -155,8 +130,8 @@ public class TestEngine extends TestContext {
 						// not scheduled
 						continue;
 					}
-
-					schedule.add(nextRuntime, new MlmCall(mlm, this, null));
+					
+					schedule.add(nextRuntime, new MlmCall(mlm, null, trigger));
 				}
 			} catch (InvocationTargetException e) {
 				throw new RuntimeException(e);
@@ -188,7 +163,7 @@ public class TestEngine extends TestContext {
 		public void add(ArdenTime nextRunTime, Call mlm) {
 			Queue<Call> scheduleGroup = get(nextRunTime);
 			if (scheduleGroup == null) {
-				scheduleGroup = new PriorityQueue<Call>(3, priorityComparator);
+				scheduleGroup = new LinkedList<Call>();
 				put(nextRunTime, scheduleGroup);
 			}
 			scheduleGroup.add(mlm);
@@ -196,38 +171,23 @@ public class TestEngine extends TestContext {
 	}
 
 	private static abstract class Call implements Runnable {
-		// not necessarily the same as an MLMs priority!
-		final int priority;
-
-		Call(int priority) {
-			this.priority = priority;
-		}
-
-		int getPriority() {
-			return priority;
-		}
 	}
 
-	private static class MlmCall extends Call {
+	private class MlmCall extends Call {
 		final MedicalLogicModule mlm;
 		final ArdenValue[] args;
-		final ExecutionContext context;
+		final Trigger trigger;
 
-		public MlmCall(MedicalLogicModule mlm, ExecutionContext context, ArdenValue[] args, int priority) {
-			super(priority);
+		public MlmCall(MedicalLogicModule mlm, ArdenValue[] args, Trigger trigger) {
 			this.mlm = mlm;
 			this.args = args;
-			this.context = context;
-		}
-
-		public MlmCall(MedicalLogicModule mlm, ExecutionContext context, ArdenValue[] args) {
-			this(mlm, context, args, (int) Math.round(mlm.getPriority()));
+			this.trigger = trigger;
 		}
 
 		@Override
 		public void run() {
 			try {
-				mlm.run(context, args, new CallTrigger());
+				mlm.run(TestEngine.this, args, trigger);
 			} catch (InvocationTargetException e) {
 				throw new RuntimeException(e);
 			}
@@ -239,16 +199,27 @@ public class TestEngine extends TestContext {
 		final ExecutionContext context;
 
 		public EventCall(ArdenEvent event, ExecutionContext context) {
-			super(Integer.MAX_VALUE); // always handle events before calls
 			this.event = event;
 			this.context = context;
 		}
 
 		@Override
 		public void run() {
-			for (ArdenRunnable mlm : context.findModules(event)) {
-				MlmCall call = new MlmCall((MedicalLogicModule) mlm, context, null);
-				scheduledCalls.add(context.getCurrentTime(), call);
+			for (MedicalLogicModule mlm : mlms) {
+				Trigger[] triggers;
+				try {
+					triggers = mlm.getTriggers(context);
+				} catch (InvocationTargetException e) {
+					throw new RuntimeException(e);
+				}
+
+				for (Trigger trigger : triggers) {
+					trigger.scheduleEvent(event);
+					if (trigger.runOnEvent(event)) {
+						MlmCall call = new MlmCall((MedicalLogicModule) mlm, null, trigger);
+						scheduledCalls.add(context.getCurrentTime(), call);
+					}
+				}
 			}
 		}
 	}

--- a/test/arden/tests/specification/testcompiler/impl/TestEngine.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestEngine.java
@@ -149,7 +149,7 @@ public class TestEngine extends TestContext {
 		for (MedicalLogicModule mlm : mlms) {
 			try {
 				for (Trigger trigger : mlm.getTriggers(this)) {
-					ArdenTime nextRuntime = trigger.getNextRunTime(this);
+					ArdenTime nextRuntime = trigger.getNextRunTime();
 					if (nextRuntime == null) {
 						// not scheduled
 						continue;

--- a/test/arden/tests/specification/testcompiler/impl/TestEngine.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestEngine.java
@@ -72,7 +72,7 @@ public class TestEngine extends TestContext {
 	}
 
 	@Override
-	public void call(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delayValue, double urgency) {
+	public void call(ArdenRunnable mlm, ArdenValue[] arguments, ArdenValue delayValue, Trigger trigger, double urgency) {
 		ArdenDuration delayDuration = (ArdenDuration) delayValue;
 		ArdenTime nextRuntime = new ArdenTime(currentTime.add(delayDuration));
 		scheduledCalls.add(nextRuntime, new MlmCall((MedicalLogicModule) mlm, this, arguments));

--- a/test/arden/tests/specification/testcompiler/impl/TestEngine.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestEngine.java
@@ -54,7 +54,7 @@ public class TestEngine extends TestContext {
 		// check if MLMs are directly triggered
 		for (MedicalLogicModule mlm : mlms) {
 			try {
-				for (Trigger trigger : mlm.getTriggers(this, null)) {
+				for (Trigger trigger : mlm.getTriggers(this)) {
 					trigger.scheduleEvent(event);
 					if (trigger.runOnEvent(event)) {
 						scheduledCalls.add(currentTime, new MlmCall(mlm, this, null));
@@ -148,7 +148,7 @@ public class TestEngine extends TestContext {
 		// put MLMs which should run at the same time into groups sorted by time
 		for (MedicalLogicModule mlm : mlms) {
 			try {
-				for (Trigger trigger : mlm.getTriggers(this, null)) {
+				for (Trigger trigger : mlm.getTriggers(this)) {
 					ArdenTime nextRuntime = trigger.getNextRunTime(this);
 					if (nextRuntime == null) {
 						// not scheduled


### PR DESCRIPTION
This closes #8 

The `Trigger` object, that evoked the MLM is now required as a parameter when running an MLM. For calls the `CallTrigger` can be used.

These triggers allow access to the evoking event and it's `EVENTTIME`. 
Events created via the `EVENT` statement now will return `TRUE` when used in expressions, if they are the evoking event.
The triggers also allow calculating the `TRIGGERTIME` from the `EVENTTIME` and the delay since the event was triggered.

In order to pass the evoking event from a calling MLM to the called MLM, and add the call delay, the calling MLMs trigger is also given as a parameter to the  `ExecutionContext`'s call method.
