### PR TITLE
Update Tests

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -234,12 +234,13 @@
             </fileset>
             <report format="noframes" todir="${test.report.dir}" />
         </junitreport>
+    	<fail if="test.failure" message="Unit test(s) failed. See reports!"/>
     </target>
     
     
     <target name="test.implementation" depends="compile">
         <mkdir dir="${test.report.dir}" />
-        <junit fork="yes" printsummary="withOutAndErr">
+        <junit fork="yes" printsummary="withOutAndErr" failureproperty="test.failure">
             <formatter type="xml" />
             <classpath refid="test.classpath" />
             <test name="${mainclass.test.implementation}" todir="${test.report.dir}" />
@@ -249,7 +250,7 @@
     
     <target name="test.specification" depends="compile">
         <mkdir dir="${test.report.dir}" />
-        <junit fork="yes" printsummary="withOutAndErr">
+        <junit fork="yes" printsummary="withOutAndErr" failureproperty="test.failure">
             <formatter type="xml" />
             <classpath refid="test.classpath" />
             <test name="${mainclass.test.specification}" todir="${test.report.dir}" />

--- a/test/arden/tests/specification/structureslots/EvokeSlotTest.java
+++ b/test/arden/tests/specification/structureslots/EvokeSlotTest.java
@@ -137,7 +137,7 @@ public class EvokeSlotTest extends SpecificationTest {
 		assertValidEvokeStatement("MONDAY AT 02:30");
 	}
 
-	@Test(timeout = 10000)
+	@Test(timeout = 8000)
 	public void testPeriodicEventTrigger() throws Exception {
 		String eventMapping = getMappings().createEventMapping();
 		String data = createCodeBuilder()
@@ -155,11 +155,11 @@ public class EvokeSlotTest extends SpecificationTest {
 				.toString();
 		assertDelayedBy(complex, eventMapping, 700, 1700, 2700);
 
-		String condition = new ArdenCodeBuilder(data)
-				.addData("a := 0;")
-				.addEvoke("EVERY 1 WEEK FOR 6 MONTHS STARTING 1990-01-01T12:00:00 UNTIL a > 5")
+		String until = new ArdenCodeBuilder(data)
+				.addEvoke("EVERY .5 SECONDS FOR 2 SECONDS STARTING TIME OF test_event UNTIL TRIGGERTIME > EVENTTIME + 1.1 SECONDS;")
+				.addEvoke("2.5 SECONDS AFTER TIME OF test_event;")
 				.toString();
-		assertValid(condition);
+		assertDelayedBy(until, eventMapping, 0, 500, 1000, 2500);
 	}
 
 	@Test(timeout = 10000)

--- a/test/arden/tests/specification/structureslots/EvokeSlotTest.java
+++ b/test/arden/tests/specification/structureslots/EvokeSlotTest.java
@@ -53,6 +53,19 @@ public class EvokeSlotTest extends SpecificationTest {
 	}
 
 	@Test(timeout = 5000)
+	public void testMultipleTriggers() throws Exception {
+		String eventMapping = getMappings().createEventMapping();
+		String code = createCodeBuilder()
+				.addData("test_event := EVENT {" + eventMapping + "};")
+				.addEvoke("TIME OF test_event;")
+				.addEvoke(".5 SECONDS AFTER TIME OF test_event;")
+				.addEvoke("1 SECOND AFTER TIME OF test_event;")
+				.addAction("WRITE \"success\";")
+				.toString();
+		assertDelayedBy(code, eventMapping, 0, 500, 1000);
+	}
+
+	@Test(timeout = 5000)
 	public void testDelayedEventTrigger() throws Exception {
 		// duration
 		assertDelayedBy(".5 SECONDS AFTER TIME OF test_event", 500);


### PR DESCRIPTION
Some small changes to tests i had lying around.

The `ant test` target now fails when either test suite fails. This may come in handy for using continuous integration.  
There is now also a test for the runtime behavior of the until trigger, see #63. The previous test did not fail, as it just checked the parsing.