### PR TITLE
Fix term token termination

### DIFF
--- a/src/arden.scc
+++ b/src/arden.scc
@@ -86,7 +86,9 @@ Helpers
   letter                = [['a'..'z']+['A'..'Z']];
 
   nosemicr = [[printable + tab] - semicol];
+  noapostr = [all - '''];
   ttext  = [all - semicol]+ (semicol [all - semicol]+)*;
+  tterm  = [noapostr - semicol]+ (semicol [noapostr - semicol]+)*;
   linktext = (nosemicr+ (semicol nosemicr+)* eol?)* nosemicr+ (semicol nosemicr+)*;
   simplestring = [all - '"']+;
   sstring = simplestring+ ('"' '"' simplestring+)*;
@@ -454,7 +456,7 @@ Tokens
   {datamap} data_mapping =  datamaptext;
 
   /* any string of characters enclosed in single quotes (�, ASCII 44) without semicolons */
-  {normal}term =  ''' [all - ''']* ''';
+  {normal}term =  ''' tterm ''';
 
   traditional_comment = '/*' not_star+ '*'+ (not_star_not_slash not_star* '*'+)* '/';
   documentation_comment =    '/**' '*'* (not_star_not_slash not_star* '*'+)* '/';

--- a/src/arden.scc
+++ b/src/arden.scc
@@ -454,7 +454,7 @@ Tokens
   {datamap} data_mapping =  datamaptext;
 
   /* any string of characters enclosed in single quotes (�, ASCII 44) without semicolons */
-  {normal}term =  ''' ttext ''';
+  {normal}term =  ''' [all - ''']* ''';
 
   traditional_comment = '/*' not_star+ '*'+ (not_star_not_slash not_star* '*'+)* '/';
   documentation_comment =    '/**' '*'* (not_star_not_slash not_star* '*'+)* '/';


### PR DESCRIPTION
I ran into issues trying to make multiple `MLM` calls in the `data` block. It seems that the root problem is that the `term` token does not terminate until hits the double semicolon (`;;`) at the end of the `data` block.

This is a quick and dirty fix to make the `term` token terminate at the next single quote `'`. It seems that the `term` token is currently only used by the mlm related tokens, so this shouldn't break anything I don't think. Otherwise you may wish to disregard this PR and make a more proper fix it at the `ttext` token level.