### PR TITLE
Improves handling of 'formatted with'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: java
+install: ant dependencies

--- a/src/arden/compiler/HexadecimalFormat.java
+++ b/src/arden/compiler/HexadecimalFormat.java
@@ -1,0 +1,66 @@
+// arden2bytecode
+// Copyright (c) 2017, Klaus-Hendrik Wolf
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice, this list
+//   of conditions and the following disclaimer.
+//
+// - Redistributions in binary form must reproduce the above copyright notice, this list
+//   of conditions and the following disclaimer in the documentation and/or other materials
+//   provided with the distribution.
+//
+// - Neither the name of the owner nor the names of its contributors may be used to
+//   endorse or promote products derived from this software without specific prior written
+//   permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &AS IS& AND ANY EXPRESS
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+// IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+// OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package arden.compiler;
+
+import java.text.FieldPosition;
+import java.text.NumberFormat;
+import java.text.ParsePosition;
+
+final public class HexadecimalFormat extends NumberFormat {
+    private boolean upperCase;
+    public HexadecimalFormat() {
+        super();
+        upperCase = false;
+    }
+
+    public StringBuffer format(double number, StringBuffer toAppendTo, FieldPosition pos) {
+        return format((long) number, toAppendTo, pos);
+    }
+
+    public StringBuffer format(long number, StringBuffer toAppendTo, FieldPosition pos)
+    {
+        if (upperCase) {
+            return new StringBuffer(Long.toHexString(number).toUpperCase());
+        } else {
+            return new StringBuffer(Long.toHexString(number));
+        } 
+    }
+
+    public Number parse(String source, ParsePosition parsePosition) {
+        return null;
+    }
+
+    public void useLowerCase() {
+        upperCase = false;
+    }
+
+    public void useUpperCase() {
+        upperCase = true;
+    }
+}
+

--- a/src/arden/compiler/OctalFormat.java
+++ b/src/arden/compiler/OctalFormat.java
@@ -1,0 +1,51 @@
+// arden2bytecode
+// Copyright (c) 2017, Klaus-Hendrik Wolf
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice, this list
+//   of conditions and the following disclaimer.
+//
+// - Redistributions in binary form must reproduce the above copyright notice, this list
+//   of conditions and the following disclaimer in the documentation and/or other materials
+//   provided with the distribution.
+//
+// - Neither the name of the owner nor the names of its contributors may be used to
+//   endorse or promote products derived from this software without specific prior written
+//   permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &AS IS& AND ANY EXPRESS
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+// IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+// OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package arden.compiler;
+
+import java.text.FieldPosition;
+import java.text.NumberFormat;
+import java.text.ParsePosition;
+
+final public class OctalFormat extends NumberFormat {
+    public OctalFormat() {
+        super();
+    }
+
+    public StringBuffer format(double number, StringBuffer toAppendTo, FieldPosition pos) {
+        return format((long) number, toAppendTo, pos);
+    }
+
+    public StringBuffer format(long number, StringBuffer toAppendTo, FieldPosition pos)
+    {
+        return new StringBuffer(Long.toOctalString(number));
+    }
+
+    public Number parse(String source, ParsePosition parsePosition) {
+        return null;
+    }
+}

--- a/test/arden/tests/specification/operators/StringOperatorsTest.java
+++ b/test/arden/tests/specification/operators/StringOperatorsTest.java
@@ -40,6 +40,8 @@ public class StringOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("(\"a\", \"b\", \"c\") formatted with \"%s ~ %s ~ %s\"", "\"a ~ b ~ c\"");
 		assertEvaluatesTo("(97, 98, 99) formatted with \"%c, %c, %c\"", "\"a, b, c\"");
 		assertEvaluatesTo("5.1234 formatted with \"%3.5f\"", "\"5.12340\"");
+		assertEvaluatesTo("-5.1234 formatted with \"%3.3f\"", "\"-5.123\"");
+		assertEvaluatesTo("-321.1234 formatted with \"%3.3f\"", "\"-321.123\"");
 		assertEvaluatesTo("12345678 formatted with \"%I\"", "\"12345678\"");
 		assertEvaluatesTo("1 formatted with \"%3d%%\"", "\"  1%\"");
 		assertEvaluatesTo("1 formatted with \"%03d%%\"", "\"001%\"");
@@ -47,11 +49,15 @@ public class StringOperatorsTest extends SpecificationTest {
 		assertEvaluatesTo("1 formatted with \"%-3I\"", "\"1  \"");
 		assertEvaluatesTo("1 formatted with \"%-+3I\"", "\"+1 \"");
 		assertEvaluatesTo("\"abc\" formatted with \"%3.2s\"", "\" ab\"");
-		assertEvaluatesTo("5.1234 formatted with \"%.4e\"", "\"5.1234e+000\"");
-		assertEvaluatesTo("5.1234 formatted with \"%.4g\"", "\"5.123\"");
+        assertEvaluatesTo("-0.0012345 formatted with \"%.3e\"", "\"-1.234e-003\"");
+        assertEvaluatesTo("-0.0012345 formatted with \"%.3E\"", "\"-1.234E-003\"");
+        assertEvaluatesTo("5.1234 formatted with \"%.4e\"", "\"5.1234e+000\"");
+		assertEvaluatesTo("5.1234 formatted with \"%.3g\"", "\"5.123\"");
+		assertEvaluatesTo("5.1234 formatted with \"%.4g\"", "\"5.1234\"");
 		assertEvaluatesTo("8 formatted with \"%o\"", "\"10\"");
 		assertEvaluatesTo("8 formatted with \"%u\"", "\"8\"");
 		assertEvaluatesTo("63 formatted with \"%x\"", "\"3f\"");
+		assertEvaluatesTo("63 formatted with \"%X\"", "\"3F\"");
 		assertInvalidExpression("8 formatted with \"%n\"");
 		assertInvalidExpression("8 formatted with \"%p\"");
 	}


### PR DESCRIPTION
- Now supports all specified format specifiers
- Allows the use of lower and upper case specifiers
- Adds support for hexadecimal
  (%x: lowercase [a-f], %X: uppercase [A-F])
- Adds support for octal (%o, %O)
- Adds support for scientific representation
  (%e: lowercase e-exponent, %E: uppercase E-exponent)
- Adds basic support for (%g and %G), though only as alias to %f resp %F