### PR TITLE
Make evoke engine reusable

### DIFF
--- a/src/arden/MainClass.java
+++ b/src/arden/MainClass.java
@@ -53,6 +53,7 @@ import arden.compiler.Compiler;
 import arden.compiler.CompilerException;
 import arden.constants.ConstantParser;
 import arden.constants.ConstantParserException;
+import arden.engine.EvokeEngine;
 import arden.runtime.ArdenValue;
 import arden.runtime.BaseExecutionContext;
 import arden.runtime.ExecutionContext;

--- a/src/arden/MainClass.java
+++ b/src/arden/MainClass.java
@@ -361,13 +361,14 @@ public class MainClass {
 		});
 
 		BaseExecutionContext context = createExecutionContext();
+		EvokeEngine engine = new EvokeEngine(context, mlms);
+		context.setEngine(engine);
 
 		// start event server
 		if (options.isPort()) {
 			new EventServer(context, options.getVerbose(), options.getPort()).startServer();
 		}
 
-		EvokeEngine engine = new EvokeEngine(context, mlms);
 		// launch engine loop on main thread -> only exits on interrupt
 		engine.run();
 
@@ -391,16 +392,13 @@ public class MainClass {
 	}
 
 	private BaseExecutionContext createExecutionContext() {
-		BaseExecutionContext context;
 		if (options.getEnvironment().startsWith("jdbc")) {
-			context = new JDBCExecutionContext(options);
+			return new JDBCExecutionContext(options);
 		} else if ("stdio".equalsIgnoreCase(options.getEnvironment())) {
-			context = new StdIOExecutionContext(options);
+			return new StdIOExecutionContext(options);
 		} else {
-			context = new StdIOExecutionContext(options);
+			return new StdIOExecutionContext(options);
 		}
-
-		return context;
 	}
 
 	private List<MedicalLogicModule> getMlmsFromFiles(List<File> files) throws MainException {

--- a/src/arden/engine/Call.java
+++ b/src/arden/engine/Call.java
@@ -1,0 +1,14 @@
+package arden.engine;
+
+public abstract class Call implements Runnable, Comparable<Call> {
+	private final int priority;
+
+	public Call(int priority) {
+		this.priority = priority;
+	}
+
+	@Override
+	public int compareTo(Call other) {
+		return priority - other.priority;
+	}
+}

--- a/src/arden/engine/EventCall.java
+++ b/src/arden/engine/EventCall.java
@@ -1,0 +1,45 @@
+package arden.engine;
+
+import java.lang.reflect.InvocationTargetException;
+
+import arden.runtime.ArdenDuration;
+import arden.runtime.ArdenEvent;
+import arden.runtime.ExecutionContext;
+import arden.runtime.MedicalLogicModule;
+import arden.runtime.evoke.Trigger;
+
+public final class EventCall extends Call {
+	private final ArdenEvent event;
+	private final ExecutionContext context;
+	private final Iterable<MedicalLogicModule> mlms;
+
+	public EventCall(ExecutionContext context, Iterable<MedicalLogicModule> mlms, ArdenEvent event, int urgency) {
+		// handle events before MlmCalls (highest priority/urgency is 99)
+		super(99 + urgency);
+		this.context = context;
+		this.mlms = mlms;
+		this.event = event;
+	}
+
+	@Override
+	public void run() {
+		// schedule event for all triggers and call directly triggered MLMs
+		for (MedicalLogicModule mlm : mlms) {
+			Trigger[] triggers;
+			try {
+				triggers = mlm.getTriggers(context);
+			} catch (InvocationTargetException e) {
+				// print error and skip this MLM
+				e.printStackTrace();
+				continue;
+			}
+
+			for (Trigger trigger : triggers) {
+				trigger.scheduleEvent(event);
+				if (trigger.runOnEvent(event)) {
+					context.call(mlm, null, ArdenDuration.ZERO, trigger, mlm.getPriority());
+				}
+			}
+		}
+	}
+}

--- a/src/arden/engine/EvokeEngine.java
+++ b/src/arden/engine/EvokeEngine.java
@@ -1,4 +1,4 @@
-package arden;
+package arden.engine;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;

--- a/src/arden/engine/EvokeEngine.java
+++ b/src/arden/engine/EvokeEngine.java
@@ -14,7 +14,6 @@ import arden.runtime.ArdenEvent;
 import arden.runtime.ArdenRunnable;
 import arden.runtime.ArdenTime;
 import arden.runtime.ArdenValue;
-import arden.runtime.BaseExecutionContext;
 import arden.runtime.ExecutionContext;
 import arden.runtime.MedicalLogicModule;
 import arden.runtime.evoke.Trigger;
@@ -47,10 +46,9 @@ public class EvokeEngine implements Runnable {
 	private final ExecutionContext context;
 	private final List<MedicalLogicModule> mlms;
 
-	public EvokeEngine(BaseExecutionContext context, List<MedicalLogicModule> mlms) {
+	public EvokeEngine(ExecutionContext context, List<MedicalLogicModule> mlms) {
 		this.mlms = mlms;
 		this.context = context;
-		context.setEngine(this);
 	}
 
 	/** @see {@link ExecutionContext#findModules(ArdenEvent)} */

--- a/src/arden/engine/MlmCall.java
+++ b/src/arden/engine/MlmCall.java
@@ -1,0 +1,34 @@
+package arden.engine;
+
+import java.lang.reflect.InvocationTargetException;
+
+import arden.runtime.ArdenRunnable;
+import arden.runtime.ArdenValue;
+import arden.runtime.ExecutionContext;
+import arden.runtime.evoke.Trigger;
+
+public final class MlmCall extends Call {
+	private final ArdenRunnable runnable;
+	private final ArdenValue[] args;
+	private final Trigger trigger;
+	private final ExecutionContext context;
+
+	public MlmCall(ExecutionContext context, ArdenRunnable runnable, ArdenValue[] args, Trigger trigger, int priority) {
+		super(priority);
+		this.context = context;
+		this.runnable = runnable;
+		this.args = args;
+		this.trigger = trigger;
+	}
+
+	@Override
+	public void run() {
+		// run MLM now
+		try {
+			runnable.run(context, args, trigger);
+		} catch (InvocationTargetException e) {
+			// print error and skip this MLM
+			e.printStackTrace();
+		}
+	}
+}

--- a/src/arden/engine/Schedule.java
+++ b/src/arden/engine/Schedule.java
@@ -1,0 +1,68 @@
+package arden.engine;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.TreeMap;
+
+import arden.runtime.ArdenTime;
+import arden.runtime.ExecutionContext;
+import arden.runtime.MedicalLogicModule;
+import arden.runtime.evoke.Trigger;
+
+@SuppressWarnings("serial")
+public class Schedule extends TreeMap<ArdenTime, Queue<Call>> {
+	public Schedule() {
+		// sort by time
+		super(new ArdenTime.NaturalComparator());
+	}
+
+	public static Schedule create(ExecutionContext context, List<MedicalLogicModule> mlms) {
+		Schedule schedule = new Schedule();
+
+		for (MedicalLogicModule mlm : mlms) {
+			Trigger[] triggers;
+			try {
+				triggers = mlm.getTriggers(context);
+			} catch (InvocationTargetException e) {
+				// print error and skip this MLM
+				e.printStackTrace();
+				continue;
+			}
+			for (Trigger trigger : triggers) {
+				ArdenTime nextRuntime = trigger.getNextRunTime();
+				if (nextRuntime != null) {
+					// scheduled
+					MlmCall call = new MlmCall(context, mlm, null, trigger, (int) mlm.getPriority());
+					schedule.add(nextRuntime, call);
+				}
+			}
+		}
+
+		return schedule;
+	}
+
+	public void add(ArdenTime nextRunTime, Call call) {
+		// put MLMs which should run at the same time into groups
+		Queue<Call> scheduleGroup = get(nextRunTime);
+		if (scheduleGroup == null) {
+			scheduleGroup = new PriorityQueue<Call>(3);
+			put(nextRunTime, scheduleGroup);
+		}
+		scheduleGroup.add(call);
+	}
+
+	public void add(Schedule additionalSchedule) {
+		for (Map.Entry<ArdenTime, Queue<Call>> entry : additionalSchedule.entrySet()) {
+			ArdenTime time = entry.getKey();
+			Queue<Call> scheduleGroup = get(time);
+			if (scheduleGroup == null) {
+				put(time, entry.getValue());
+			} else {
+				scheduleGroup.addAll(entry.getValue());
+			}
+		}
+	}
+}

--- a/src/arden/runtime/BaseExecutionContext.java
+++ b/src/arden/runtime/BaseExecutionContext.java
@@ -16,11 +16,11 @@ import java.util.List;
 import java.util.Map;
 
 import arden.CommandLineOptions;
-import arden.EvokeEngine;
 import arden.MainClass;
 import arden.compiler.CompiledMlm;
 import arden.compiler.Compiler;
 import arden.compiler.CompilerException;
+import arden.engine.EvokeEngine;
 import arden.runtime.MaintenanceMetadata.Validation;
 import arden.runtime.evoke.CallTrigger;
 import arden.runtime.evoke.Trigger;


### PR DESCRIPTION
This splits the evoke engine into multiple classes, which now reside in the `arden.engine` package.
`MlmCall`, `EventCall` and `Schedule` are now separate from the engine and can be reused in other engines.

The core mechanism of the engine can now easily be changed (e.g. cron jobs, instead of `ScheduledExecutorService`), without needing to rewrite the scheduling logic.