### PR TITLE
Add calling MLM as parameter to all mapping methods

### DIFF
--- a/src/arden/compiler/DataCompiler.java
+++ b/src/arden/compiler/DataCompiler.java
@@ -271,6 +271,7 @@ final class DataCompiler extends VisitorBase {
 				context.writer.sequencePoint(lhs.getPosition().getLine());
 				context.writer.loadThis();
 				context.writer.loadVariable(context.executionContextVariable);
+				context.writer.loadVariable(context.selfMLMVariable);
 				context.writer.loadStringConstant(ParseHelpers.getStringForMapping(node.getMappingFactor()));
 				context.writer.invokeInstance(ExecutionContextMethods.findInterface);
 				context.writer.storeInstanceField(var.runnableField);
@@ -283,6 +284,7 @@ final class DataCompiler extends VisitorBase {
 				context.writer.sequencePoint(lhs.getPosition().getLine());
 				context.writer.loadThis();
 				context.writer.loadVariable(context.executionContextVariable);
+				context.writer.loadVariable(context.selfMLMVariable);
 				context.writer.loadStringConstant(ParseHelpers.getStringForMapping(node.getMappingFactor()));
 				context.writer.invokeInstance(ExecutionContextMethods.getEvent);
 				context.writer.loadThis();
@@ -298,6 +300,7 @@ final class DataCompiler extends VisitorBase {
 				MessageVariable v = MessageVariable.getVariable(context.codeGenerator, lhs);
 				context.writer.loadThis();
 				context.writer.loadVariable(context.executionContextVariable);
+				context.writer.loadVariable(context.selfMLMVariable);
 				String mappingString = ParseHelpers.getStringForMapping(node.getMappingFactor());
 				context.writer.loadStringConstant(mappingString);
 				context.writer.invokeInstance(ExecutionContextMethods.getMessage);
@@ -310,6 +313,8 @@ final class DataCompiler extends VisitorBase {
 				MessageVariable v = MessageVariable.getVariable(context.codeGenerator, lhs);
 				context.writer.loadThis();
 				context.writer.loadVariable(context.executionContextVariable);
+
+				context.writer.loadVariable(context.selfMLMVariable);
 				String mappingString = ParseHelpers.getStringForMapping(node.getMappingFactor());
 				context.writer.loadStringConstant(mappingString);
 
@@ -328,6 +333,7 @@ final class DataCompiler extends VisitorBase {
 				DestinationVariable v = DestinationVariable.getDestinationVariable(context.codeGenerator, lhs);
 				context.writer.loadThis();
 				context.writer.loadVariable(context.executionContextVariable);
+				context.writer.loadVariable(context.selfMLMVariable);
 				String mappingString = ParseHelpers.getStringForMapping(node.getMappingFactor());
 				context.writer.loadStringConstant(mappingString);
 				context.writer.invokeInstance(ExecutionContextMethods.getDestination);
@@ -340,6 +346,8 @@ final class DataCompiler extends VisitorBase {
 				DestinationVariable v = DestinationVariable.getDestinationVariable(context.codeGenerator, lhs);
 				context.writer.loadThis();
 				context.writer.loadVariable(context.executionContextVariable);
+
+				context.writer.loadVariable(context.selfMLMVariable);
 				String mappingString = ParseHelpers.getStringForMapping(node.getMappingFactor());
 				context.writer.loadStringConstant(mappingString);
 

--- a/src/arden/compiler/ExecutionContextMethods.java
+++ b/src/arden/compiler/ExecutionContextMethods.java
@@ -33,6 +33,7 @@ import arden.runtime.ArdenEvent;
 import arden.runtime.ArdenRunnable;
 import arden.runtime.ArdenValue;
 import arden.runtime.ExecutionContext;
+import arden.runtime.MedicalLogicModule;
 import arden.runtime.ObjectType;
 import arden.runtime.evoke.Trigger;
 
@@ -46,7 +47,7 @@ final class ExecutionContextMethods {
 
 	static {
 		try {
-			createQuery = ExecutionContext.class.getMethod("createQuery", String.class);
+			createQuery = ExecutionContext.class.getMethod("createQuery", MedicalLogicModule.class, String.class);
 
 			getMessage = ExecutionContext.class.getMethod("getMessage", String.class);
 			getMessageAs = ExecutionContext.class.getMethod("getMessageAs", String.class, ObjectType.class);

--- a/src/arden/compiler/ExecutionContextMethods.java
+++ b/src/arden/compiler/ExecutionContextMethods.java
@@ -49,22 +49,21 @@ final class ExecutionContextMethods {
 		try {
 			createQuery = ExecutionContext.class.getMethod("createQuery", MedicalLogicModule.class, String.class);
 
-			getMessage = ExecutionContext.class.getMethod("getMessage", String.class);
-			getMessageAs = ExecutionContext.class.getMethod("getMessageAs", String.class, ObjectType.class);
-			getDestination = ExecutionContext.class.getMethod("getDestination", String.class);
-			getDestinationAs = ExecutionContext.class.getMethod("getDestinationAs", String.class, ObjectType.class);
-			getEvent = ExecutionContext.class.getMethod("getEvent", String.class);
+			getMessage = ExecutionContext.class.getMethod("getMessage", MedicalLogicModule.class, String.class);
+			getMessageAs = ExecutionContext.class.getMethod("getMessageAs", MedicalLogicModule.class, String.class, ObjectType.class);
+			getDestination = ExecutionContext.class.getMethod("getDestination", MedicalLogicModule.class, String.class);
+			getDestinationAs = ExecutionContext.class.getMethod("getDestinationAs", MedicalLogicModule.class, String.class, ObjectType.class);
+			getEvent = ExecutionContext.class.getMethod("getEvent", MedicalLogicModule.class, String.class);
 
+			findInterface = ExecutionContext.class.getMethod("findInterface", MedicalLogicModule.class, String.class);
 			findModule = ExecutionContext.class.getMethod("findModule", String.class, String.class);
 			findModules = ExecutionContext.class.getMethod("findModules", ArdenEvent.class);
-			findInterface = ExecutionContext.class.getMethod("findInterface", String.class);
-
-			write = ExecutionContext.class.getMethod("write", ArdenValue.class, ArdenValue.class, double.class);
-			call = ExecutionContext.class.getMethod("call", ArdenRunnable.class, ArdenValue[].class, ArdenValue.class,
-					Trigger.class, double.class);
-			callEvent = ExecutionContext.class.getMethod("call", ArdenEvent.class, ArdenValue.class, double.class);
 
 			getCurrentTime = ExecutionContext.class.getMethod("getCurrentTime");
+
+			write = ExecutionContext.class.getMethod("write", ArdenValue.class, ArdenValue.class, double.class);
+			call = ExecutionContext.class.getMethod("call", ArdenRunnable.class, ArdenValue[].class, ArdenValue.class, Trigger.class, double.class);
+			callEvent = ExecutionContext.class.getMethod("call", ArdenEvent.class, ArdenValue.class, double.class);
 		} catch (SecurityException e) {
 			throw new RuntimeException(e);
 		} catch (NoSuchMethodException e) {

--- a/src/arden/compiler/ReadPhraseCompiler.java
+++ b/src/arden/compiler/ReadPhraseCompiler.java
@@ -228,6 +228,7 @@ final class ReadPhraseCompiler extends VisitorBase {
 	@Override
 	public void caseAMappingFactor(AMappingFactor node) {
 		context.writer.loadVariable(context.executionContextVariable);
+		context.writer.loadVariable(context.selfMLMVariable);
 		context.writer.loadStringConstant(node.getDataMapping().getText());
 		context.writer.invokeInstance(ExecutionContextMethods.createQuery);
 	}

--- a/src/arden/runtime/ExecutionContext.java
+++ b/src/arden/runtime/ExecutionContext.java
@@ -45,9 +45,9 @@ public abstract class ExecutionContext {
 	 * produced.
 	 * 
 	 * @param mlm
-	 *            The MLM, that called this query. It's variables can be
-	 *            accessed via {@link MedicalLogicModule#getValue(String)}, e.g.
-	 *            for variable-substitution in the mapping.
+	 *            The MLM,that called this query. Its variables can be accessed
+	 *            via {@link MedicalLogicModule#getValue(String)}, e.g. for
+	 *            variable-substitution in the mapping.
 	 * 
 	 * @param mapping
 	 *            The contents of the statement's mapping clause (text between
@@ -67,6 +67,9 @@ public abstract class ExecutionContext {
 	 * Gets a value that represents a message, as part of a <code>MESSAGE</code>
 	 * statement.
 	 * 
+	 * @param mlm
+	 *            The MLM that called this method.
+	 * 
 	 * @param mapping
 	 *            The contents of the statement's mapping clause.
 	 * 
@@ -74,13 +77,16 @@ public abstract class ExecutionContext {
 	 *         represents the message. This value may be given as a parameter in
 	 *         the {@link #write(ArdenValue, ArdenValue)} method.
 	 */
-	public ArdenValue getMessage(String mapping) {
+	public ArdenValue getMessage(MedicalLogicModule mlm, String mapping) {
 		return new ArdenString(mapping);
 	}
 
 	/**
 	 * Gets an object that represents a message, as part of a
 	 * <code>MESSAGE AS</code> statement.
+	 * 
+	 * @param mlm
+	 *            The MLM that called this method.
 	 * 
 	 * @param mapping
 	 *            The contents of the statement's mapping clause.
@@ -90,13 +96,16 @@ public abstract class ExecutionContext {
 	 * 
 	 * @return An {@link ArdenObject} of the given {@link ObjectType}.
 	 */
-	public ArdenObject getMessageAs(String mapping, ObjectType type) {
+	public ArdenObject getMessageAs(MedicalLogicModule mlm, String mapping, ObjectType type) {
 		return new ArdenObject(type);
 	}
 
 	/**
 	 * Gets a value that represents a destination, as part of the
 	 * <code>DESTINATION</code> statement.
+	 * 
+	 * @param mlm
+	 *            The MLM that called this method.
 	 * 
 	 * @param mapping
 	 *            The contents of the statement's mapping clause.
@@ -105,13 +114,16 @@ public abstract class ExecutionContext {
 	 *         represents the destination. This value is used as a parameter in
 	 *         the {@link #write(ArdenValue, ArdenValue)} method.
 	 */
-	public ArdenValue getDestination(String mapping) {
+	public ArdenValue getDestination(MedicalLogicModule mlm, String mapping) {
 		return new ArdenString(mapping);
 	}
 
 	/**
 	 * Gets an object that represents a destination, as part of a
 	 * <code>DESTINATION AS</code> statement.
+	 * 
+	 * @param mlm
+	 *            The MLM that called this method.
 	 * 
 	 * @param mapping
 	 *            The contents of the statement's mapping clause.
@@ -121,42 +133,42 @@ public abstract class ExecutionContext {
 	 * 
 	 * @return An {@link ArdenObject} of the given {@link ObjectType}.
 	 */
-	public ArdenObject getDestinationAs(String mapping, ObjectType type) {
+	public ArdenObject getDestinationAs(MedicalLogicModule mlm, String mapping, ObjectType type) {
 		return new ArdenObject(type);
 	}
 
 	/**
-	 * Gets an event as part of the <code>EVENT</code> statement.
+	 * Gets an event definition as part of the <code>EVENT</code> statement.
+	 * 
+	 * @param mlm
+	 *            The MLM that called this method.
 	 * 
 	 * @param mapping
 	 *            The contents of the statement's mapping clause.
 	 * 
-	 * @return An {@link ArdenEvent}. If it is the event, that triggered the
-	 *         MLM, it will automatically flagged as such.
+	 * @return An {@link ArdenEvent}. It will be compared with other events via
+	 *         its {@link ArdenEvent#equals(Object)} method. If it is the event,
+	 *         that triggered the MLM, it will automatically flagged as such via
+	 *         {@link ArdenEvent#setEvokingEvent(boolean)}.
 	 */
-	public ArdenEvent getEvent(String mapping) {
+	public ArdenEvent getEvent(MedicalLogicModule mlm, String mapping) {
 		return new ArdenEvent(mapping);
 	}
 
 	/**
-	 * Called by the <code>WRITE</code> statement.
+	 * Retrieves an interface implementation, as part of the
+	 * <code>INTERFACE</code> statement.
 	 * 
-	 * @param message
-	 *            The message to be written. This may be an instance returned
-	 *            from {@link #getMessage(String)} or
-	 *            {@link #getMessageAs(String, ObjectType)}, but other values
-	 *            are possible.
+	 * @param mlm
+	 *            The MLM that called this method.
 	 * 
-	 * @param destination
-	 *            The destination for the message. This will be an instance
-	 *            returned from {@link #getDestination(String)} or
-	 *            {@link #getDestinationAs(String, ObjectType)}. May be null, if
-	 *            the default destination should be used.
+	 * @param mapping
+	 *            The contents of the statement's mapping clause.
 	 * 
-	 * @param urgency
-	 *            The urgency from the MLMs urgency slot.
+	 * @return The interface implementation as an {@link ArdenRunnable}.
 	 */
-	public void write(ArdenValue message, ArdenValue destination, double urgency) {
+	public ArdenRunnable findInterface(MedicalLogicModule mlm, String mapping) {
+		throw new RuntimeException("findInterface not implemented");
 	}
 
 	/**
@@ -189,16 +201,31 @@ public abstract class ExecutionContext {
 	}
 
 	/**
-	 * Retrieves an interface implementation, as part of the
-	 * <code>INTERFACE</code> statement.
-	 * 
-	 * @param mapping
-	 *            The contents of the statement's mapping clause.
-	 * 
-	 * @return The interface implementation as an {@link ArdenRunnable}.
+	 * @return The <code>CURRENTTIME</code>.
 	 */
-	public ArdenRunnable findInterface(String mapping) {
-		throw new RuntimeException("findInterface not implemented");
+	public ArdenTime getCurrentTime() {
+		return new ArdenTime(new Date());
+	}
+
+	/**
+	 * Called by the <code>WRITE</code> statement.
+	 * 
+	 * @param message
+	 *            The message to be written. This may be an instance returned
+	 *            from {@link #getMessage(String)} or
+	 *            {@link #getMessageAs(String, ObjectType)}, but other values
+	 *            are possible.
+	 * 
+	 * @param destination
+	 *            The destination for the message. This will be an instance
+	 *            returned from {@link #getDestination(String)} or
+	 *            {@link #getDestinationAs(String, ObjectType)}. May be null, if
+	 *            the default destination should be used.
+	 * 
+	 * @param urgency
+	 *            The urgency from the MLMs urgency slot.
+	 */
+	public void write(ArdenValue message, ArdenValue destination, double urgency) {
 	}
 
 	/**
@@ -240,12 +267,5 @@ public abstract class ExecutionContext {
 	 */
 	public void call(ArdenEvent event, ArdenValue delay, double urgency) {
 		throw new RuntimeException("Event call not implemented");
-	}
-
-	/**
-	 * @return The <code>CURRENTTIME</code>.
-	 */
-	public ArdenTime getCurrentTime() {
-		return new ArdenTime(new Date());
 	}
 }

--- a/src/arden/runtime/ExecutionContext.java
+++ b/src/arden/runtime/ExecutionContext.java
@@ -44,6 +44,11 @@ public abstract class ExecutionContext {
 	 * {@link DatabaseQuery} object can be used to limit the number of results
 	 * produced.
 	 * 
+	 * @param mlm
+	 *            The MLM, that called this query. It's variables can be
+	 *            accessed via {@link MedicalLogicModule#getValue(String)}, e.g.
+	 *            for variable-substitution in the mapping.
+	 * 
 	 * @param mapping
 	 *            The contents of the statement's mapping clause (text between
 	 *            curly braces). The meaning is implementation-defined. The
@@ -54,7 +59,7 @@ public abstract class ExecutionContext {
 	 *         {@link DatabaseQuery#NULL}, a query that will always produce an
 	 *         empty result set.
 	 */
-	public DatabaseQuery createQuery(String mapping) {
+	public DatabaseQuery createQuery(MedicalLogicModule mlm, String mapping) {
 		return DatabaseQuery.NULL;
 	}
 

--- a/src/arden/runtime/StdIOExecutionContext.java
+++ b/src/arden/runtime/StdIOExecutionContext.java
@@ -16,7 +16,7 @@ public class StdIOExecutionContext extends BaseExecutionContext {
 	}
 	
 	@Override
-	public DatabaseQuery createQuery(String mapping) {
+	public DatabaseQuery createQuery(MedicalLogicModule mlm, String mapping) {
 		System.out.println(
 				"Query mapping: \"" + mapping + "\". Enter result as " + "Arden Syntax constant (Strings in quotes)");
 		System.out.print(PROMPT_SIGN);

--- a/src/arden/runtime/StdIOExecutionContext.java
+++ b/src/arden/runtime/StdIOExecutionContext.java
@@ -48,13 +48,13 @@ public class StdIOExecutionContext extends BaseExecutionContext {
 	}
 
 	@Override
-	public ArdenValue getMessage(String mapping) {
+	public ArdenValue getMessage(MedicalLogicModule mlm, String mapping) {
 		System.out.println("Message, mapping: " + mapping);
 		return new ArdenString(mapping);
 	}
 	
 	@Override
-	public ArdenObject getMessageAs(String mapping, ObjectType type) {
+	public ArdenObject getMessageAs(MedicalLogicModule mlm, String mapping, ObjectType type) {
 		System.out.println("Message, mapping: " + mapping + ", type: " + type.name);
 		ArdenObject object = new ArdenObject(type);
 		if(object.fields.length > 0) {
@@ -64,13 +64,13 @@ public class StdIOExecutionContext extends BaseExecutionContext {
 	}
 	
 	@Override
-	public ArdenValue getDestination(String mapping) {
+	public ArdenValue getDestination(MedicalLogicModule mlm, String mapping) {
 		System.out.println("Destination, mapping: " + mapping);
 		return new ArdenString(mapping);
 	}
 	
 	@Override
-	public ArdenObject getDestinationAs(String mapping, ObjectType type) {
+	public ArdenObject getDestinationAs(MedicalLogicModule mlm, String mapping, ObjectType type) {
 		System.out.println("Destination, mapping: " + mapping + ", type: " + type.name);
 		ArdenObject object = new ArdenObject(type);
 		if(object.fields.length > 0) {

--- a/src/arden/runtime/jdbc/JDBCExecutionContext.java
+++ b/src/arden/runtime/jdbc/JDBCExecutionContext.java
@@ -36,6 +36,7 @@ import arden.CommandLineOptions;
 import arden.runtime.ArdenString;
 import arden.runtime.ArdenValue;
 import arden.runtime.DatabaseQuery;
+import arden.runtime.MedicalLogicModule;
 import arden.runtime.StdIOExecutionContext;
 
 public class JDBCExecutionContext extends StdIOExecutionContext {
@@ -95,7 +96,7 @@ public class JDBCExecutionContext extends StdIOExecutionContext {
 	}
 	
 	@Override
-	public DatabaseQuery createQuery(String mapping) {		
+	public DatabaseQuery createQuery(MedicalLogicModule mlm, String mapping) {
 		return new JDBCQuery(mapping, connection);
 	}	
 	

--- a/test/arden/tests/implementation/ExampleEvokeTest.java
+++ b/test/arden/tests/implementation/ExampleEvokeTest.java
@@ -86,7 +86,7 @@ public class ExampleEvokeTest extends ImplementationTest {
 		MedicalLogicModule mlm = compile("x3.3.mlm");
 		TestContext context = new TestContext() {
 			@Override
-			public DatabaseQuery createQuery(String mapping) {
+			public DatabaseQuery createQuery(MedicalLogicModule mlm, String mapping) {
 				Assert.assertEquals("allergy where agent_class = penicillin", mapping);
 				ArdenList list = new ArdenList(new ArdenValue[] { new ArdenString("all1"), new ArdenString("all2") });
 				return new MemoryQuery(new ArdenValue[] { list });
@@ -104,7 +104,7 @@ public class ExampleEvokeTest extends ImplementationTest {
 		MedicalLogicModule mlm = compile("x3.3.mlm");
 		TestContext context = new TestContext() {
 			@Override
-			public DatabaseQuery createQuery(String mapping) {
+			public DatabaseQuery createQuery(MedicalLogicModule mlm, String mapping) {
 				Assert.assertEquals("allergy where agent_class = penicillin", mapping);
 				ArdenList list = new ArdenList(new ArdenValue[] { new ArdenString("all1"), ArdenNull.INSTANCE });
 				return new MemoryQuery(new ArdenValue[] { list });

--- a/test/arden/tests/implementation/ExampleTest.java
+++ b/test/arden/tests/implementation/ExampleTest.java
@@ -75,7 +75,7 @@ public class ExampleTest extends ImplementationTest {
 		MedicalLogicModule mlm = compile("x3.3.mlm");
 		TestContext context = new TestContext() {
 			@Override
-			public DatabaseQuery createQuery(String mapping) {
+			public DatabaseQuery createQuery(MedicalLogicModule mlm, String mapping) {
 				Assert.assertEquals("allergy where agent_class = penicillin", mapping);
 				ArdenList list = new ArdenList(new ArdenValue[] { new ArdenString("all1"), new ArdenString("all2") });
 				return new MemoryQuery(new ArdenValue[] { list });
@@ -91,7 +91,7 @@ public class ExampleTest extends ImplementationTest {
 		MedicalLogicModule mlm = compile("x3.3.mlm");
 		TestContext context = new TestContext() {
 			@Override
-			public DatabaseQuery createQuery(String mapping) {
+			public DatabaseQuery createQuery(MedicalLogicModule mlm, String mapping) {
 				Assert.assertEquals("allergy where agent_class = penicillin", mapping);
 				ArdenList list = new ArdenList(new ArdenValue[] { new ArdenString("all1"), ArdenNull.INSTANCE });
 				return new MemoryQuery(new ArdenValue[] { list });

--- a/test/arden/tests/implementation/LoadMlmFromBytecodeTest.java
+++ b/test/arden/tests/implementation/LoadMlmFromBytecodeTest.java
@@ -71,7 +71,7 @@ public class LoadMlmFromBytecodeTest extends ImplementationTest {
 		MedicalLogicModule mlm = compileBytecode("x3.3.mlm");
 		TestContext context = new TestContext() {
 			@Override
-			public DatabaseQuery createQuery(String mapping) {
+			public DatabaseQuery createQuery(MedicalLogicModule mlm, String mapping) {
 				Assert.assertEquals("allergy where agent_class = penicillin", mapping);
 				ArdenList list = new ArdenList(new ArdenValue[] { new ArdenString("all1"), new ArdenString("all2") });
 				return new MemoryQuery(new ArdenValue[] { list });
@@ -87,7 +87,7 @@ public class LoadMlmFromBytecodeTest extends ImplementationTest {
 		MedicalLogicModule mlm = compileBytecode("x3.3.mlm");
 		TestContext context = new TestContext() {
 			@Override
-			public DatabaseQuery createQuery(String mapping) {
+			public DatabaseQuery createQuery(MedicalLogicModule mlm, String mapping) {
 				Assert.assertEquals("allergy where agent_class = penicillin", mapping);
 				ArdenList list = new ArdenList(new ArdenValue[] { new ArdenString("all1"), ArdenNull.INSTANCE });
 				return new MemoryQuery(new ArdenValue[] { list });

--- a/test/arden/tests/implementation/TestContext.java
+++ b/test/arden/tests/implementation/TestContext.java
@@ -33,6 +33,7 @@ import arden.runtime.ArdenTime;
 import arden.runtime.ArdenValue;
 import arden.runtime.DatabaseQuery;
 import arden.runtime.ExecutionContext;
+import arden.runtime.MedicalLogicModule;
 
 public class TestContext extends ExecutionContext {
 	StringBuilder b = new StringBuilder();
@@ -57,7 +58,7 @@ public class TestContext extends ExecutionContext {
 	}
 	
 	@Override
-	public DatabaseQuery createQuery(String mapping) {
+	public DatabaseQuery createQuery(MedicalLogicModule mlm, String mapping) {
 		return DatabaseQuery.NULL;
 	}
 

--- a/test/arden/tests/implementation/TestContext.java
+++ b/test/arden/tests/implementation/TestContext.java
@@ -73,11 +73,11 @@ public class TestContext extends ExecutionContext {
 	}
 	
 	@Override
-	public ArdenEvent getEvent(String mapping) {
+	public ArdenEvent getEvent(MedicalLogicModule mlm, String mapping) {
 		if (defaultEvent != null) {
 			return defaultEvent;
 		}
-		return super.getEvent(mapping);
+		return super.getEvent(mlm, mapping);
 	}
 	
 	@Override

--- a/test/arden/tests/specification/testcompiler/impl/TestContext.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestContext.java
@@ -79,7 +79,7 @@ public class TestContext extends ExecutionContext {
 	}
 
 	@Override
-	public ArdenRunnable findInterface(String mapping) {
+	public ArdenRunnable findInterface(MedicalLogicModule mlm, String mapping) {
 		if (INTERFACE_MAPPING.equals(mapping)) {
 			return new ArdenRunnable() {
 
@@ -96,11 +96,11 @@ public class TestContext extends ExecutionContext {
 			};
 
 		}
-		return super.findInterface(mapping);
+		return super.findInterface(mlm, mapping);
 	}
 
 	@Override
-	public ArdenEvent getEvent(String mapping) {
+	public ArdenEvent getEvent(MedicalLogicModule mlm, String mapping) {
 		return new ArdenEvent(mapping, getCurrentTime().value);
 	}
 

--- a/test/arden/tests/specification/testcompiler/impl/TestContext.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestContext.java
@@ -105,7 +105,7 @@ public class TestContext extends ExecutionContext {
 	}
 
 	@Override
-	public DatabaseQuery createQuery(String mapping) {
+	public DatabaseQuery createQuery(MedicalLogicModule mlm, String mapping) {
 		if (READ_MAPPING.equals(mapping)) {
 			return new DatabaseQuery() {
 

--- a/test/arden/tests/specification/testcompiler/impl/TestEngine.java
+++ b/test/arden/tests/specification/testcompiler/impl/TestEngine.java
@@ -111,7 +111,7 @@ public class TestEngine extends TestContext {
 	}
 
 	@Override
-	public ArdenEvent getEvent(String mapping) {
+	public ArdenEvent getEvent(MedicalLogicModule mlm, String mapping) {
 		return new ArdenEvent(mapping, getCurrentTime().value);
 	}
 


### PR DESCRIPTION
This allows reading the MLMs variables in mappings, as mentioned in the specification.
Also allows access to the evoking event, e.g. to return data associated with that event.